### PR TITLE
Mount host certificate for KCM/CCM

### DIFF
--- a/charts/internal/cloud-controller-manager/templates/cloud-controller-manager.yaml
+++ b/charts/internal/cloud-controller-manager/templates/cloud-controller-manager.yaml
@@ -117,6 +117,14 @@ spec:
           mountPath: /var/lib/cloud-controller-manager-server
         - name: cloud-provider-config
           mountPath: /etc/kubernetes/cloudprovider
+      # Host certificates are mounted to accommodate OpenStack endpoints that might be served with a certificate
+      # signed by a CA that is not globally trusted.
+        - name: usr-share-ca-certificates
+          mountPath: /usr/share/ca-certificates
+          readOnly: true
+        - name: etc-ssl
+          mountPath: /etc/ssl
+          readOnly: true
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler
@@ -135,3 +143,11 @@ spec:
           {{- else }}
           name: cloud-provider-config-kube-controller-manager
           {{- end }}
+      # Host certificates are mounted to accommodate OpenStack endpoints that might be served with a certificate
+      # signed by a CA that is not globally trusted.
+      - name: usr-share-ca-certificates
+        hostPath:
+          path: /usr/share/ca-certificates
+      - name: etc-ssl
+        hostPath:
+          path: /etc/ssl


### PR DESCRIPTION
**What this PR does / why we need it**:
The OpenStack extension does now by default mount the host certificates from `/etc/ssl` and `/usr/share/ca-certificates` into the pods that are running in the seed and need to interact with the OpenStack API (kube-apiserver, kube-controller-manager (only until #1 is fixed), and cloud-controller-manager).
This is to accommodate OpenStack environments that are serving certificates signed by CAs not commonly known/trusted.

**Special notes for your reviewer**:
/cc @bnerd

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The OpenStack extension does now by default mount the host certificates from `/etc/ssl` and `/usr/share/ca-certificates` into the pods that are running in the seed and need to interact with the OpenStack API (kube-apiserver, kube-controller-manager (only until #1 is fixed), and cloud-controller-manager).
This is to accommodate OpenStack environments that are serving certificates signed by CAs not commonly known/trusted.
```
