### PR TITLE
Validate min workers for autoscaling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,18 @@ WORKDIR /go/src/github.com/gardener/gardener-extension-provider-openstack
 COPY . .
 RUN make install-requirements && make VERIFY=true all
 
+############# base
+FROM alpine:3.11.3 AS base
+
 ############# gardener-extension-provider-openstack
-FROM alpine:3.11.3 AS gardener-extension-provider-openstack
+FROM base AS gardener-extension-provider-openstack
 
 COPY charts /charts
 COPY --from=builder /go/bin/gardener-extension-provider-openstack /gardener-extension-provider-openstack
 ENTRYPOINT ["/gardener-extension-provider-openstack"]
+
+############# gardener-extension-validator-openstack
+FROM base AS gardener-extension-validator-openstack
+
+COPY --from=builder /go/bin/gardener-extension-validator-openstack /gardener-extension-validator-openstack
+ENTRYPOINT ["/gardener-extension-validator-openstack"]

--- a/pkg/apis/openstack/validation/shoot.go
+++ b/pkg/apis/openstack/validation/shoot.go
@@ -38,16 +38,20 @@ func ValidateWorkers(workers []core.Worker, fldPath *field.Path) field.ErrorList
 	allErrs := field.ErrorList{}
 
 	for i, worker := range workers {
-
+		workerFldPath := fldPath.Index(i)
 		if len(worker.Zones) == 0 {
-			allErrs = append(allErrs, field.Required(fldPath.Index(i).Child("zones"), "at least one zone must be configured"))
+			allErrs = append(allErrs, field.Required(workerFldPath.Child("zones"), "at least one zone must be configured"))
 			continue
+		}
+
+		if worker.Maximum != 0 && worker.Minimum == 0 {
+			allErrs = append(allErrs, field.Forbidden(workerFldPath.Child("minimum"), "minimum value must be >= 1 if maximum value > 0 (auto scaling to 0 is not supported)"))
 		}
 
 		zones := sets.NewString()
 		for j, zone := range worker.Zones {
 			if zones.Has(zone) {
-				allErrs = append(allErrs, field.Invalid(fldPath.Index(i).Child("zones").Index(j), zone, "must only be specified once per worker group"))
+				allErrs = append(allErrs, field.Invalid(workerFldPath.Child("zones").Index(j), zone, "must only be specified once per worker group"))
 				continue
 			}
 			zones.Insert(zone)

--- a/pkg/apis/openstack/validation/shoot_test.go
+++ b/pkg/apis/openstack/validation/shoot_test.go
@@ -67,7 +67,9 @@ var _ = Describe("Shoot validation", func() {
 						Type: pointer.StringPtr("Volume"),
 						Size: "30G",
 					},
-					Zones: []string{"1", "2"},
+					Minimum: 1,
+					Maximum: 2,
+					Zones:   []string{"1", "2"},
 				},
 				{
 					Name: "worker2",
@@ -75,7 +77,9 @@ var _ = Describe("Shoot validation", func() {
 						Type: pointer.StringPtr("Volume"),
 						Size: "20G",
 					},
-					Zones: []string{"1", "2"},
+					Minimum: 1,
+					Maximum: 2,
+					Zones:   []string{"1", "2"},
 				},
 			}
 		})
@@ -110,6 +114,19 @@ var _ = Describe("Shoot validation", func() {
 					PointTo(MatchFields(IgnoreExtras, Fields{
 						"Type":  Equal(field.ErrorTypeInvalid),
 						"Field": Equal("[0].zones[1]"),
+					})),
+				))
+			})
+
+			It("should enforce workers min > 0 if max > 0", func() {
+				workers[0].Minimum = 0
+
+				errorList := ValidateWorkers(workers, nilPath)
+
+				Expect(errorList).To(ConsistOf(
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeForbidden),
+						"Field": Equal("[0].minimum"),
 					})),
 				))
 			})


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR enhances the shoot workers validation. It prevents that a worker `minimum` value can be set to 0 if `maximum > 0` since this is not yet supported by autoscaling, see https://github.com/gardener/gardener/pull/2045.

/cc @hardikdr

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The OpenStack shoot validator now checks that `workers[].minimum != 0` if `workers[].maximum >0` since autoscaling does not support this setup yet.
```
