### PR TITLE
Add v1.18.0 cloud-controller-manager for 1.18 shoots

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -16,3 +16,8 @@ images:
   repository: k8scloudprovider/openstack-cloud-controller-manager
   tag: "v1.17.0"
   targetVersion: ">= 1.15"
+- name: cloud-controller-manager
+  sourceRepository: github.com/kubernetes/cloud-provider-openstack
+  repository: k8scloudprovider/openstack-cloud-controller-manager
+  tag: "v1.18.0"
+  targetVersion: ">= 1.18"


### PR DESCRIPTION
**What this PR does / why we need it**:
Add v1.18.0 cloud-controller-manager for 1.18 shoots.

Part of gardener/gardener#2095

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
