### PR TITLE
Allow defining zones multiple times for workers

### DIFF
--- a/pkg/apis/openstack/validation/shoot.go
+++ b/pkg/apis/openstack/validation/shoot.go
@@ -18,7 +18,6 @@ import (
 	"github.com/gardener/gardener/pkg/apis/core"
 	"github.com/gardener/gardener/pkg/apis/core/validation"
 	apivalidation "k8s.io/apimachinery/pkg/api/validation"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
@@ -46,15 +45,6 @@ func ValidateWorkers(workers []core.Worker, fldPath *field.Path) field.ErrorList
 
 		if worker.Maximum != 0 && worker.Minimum == 0 {
 			allErrs = append(allErrs, field.Forbidden(workerFldPath.Child("minimum"), "minimum value must be >= 1 if maximum value > 0 (auto scaling to 0 is not supported)"))
-		}
-
-		zones := sets.NewString()
-		for j, zone := range worker.Zones {
-			if zones.Has(zone) {
-				allErrs = append(allErrs, field.Invalid(workerFldPath.Child("zones").Index(j), zone, "must only be specified once per worker group"))
-				continue
-			}
-			zones.Insert(zone)
 		}
 	}
 

--- a/pkg/apis/openstack/validation/shoot_test.go
+++ b/pkg/apis/openstack/validation/shoot_test.go
@@ -105,19 +105,6 @@ var _ = Describe("Shoot validation", func() {
 				))
 			})
 
-			It("should forbid because worker use zone twice", func() {
-				workers[0].Zones[1] = workers[0].Zones[0]
-
-				errorList := ValidateWorkers(workers, nilPath)
-
-				Expect(errorList).To(ConsistOf(
-					PointTo(MatchFields(IgnoreExtras, Fields{
-						"Type":  Equal(field.ErrorTypeInvalid),
-						"Field": Equal("[0].zones[1]"),
-					})),
-				))
-			})
-
 			It("should enforce workers min > 0 if max > 0", func() {
 				workers[0].Minimum = 0
 

--- a/pkg/validator/shoot_handler.go
+++ b/pkg/validator/shoot_handler.go
@@ -16,6 +16,7 @@ package validator
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"github.com/gardener/gardener-extension-provider-openstack/pkg/openstack"
@@ -52,7 +53,7 @@ func (v *Shoot) Handle(ctx context.Context, req admission.Request) admission.Res
 	switch req.Operation {
 	case admissionv1beta1.Create:
 		if err := v.validateShootCreation(ctx, shoot); err != nil {
-			v.Logger.Error(err, "denied request")
+			v.Logger.Error(err, "denied request", "operation", req.Operation, "shoot", fmt.Sprintf("%s/%s", shoot.Namespace, shoot.Name))
 			return admission.Errored(http.StatusBadRequest, err)
 		}
 	case admissionv1beta1.Update:
@@ -63,7 +64,7 @@ func (v *Shoot) Handle(ctx context.Context, req admission.Request) admission.Res
 		}
 
 		if err := v.validateShootUpdate(ctx, oldShoot, shoot); err != nil {
-			v.Logger.Error(err, "denied request")
+			v.Logger.Error(err, "denied request", "operation", req.Operation, "shoot", fmt.Sprintf("%s/%s", shoot.Namespace, shoot.Name))
 			return admission.Errored(http.StatusBadRequest, err)
 		}
 	default:


### PR DESCRIPTION
**What this PR does / why we need it**:
Allow defining zones multiple times for workers.

**Special notes for your reviewer**:
Ready for review but please don't merge yet. I want to do some final tests.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The OpenStack validator now allows zones to be specified multiple times for a worker group.
```
