### PR TITLE
Allow wildcard expressions in FloatingPoolNames

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ############# builder
-FROM golang:1.13.8 AS builder
+FROM golang:1.14.2 AS builder
 
 WORKDIR /go/src/github.com/gardener/gardener-extension-provider-openstack
 COPY . .

--- a/docs/usage-as-operator.md
+++ b/docs/usage-as-operator.md
@@ -51,6 +51,13 @@ constraints:
 #     floatingSubnetID: "1234"
 #     floatingNetworkID: "4567"
 #     subnetID: "7890"
+# - name: "fp-pool-*"
+#   region: europe
+#   loadBalancerClasses:
+#   - name: lb-class-1
+#     floatingSubnetID: "1234"
+#     floatingNetworkID: "4567"
+#     subnetID: "7890"
   loadBalancerProviders:
   - name: haproxy
 #   region: europe
@@ -59,8 +66,9 @@ constraints:
 ```
 
 Please note that it is possible to configure a region mapping for keystone URLs, floating pools, and load balancer providers.
+Floating pool names may also contains simple wildcard expressions, like `*` or `fp-pool-*` or `*-fp-pool`. Please note that the `*` must be either single or at the beginning or at the end. Consequently, `fp-*-pool` is not possible/allowed.
 The default behavior is that, if found, the regional entry is taken.
-If no entry for the given region exists then the fallback value is the first entry in the list without a `region` field (or the `keystoneURL` value for the keystone URLs).
+If no entry for the given region exists then the fallback value is the most matching entry (w.r.t. wildcard matching) in the list without a `region` field (or the `keystoneURL` value for the keystone URLs).
 Some OpenStack environments don't need these regional mappings, hence, the `region` and `keystoneURLs` fields are optional.
 If your OpenStack environment only has regional values and it doesn't make sense to provide a (non-regional) fallback then simply
 omit `keystoneURL` and always specify `region`.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gardener/gardener-extension-provider-openstack
 
-go 1.13
+go 1.14
 
 require (
 	github.com/ahmetb/gen-crd-api-reference-docs v0.1.5

--- a/pkg/apis/openstack/validation/infrastructure_test.go
+++ b/pkg/apis/openstack/validation/infrastructure_test.go
@@ -171,6 +171,15 @@ var _ = Describe("InfrastructureConfig validation", func() {
 			Expect(errorList).To(BeEmpty())
 		})
 
+		It("should allow using an arbitrary regional floating pool from the same region (wildcard case)", func() {
+			cloudProfileConfig.Constraints.FloatingPools[0].Name = "*"
+			infrastructureConfig.FloatingPoolName = floatingPoolName1
+
+			errorList := ValidateInfrastructureConfigAgainstCloudProfile(infrastructureConfig, region, cloudProfileConfig, nilPath)
+
+			Expect(errorList).To(BeEmpty())
+		})
+
 		It("should forbid using a floating pool name for different region", func() {
 			differentRegion := "asia"
 			cloudProfileConfig.Constraints = api.Constraints{
@@ -249,6 +258,28 @@ var _ = Describe("InfrastructureConfig validation", func() {
 				},
 			}
 			infrastructureConfig.FloatingPoolName = floatingPoolName2
+
+			errorList := ValidateInfrastructureConfigAgainstCloudProfile(infrastructureConfig, differentRegion, cloudProfileConfig, nilPath)
+
+			Expect(errorList).To(BeEmpty())
+		})
+
+		It("should allow using an arbitrary non-regional floating pool name if region not specified (wildcard case)", func() {
+			differentRegion := "asia"
+			someFloatingPool := "fp2"
+
+			cloudProfileConfig.Constraints = api.Constraints{
+				FloatingPools: []api.FloatingPool{
+					{
+						Name: "*",
+					},
+					{
+						Name:   floatingPoolName1,
+						Region: &region,
+					},
+				},
+			}
+			infrastructureConfig.FloatingPoolName = someFloatingPool
 
 			errorList := ValidateInfrastructureConfigAgainstCloudProfile(infrastructureConfig, differentRegion, cloudProfileConfig, nilPath)
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -16,6 +16,10 @@
 
 package utils
 
+import (
+	"strings"
+)
+
 // IsEmptyString checks whether a string is empty
 func IsEmptyString(s *string) bool {
 	return s == nil || *s == ""
@@ -40,4 +44,27 @@ func SetStringValue(values map[string]interface{}, key string, value *string) {
 	if !IsEmptyString(value) {
 		values[key] = *value
 	}
+}
+
+// SimpleMatch returns whether the given pattern matches the given text.
+// It also returns a score indicating the match between `pattern` and `text`. The higher the score the higher the match.
+// Only simple wildcard patterns are supposed to be passed, e.g. '*', 'tex*'.
+func SimpleMatch(pattern, text string) (bool, int) {
+	const wildcard = "*"
+	if pattern == wildcard {
+		return true, 0
+	}
+	if pattern == text {
+		return true, len(text)
+	}
+	if strings.HasSuffix(pattern, wildcard) && strings.HasPrefix(text, pattern[:len(pattern)-1]) {
+		s := strings.SplitAfterN(text, pattern[:len(pattern)-1], 2)
+		return true, len(s[0])
+	}
+	if strings.HasPrefix(pattern, wildcard) && strings.HasSuffix(text, pattern[1:]) {
+		i := strings.LastIndex(text, pattern[1:])
+		return true, len(text) - i
+	}
+
+	return false, 0
 }

--- a/pkg/utils/utils_suite_test.go
+++ b/pkg/utils/utils_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestWorker(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Utils Suite")
+}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -1,0 +1,49 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils_test
+
+import (
+	. "github.com/gardener/gardener-extension-provider-openstack/pkg/utils"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Utils", func() {
+	DescribeTable("#SimpleMatch", func(pattern, text string, expected bool, expectedSocre int) {
+		match, score := SimpleMatch(pattern, text)
+		Expect(match).To(Equal(expected))
+		Expect(score).To(Equal(expectedSocre))
+	},
+		Entry("should match wildcard", "*", "test", true, 0),
+		Entry("should not match empty string", "", "test", false, 0),
+		Entry("should match text", "test", "test", true, 4),
+		Entry("should not match text", "tet", "test", false, 0),
+		Entry("should match wildcard suffix", "t*", "test", true, 1),
+		Entry("should match wildcard suffix score 2", "te*", "test", true, 2),
+		Entry("should match wildcard suffix score 3", "tes*", "test", true, 3),
+		Entry("should match wildcard suffix score 4", "test*", "test", true, 4),
+		Entry("should not match wildcard suffix", "e*", "test", false, 0),
+		Entry("should not match wildcard suffix", "teste*", "test", false, 0),
+		Entry("should match wildcard prefix", "*t", "test", true, 1),
+		Entry("should match wildcard prefix score 2", "*st", "test", true, 2),
+		Entry("should match wildcard prefix score 3", "*est", "test", true, 3),
+		Entry("should match wildcard prefix score 4", "*test", "test", true, 4),
+		Entry("should not match wildcard prefix", "*d", "test", false, 0),
+		Entry("should not match wildcard prefix", "*teste", "test", false, 0),
+		Entry("should not match wildcard arbitrary", "te*t", "test", false, 0),
+	)
+})

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -11,10 +11,12 @@ github.com/PuerkitoBio/purell
 # github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578
 github.com/PuerkitoBio/urlesc
 # github.com/ahmetb/gen-crd-api-reference-docs v0.1.5
+## explicit
 github.com/ahmetb/gen-crd-api-reference-docs
 # github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973
 github.com/beorn7/perks/quantile
 # github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f
+## explicit
 github.com/coreos/go-systemd/unit
 # github.com/cyphar/filepath-securejoin v0.2.2
 github.com/cyphar/filepath-securejoin
@@ -47,12 +49,14 @@ github.com/gardener/controller-manager-library/pkg/logger
 github.com/gardener/controller-manager-library/pkg/resources
 github.com/gardener/controller-manager-library/pkg/utils
 # github.com/gardener/etcd-druid v0.1.12
+## explicit
 github.com/gardener/etcd-druid/api/v1alpha1
 # github.com/gardener/external-dns-management v0.7.7
 github.com/gardener/external-dns-management/pkg/apis/dns
 github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1
 github.com/gardener/external-dns-management/pkg/client/dns/clientset/versioned/scheme
 # github.com/gardener/gardener v1.2.1-0.20200408030154-40b97d31d7f7
+## explicit
 github.com/gardener/gardener/extensions/hack
 github.com/gardener/gardener/extensions/pkg/controller
 github.com/gardener/gardener/extensions/pkg/controller/backupbucket
@@ -171,12 +175,14 @@ github.com/gardener/gardener-resource-manager/pkg/manager
 # github.com/gardener/hvpa-controller v0.0.0-20191014062307-fad3bdf06a25
 github.com/gardener/hvpa-controller/api/v1alpha1
 # github.com/gardener/machine-controller-manager v0.27.0
+## explicit
 github.com/gardener/machine-controller-manager/pkg/apis/machine
 github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1
 github.com/gardener/machine-controller-manager/pkg/client/clientset/versioned/scheme
 # github.com/ghodss/yaml v1.0.0
 github.com/ghodss/yaml
 # github.com/go-logr/logr v0.1.0
+## explicit
 github.com/go-logr/logr
 # github.com/go-logr/zapr v0.1.1
 github.com/go-logr/zapr
@@ -194,6 +200,7 @@ github.com/gobuffalo/logger
 github.com/gobuffalo/packd
 github.com/gobuffalo/packd/internal/takeon/github.com/markbates/errx
 # github.com/gobuffalo/packr/v2 v2.8.0
+## explicit
 github.com/gobuffalo/packr/v2
 github.com/gobuffalo/packr/v2/file
 github.com/gobuffalo/packr/v2/file/resolver
@@ -245,6 +252,7 @@ github.com/gogo/protobuf/vanity/command
 # github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7
 github.com/golang/groupcache/lru
 # github.com/golang/mock v1.4.3
+## explicit
 github.com/golang/mock/gomock
 github.com/golang/mock/mockgen
 github.com/golang/mock/mockgen/model
@@ -271,6 +279,7 @@ github.com/googleapis/gnostic/OpenAPIv2
 github.com/googleapis/gnostic/compiler
 github.com/googleapis/gnostic/extensions
 # github.com/gophercloud/gophercloud v0.7.0
+## explicit
 github.com/gophercloud/gophercloud
 github.com/gophercloud/gophercloud/openstack
 github.com/gophercloud/gophercloud/openstack/identity/v2/tenants
@@ -282,6 +291,7 @@ github.com/gophercloud/gophercloud/openstack/objectstorage/v1/objects
 github.com/gophercloud/gophercloud/openstack/utils
 github.com/gophercloud/gophercloud/pagination
 # github.com/gophercloud/utils v0.0.0-20200204043447-9864b6f1f12f
+## explicit
 github.com/gophercloud/utils/env
 github.com/gophercloud/utils/openstack/clientconfig
 # github.com/hashicorp/errwrap v1.0.0
@@ -349,6 +359,7 @@ github.com/modern-go/reflect2
 # github.com/nwaples/rardecode v1.0.0
 github.com/nwaples/rardecode
 # github.com/onsi/ginkgo v1.10.1
+## explicit
 github.com/onsi/ginkgo
 github.com/onsi/ginkgo/config
 github.com/onsi/ginkgo/extensions/table
@@ -376,6 +387,7 @@ github.com/onsi/ginkgo/reporters/stenographer/support/go-colorable
 github.com/onsi/ginkgo/reporters/stenographer/support/go-isatty
 github.com/onsi/ginkgo/types
 # github.com/onsi/gomega v1.7.0
+## explicit
 github.com/onsi/gomega
 github.com/onsi/gomega/format
 github.com/onsi/gomega/gstruct
@@ -396,6 +408,7 @@ github.com/pelletier/go-toml
 github.com/pierrec/lz4
 github.com/pierrec/lz4/internal/xxh32
 # github.com/pkg/errors v0.9.1
+## explicit
 github.com/pkg/errors
 # github.com/prometheus/client_golang v1.3.0 => github.com/prometheus/client_golang v0.9.2
 github.com/prometheus/client_golang/api
@@ -425,6 +438,7 @@ github.com/russross/blackfriday/v2
 # github.com/shurcooL/sanitized_anchor_name v1.0.0
 github.com/shurcooL/sanitized_anchor_name
 # github.com/sirupsen/logrus v1.4.2
+## explicit
 github.com/sirupsen/logrus
 # github.com/spf13/afero v1.2.2
 github.com/spf13/afero
@@ -432,10 +446,12 @@ github.com/spf13/afero/mem
 # github.com/spf13/cast v1.3.0
 github.com/spf13/cast
 # github.com/spf13/cobra v0.0.6
+## explicit
 github.com/spf13/cobra
 # github.com/spf13/jwalterweatherman v1.0.0
 github.com/spf13/jwalterweatherman
 # github.com/spf13/pflag v1.0.5
+## explicit
 github.com/spf13/pflag
 # github.com/spf13/viper v1.6.1
 github.com/spf13/viper
@@ -626,6 +642,7 @@ honnef.co/go/tools/stylecheck
 honnef.co/go/tools/unused
 honnef.co/go/tools/version
 # k8s.io/api v0.17.0 => k8s.io/api v0.16.8
+## explicit
 k8s.io/api/admission/v1beta1
 k8s.io/api/admissionregistration/v1
 k8s.io/api/admissionregistration/v1beta1
@@ -666,6 +683,7 @@ k8s.io/api/storage/v1
 k8s.io/api/storage/v1alpha1
 k8s.io/api/storage/v1beta1
 # k8s.io/apiextensions-apiserver v0.17.0 => k8s.io/apiextensions-apiserver v0.16.8
+## explicit
 k8s.io/apiextensions-apiserver/pkg/apis/apiextensions
 k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1
 k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1
@@ -674,6 +692,7 @@ k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme
 k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1
 k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1
 # k8s.io/apimachinery v0.17.0 => k8s.io/apimachinery v0.16.8
+## explicit
 k8s.io/apimachinery/pkg/api/equality
 k8s.io/apimachinery/pkg/api/errors
 k8s.io/apimachinery/pkg/api/meta
@@ -727,6 +746,7 @@ k8s.io/apimachinery/third_party/forked/golang/json
 k8s.io/apimachinery/third_party/forked/golang/netutil
 k8s.io/apimachinery/third_party/forked/golang/reflect
 # k8s.io/apiserver v0.17.0 => k8s.io/apiserver v0.16.8
+## explicit
 k8s.io/apiserver/pkg/admission/plugin/webhook
 k8s.io/apiserver/pkg/apis/audit
 k8s.io/apiserver/pkg/apis/audit/v1
@@ -740,6 +760,7 @@ k8s.io/apiserver/pkg/util/webhook
 # k8s.io/autoscaler v0.0.0-20190805135949-100e91ba756e
 k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2
 # k8s.io/client-go v11.0.1-0.20190409021438-1a26190bd76a+incompatible => k8s.io/client-go v0.16.8
+## explicit
 k8s.io/client-go/discovery
 k8s.io/client-go/discovery/cached/memory
 k8s.io/client-go/dynamic
@@ -908,6 +929,7 @@ k8s.io/client-go/util/workqueue
 k8s.io/cluster-bootstrap/token/api
 k8s.io/cluster-bootstrap/token/util
 # k8s.io/code-generator v0.17.0 => k8s.io/code-generator v0.16.8
+## explicit
 k8s.io/code-generator
 k8s.io/code-generator/cmd/client-gen
 k8s.io/code-generator/cmd/client-gen/args
@@ -943,10 +965,12 @@ k8s.io/code-generator/pkg/namer
 k8s.io/code-generator/pkg/util
 k8s.io/code-generator/third_party/forked/golang/reflect
 # k8s.io/component-base v0.17.0 => k8s.io/component-base v0.16.8
+## explicit
 k8s.io/component-base/config
 k8s.io/component-base/config/v1alpha1
 k8s.io/component-base/featuregate
 # k8s.io/gengo v0.0.0-20190826232639-a874a240740c
+## explicit
 k8s.io/gengo/args
 k8s.io/gengo/examples/deepcopy-gen/generators
 k8s.io/gengo/examples/defaulter-gen/generators
@@ -980,6 +1004,7 @@ k8s.io/helm/pkg/tlsutil
 k8s.io/helm/pkg/urlutil
 k8s.io/helm/pkg/version
 # k8s.io/klog v1.0.0
+## explicit
 k8s.io/klog
 # k8s.io/kube-aggregator v0.16.8 => k8s.io/kube-aggregator v0.16.8
 k8s.io/kube-aggregator/pkg/apis/apiregistration
@@ -1003,6 +1028,7 @@ k8s.io/kube-openapi/pkg/generators/rules
 k8s.io/kube-openapi/pkg/util/proto
 k8s.io/kube-openapi/pkg/util/sets
 # k8s.io/kubelet v0.16.8
+## explicit
 k8s.io/kubelet/config/v1beta1
 # k8s.io/metrics v0.16.8
 k8s.io/metrics/pkg/apis/metrics
@@ -1010,11 +1036,13 @@ k8s.io/metrics/pkg/apis/metrics/v1alpha1
 k8s.io/metrics/pkg/apis/metrics/v1beta1
 k8s.io/metrics/pkg/client/clientset/versioned/scheme
 # k8s.io/utils v0.0.0-20200327001022-6496210b90e8
+## explicit
 k8s.io/utils/buffer
 k8s.io/utils/integer
 k8s.io/utils/pointer
 k8s.io/utils/trace
 # sigs.k8s.io/controller-runtime v0.4.0
+## explicit
 sigs.k8s.io/controller-runtime
 sigs.k8s.io/controller-runtime/pkg/builder
 sigs.k8s.io/controller-runtime/pkg/cache
@@ -1052,3 +1080,14 @@ sigs.k8s.io/controller-runtime/pkg/webhook/internal/certwatcher
 sigs.k8s.io/controller-runtime/pkg/webhook/internal/metrics
 # sigs.k8s.io/yaml v1.1.0
 sigs.k8s.io/yaml
+# github.com/prometheus/client_golang => github.com/prometheus/client_golang v0.9.2
+# k8s.io/api => k8s.io/api v0.16.8
+# k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.16.8
+# k8s.io/apimachinery => k8s.io/apimachinery v0.16.8
+# k8s.io/apiserver => k8s.io/apiserver v0.16.8
+# k8s.io/client-go => k8s.io/client-go v0.16.8
+# k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.16.8
+# k8s.io/code-generator => k8s.io/code-generator v0.16.8
+# k8s.io/component-base => k8s.io/component-base v0.16.8
+# k8s.io/helm => k8s.io/helm v2.13.1+incompatible
+# k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.16.8


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the support for wildcard expressions when declaring `floatingPools[].name` in the `CloudProfile`.

**Which issue(s) this PR fixes**:
Fixes #62

**Special notes for your reviewer**:
`LoadBalancerClasses` in the `ControlPlaneConfig` are now cross checked against the configured `FloatingPoolName` in the `InfrastructureConfig`.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
It is now possible to use simple wildcard expressions when configuring `floatingPools[].name` in the `CloudProfileConfig`. As a consequence, the `FloatingPoolName` in a shoot cluster is matched against this wildcard expression instead of only allowing a strict match. Please consult the documentation https://github.com/gardener/gardener-extension-provider-openstack/blob/c0588dd370006b9f9fca910037e05387c752654b/docs/usage-as-operator.md for more details.
```
