### PR TITLE
Explicitly set 'useOctavia' to 'false'

### DIFF
--- a/charts/internal/cloud-provider-config/templates/cloud-provider-config-global.tpl
+++ b/charts/internal/cloud-provider-config/templates/cloud-provider-config-global.tpl
@@ -13,7 +13,5 @@ monitor-max-retries=5
 lb-version=v2
 lb-provider="{{ .Values.lbProvider }}"
 floating-network-id="{{ .Values.floatingNetworkID }}"
-{{- if .Values.useOctavia }}
-use-octavia="true"
-{{- end }}
+use-octavia="{{ .Values.useOctavia }}"
 {{- end }}

--- a/charts/internal/cloud-provider-config/values.yaml
+++ b/charts/internal/cloud-provider-config/values.yaml
@@ -12,7 +12,7 @@ lbProvider: foobar
 # [Metadata]
 dhcpDomain: foobar
 requestTimeout: 2s
-#useOctavia: false
+useOctavia: false
 # floatingClasses:
 # - name: A
 #   floatingNetworkID: "1234"

--- a/docs/usage-as-operator.md
+++ b/docs/usage-as-operator.md
@@ -17,7 +17,7 @@ Also, you have to specify the keystone URL in the `keystoneURL` field to your en
 Additionally, you can influence the HTTP request timeout when talking to the OpenStack API in the `requestTimeout` field.
 This may help when you have for example a long list of load balancers in your environment.
 
-In case your OpenStack system uses [Octavia](https://docs.openstack.org/octavia/latest/) for network load balancing then you have to set the `useOctavia` field to `true` such that the cloud-controller-manager for OpenStack gets correctly configured.
+In case your OpenStack system uses [Octavia](https://docs.openstack.org/octavia/latest/) for network load balancing then you have to set the `useOctavia` field to `true` such that the cloud-controller-manager for OpenStack gets correctly configured (it defaults to `false`).
 
 The cloud profile config also contains constraints for floating pools and load balancer providers that can be used in shoots.
 


### PR DESCRIPTION
**What this PR does / why we need it**:
As of https://github.com/kubernetes/cloud-provider-openstack/pull/977 (released with v1.18.0 version of CCM) the `UseOctavia` is defaulted to `true`. Hence, let's explicitly set it to `false` so that our old behaviour is kept.

/cc @kayrus 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The `useOctavia` setting of the cloud-controller-manager is now explicitly set to `false`. You can set it to `true` using the `ControlPlaneConfig`.
```
