### PR TITLE
use first load balancer class as default if no class with name "default" provided

### DIFF
--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -246,7 +246,7 @@ func getConfigChartValues(
 		var fallback *api.FloatingPool
 
 		for _, pool := range cloudProfileConfig.Constraints.FloatingPools {
-			if pool.Region == nil && fallback == nil {
+			if pool.Region == nil && fallback == nil && pool.Name == infraStatus.Networks.FloatingPool.Name {
 				v := pool
 				fallback = &v
 			}
@@ -262,12 +262,10 @@ func getConfigChartValues(
 		}
 	}
 
-	for _, class := range cpConfig.LoadBalancerClasses {
-		if class.Name == api.DefaultLoadBalancerClass {
-			utils.SetStringValue(values, "floatingNetworkID", class.FloatingNetworkID)
+	for i, class := range cpConfig.LoadBalancerClasses {
+		if i == 0 || class.Name == api.DefaultLoadBalancerClass {
 			utils.SetStringValue(values, "floatingSubnetID", class.FloatingSubnetID)
 			utils.SetStringValue(values, "subnetID", class.SubnetID)
-			break
 		}
 	}
 	for _, class := range cpConfig.LoadBalancerClasses {
@@ -281,11 +279,7 @@ func getConfigChartValues(
 
 	for _, class := range cpConfig.LoadBalancerClasses {
 		floatingClass := map[string]interface{}{"name": class.Name}
-		if !utils.IsEmptyString(class.FloatingSubnetID) && utils.IsEmptyString(class.FloatingNetworkID) {
-			floatingClass["floatingNetworkID"] = infraStatus.Networks.FloatingPool.ID
-		} else {
-			utils.SetStringValue(floatingClass, "floatingNetworkID", class.FloatingNetworkID)
-		}
+		floatingClass["floatingNetworkID"] = infraStatus.Networks.FloatingPool.ID
 		utils.SetStringValue(floatingClass, "floatingSubnetID", class.FloatingSubnetID)
 		utils.SetStringValue(floatingClass, "subnetID", class.SubnetID)
 		floatingClasses = append(floatingClasses, floatingClass)

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -253,7 +253,6 @@ var _ = Describe("ValuesProvider", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			floatingNetworkID := "4711"
-			floatingNetworkID2 := "pub"
 			fsid := "0815"
 			floatingSubnetID2 := "pub0815"
 			subnetID := "priv"
@@ -274,10 +273,9 @@ var _ = Describe("ValuesProvider", func() {
 							SubnetID:         nil,
 						},
 						{
-							Name:              "public",
-							FloatingSubnetID:  &floatingSubnetID2,
-							FloatingNetworkID: &floatingNetworkID2,
-							SubnetID:          nil,
+							Name:             "public",
+							FloatingSubnetID: &floatingSubnetID2,
+							SubnetID:         nil,
 						},
 						{
 							Name:     "other",
@@ -315,12 +313,13 @@ var _ = Describe("ValuesProvider", func() {
 					},
 					{
 						"name":              "public",
-						"floatingNetworkID": floatingNetworkID2,
+						"floatingNetworkID": floatingNetworkID,
 						"floatingSubnetID":  floatingSubnetID2,
 					},
 					{
-						"name":     "other",
-						"subnetID": subnetID,
+						"name":              "other",
+						"floatingNetworkID": floatingNetworkID,
+						"subnetID":          subnetID,
 					},
 				},
 				"authUrl":        authURL,


### PR DESCRIPTION
Co-authored-by: Uwe Krueger <uwe.krueger@sap.com>

**What this PR does / why we need it**:
If multiple load balancer classes are defined in a floating pool of the cloud profile constraints, currently the default class must be named "default". If no "default" LB class is provided, the Openstack CCM chooses one by random. With this PR the first load balancer class is used instead.
Additionally it is ensured that the floating network ID from the infrastructure is used for all LB classes.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
If a floating pool in the cloud profile defines no load balancer class named "default", the first one is used as default.
```
