### PR TITLE
add domain field to floatingpool and validate it

### DIFF
--- a/charts/gardener-extension-validator-openstack/charts/application/templates/rbac.yaml
+++ b/charts/gardener-extension-validator-openstack/charts/application/templates/rbac.yaml
@@ -10,9 +10,19 @@ rules:
   - core.gardener.cloud
   resources:
   - cloudprofiles
+  - secretbindings
   verbs:
   - get
   - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/docs/usage-as-operator.md
+++ b/docs/usage-as-operator.md
@@ -58,6 +58,23 @@ constraints:
 #     floatingSubnetID: "1234"
 #     floatingNetworkID: "4567"
 #     subnetID: "7890"
+# - name: "fp-pool-eu-demo"
+#   region: europe
+#   domain: demo
+#   loadBalancerClasses:
+#   - name: lb-class-1
+#     floatingSubnetID: "1234"
+#     floatingNetworkID: "4567"
+#     subnetID: "7890"
+# - name: "fp-pool-eu-dev"
+#   region: europe
+#   domain: dev
+#   nonConstraining: true
+#   loadBalancerClasses:
+#   - name: lb-class-1
+#     floatingSubnetID: "1234"
+#     floatingNetworkID: "4567"
+#     subnetID: "7890"
   loadBalancerProviders:
   - name: haproxy
 #   region: europe
@@ -66,9 +83,13 @@ constraints:
 ```
 
 Please note that it is possible to configure a region mapping for keystone URLs, floating pools, and load balancer providers.
+Additionally, floating pools can be constrainted to a keystone domain by specifying the `domain` field. 
 Floating pool names may also contains simple wildcard expressions, like `*` or `fp-pool-*` or `*-fp-pool`. Please note that the `*` must be either single or at the beginning or at the end. Consequently, `fp-*-pool` is not possible/allowed.
-The default behavior is that, if found, the regional entry is taken.
+The default behavior is that, if found, the regional (and/or domain restricted) entry is taken.
 If no entry for the given region exists then the fallback value is the most matching entry (w.r.t. wildcard matching) in the list without a `region` field (or the `keystoneURL` value for the keystone URLs).
+If an additional floating pool should be selectable for a region and/or domain, you can mark it as non constraining
+with setting the optional field `nonConstraining` to `true`.
+
 Some OpenStack environments don't need these regional mappings, hence, the `region` and `keystoneURLs` fields are optional.
 If your OpenStack environment only has regional values and it doesn't make sense to provide a (non-regional) fallback then simply
 omit `keystoneURL` and always specify `region`.

--- a/hack/api-reference/api.md
+++ b/hack/api-reference/api.md
@@ -459,6 +459,30 @@ string
 </tr>
 <tr>
 <td>
+<code>domain</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Domain is the domain name.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>nonConstraining</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>NonConstraining specifies whether this floating pool is not constraining, that means additionally available independent of other FP constraints.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>loadBalancerClasses</code></br>
 <em>
 <a href="#openstack.provider.extensions.gardener.cloud/v1alpha1.LoadBalancerClass">

--- a/pkg/apis/openstack/types_cloudprofile.go
+++ b/pkg/apis/openstack/types_cloudprofile.go
@@ -60,6 +60,10 @@ type FloatingPool struct {
 	Name string
 	// Region is the region name.
 	Region *string
+	// Domain is the domain name.
+	Domain *string
+	// NonConstraining specifies whether this floating pool is not constraining, that means additionally available independent of other FP constraints.
+	NonConstraining *bool
 	// LoadBalancerClasses contains a list of supported labeled load balancer network settings.
 	LoadBalancerClasses []LoadBalancerClass
 }

--- a/pkg/apis/openstack/v1alpha1/types_cloudprofile.go
+++ b/pkg/apis/openstack/v1alpha1/types_cloudprofile.go
@@ -66,6 +66,12 @@ type FloatingPool struct {
 	// Region is the region name.
 	// +optional
 	Region *string `json:"region,omitempty"`
+	// Domain is the domain name.
+	// +optional
+	Domain *string `json:"domain,omitempty"`
+	// NonConstraining specifies whether this floating pool is not constraining, that means additionally available independent of other FP constraints.
+	// +optional
+	NonConstraining *bool `json:"nonConstraining,omitempty"`
 	// LoadBalancerClasses contains a list of supported labeled load balancer network settings.
 	// +optional
 	LoadBalancerClasses []LoadBalancerClass `json:"loadBalancerClasses,omitempty"`

--- a/pkg/apis/openstack/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/openstack/v1alpha1/zz_generated.conversion.go
@@ -377,6 +377,8 @@ func Convert_openstack_ControlPlaneConfig_To_v1alpha1_ControlPlaneConfig(in *ope
 func autoConvert_v1alpha1_FloatingPool_To_openstack_FloatingPool(in *FloatingPool, out *openstack.FloatingPool, s conversion.Scope) error {
 	out.Name = in.Name
 	out.Region = (*string)(unsafe.Pointer(in.Region))
+	out.Domain = (*string)(unsafe.Pointer(in.Domain))
+	out.NonConstraining = (*bool)(unsafe.Pointer(in.NonConstraining))
 	out.LoadBalancerClasses = *(*[]openstack.LoadBalancerClass)(unsafe.Pointer(&in.LoadBalancerClasses))
 	return nil
 }
@@ -389,6 +391,8 @@ func Convert_v1alpha1_FloatingPool_To_openstack_FloatingPool(in *FloatingPool, o
 func autoConvert_openstack_FloatingPool_To_v1alpha1_FloatingPool(in *openstack.FloatingPool, out *FloatingPool, s conversion.Scope) error {
 	out.Name = in.Name
 	out.Region = (*string)(unsafe.Pointer(in.Region))
+	out.Domain = (*string)(unsafe.Pointer(in.Domain))
+	out.NonConstraining = (*bool)(unsafe.Pointer(in.NonConstraining))
 	out.LoadBalancerClasses = *(*[]LoadBalancerClass)(unsafe.Pointer(&in.LoadBalancerClasses))
 	return nil
 }

--- a/pkg/apis/openstack/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/openstack/v1alpha1/zz_generated.deepcopy.go
@@ -180,6 +180,16 @@ func (in *FloatingPool) DeepCopyInto(out *FloatingPool) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.Domain != nil {
+		in, out := &in.Domain, &out.Domain
+		*out = new(string)
+		**out = **in
+	}
+	if in.NonConstraining != nil {
+		in, out := &in.NonConstraining, &out.NonConstraining
+		*out = new(bool)
+		**out = **in
+	}
 	if in.LoadBalancerClasses != nil {
 		in, out := &in.LoadBalancerClasses, &out.LoadBalancerClasses
 		*out = make([]LoadBalancerClass, len(*in))

--- a/pkg/apis/openstack/validation/cloudprofile_test.go
+++ b/pkg/apis/openstack/validation/cloudprofile_test.go
@@ -74,6 +74,7 @@ var _ = Describe("CloudProfileConfig validation", func() {
 					{
 						Name:   "",
 						Region: makeStringPointer(""),
+						Domain: makeStringPointer(""),
 					},
 				}
 
@@ -85,27 +86,60 @@ var _ = Describe("CloudProfileConfig validation", func() {
 				})), PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeRequired),
 					"Field": Equal("constraints.floatingPools[0].region"),
+				})), PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeRequired),
+					"Field": Equal("constraints.floatingPools[0].domain"),
 				}))))
 			})
 
-			It("should forbid duplicates regions in pools", func() {
+			It("should forbid duplicates regions and domains in pools", func() {
 				cloudProfileConfig.Constraints.FloatingPools = []api.FloatingPool{
 					{
 						Name:   "foo",
-						Region: makeStringPointer("foo"),
+						Region: makeStringPointer("rfoo"),
 					},
 					{
 						Name:   "foo",
-						Region: makeStringPointer("foo"),
+						Region: makeStringPointer("rfoo"),
+					},
+					{
+						Name:   "foo",
+						Domain: makeStringPointer("dfoo"),
+					},
+					{
+						Name:   "foo",
+						Domain: makeStringPointer("dfoo"),
+					},
+					{
+						Name:   "foo",
+						Domain: makeStringPointer("dfoo"),
+						Region: makeStringPointer("rfoo"),
+					},
+					{
+						Name:   "foo",
+						Domain: makeStringPointer("dfoo"),
+						Region: makeStringPointer("rfoo"),
 					},
 				}
 
 				errorList := ValidateCloudProfileConfig(cloudProfileConfig)
 
-				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeDuplicate),
-					"Field": Equal("constraints.floatingPools[1].region"),
-				}))))
+				Expect(errorList).To(ConsistOf(
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":     Equal(field.ErrorTypeDuplicate),
+						"Field":    Equal("constraints.floatingPools[1].name"),
+						"BadValue": Equal("foo"),
+					})),
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":     Equal(field.ErrorTypeDuplicate),
+						"Field":    Equal("constraints.floatingPools[3].name"),
+						"BadValue": Equal("foo"),
+					})),
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":     Equal(field.ErrorTypeDuplicate),
+						"Field":    Equal("constraints.floatingPools[5].name"),
+						"BadValue": Equal("foo"),
+					}))))
 			})
 		})
 

--- a/pkg/apis/openstack/validation/controlplane.go
+++ b/pkg/apis/openstack/validation/controlplane.go
@@ -50,14 +50,14 @@ func ValidateControlPlaneConfigUpdate(oldConfig, newConfig *api.ControlPlaneConf
 }
 
 // ValidateControlPlaneConfigAgainstCloudProfile validates the given ControlPlaneConfig against constraints in the given CloudProfile.
-func ValidateControlPlaneConfigAgainstCloudProfile(cpConfig *api.ControlPlaneConfig, shootRegion, floatingPoolName string, cloudProfile *gardencorev1beta1.CloudProfile, cloudProfileConfig *api.CloudProfileConfig, fldPath *field.Path) field.ErrorList {
+func ValidateControlPlaneConfigAgainstCloudProfile(cpConfig *api.ControlPlaneConfig, domain, shootRegion, floatingPoolName string, cloudProfile *gardencorev1beta1.CloudProfile, cloudProfileConfig *api.CloudProfileConfig, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	if ok, validLoadBalancerProviders := validateLoadBalancerProviderConstraints(cloudProfileConfig.Constraints.LoadBalancerProviders, shootRegion, cpConfig.LoadBalancerProvider); !ok {
 		allErrs = append(allErrs, field.NotSupported(fldPath.Child("loadBalancerProvider"), cpConfig.LoadBalancerProvider, validLoadBalancerProviders))
 	}
 
-	allErrs = append(allErrs, validateLoadBalancerClassesConstraints(cloudProfileConfig.Constraints.FloatingPools, cpConfig.LoadBalancerClasses, shootRegion, floatingPoolName, fldPath.Child("loadBalancerClasses"))...)
+	allErrs = append(allErrs, validateLoadBalancerClassesConstraints(cloudProfileConfig.Constraints.FloatingPools, cpConfig.LoadBalancerClasses, domain, shootRegion, floatingPoolName, fldPath.Child("loadBalancerClasses"))...)
 
 	if ok, validZones := validateZoneConstraints(cloudProfile.Spec.Regions, shootRegion, cpConfig.Zone); !ok {
 		allErrs = append(allErrs, field.NotSupported(fldPath.Child("zone"), cpConfig.Zone, validZones))
@@ -121,13 +121,13 @@ func validateZoneConstraints(regions []gardencorev1beta1.Region, region, zone st
 	return false, validValues
 }
 
-func validateLoadBalancerClassesConstraints(floatingPools []api.FloatingPool, shootLBClasses []api.LoadBalancerClass, shootRegion, floatingPoolName string, fldPath *field.Path) field.ErrorList {
+func validateLoadBalancerClassesConstraints(floatingPools []api.FloatingPool, shootLBClasses []api.LoadBalancerClass, domain, shootRegion, floatingPoolName string, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	if len(shootLBClasses) == 0 {
 		return allErrs
 	}
 
-	fp, errs := findFloatingPool(floatingPools, shootRegion, floatingPoolName, fldPath)
+	fp, errs := FindFloatingPool(floatingPools, domain, shootRegion, floatingPoolName, fldPath)
 	if len(errs) > 0 {
 		allErrs = append(allErrs, field.Invalid(field.NewPath("floatingPoolName"), floatingPoolName, errs.ToAggregate().Error()))
 		return allErrs

--- a/pkg/apis/openstack/validation/controlplane_test.go
+++ b/pkg/apis/openstack/validation/controlplane_test.go
@@ -89,6 +89,7 @@ var _ = Describe("ControlPlaneConfig validation", func() {
 	Describe("#ValidateControlPlaneConfigAgainstCloudProfile", func() {
 		var (
 			region       = "foo"
+			domain       = "dummy"
 			zone         = "some-zone"
 			floatingPool = "fp"
 
@@ -137,7 +138,7 @@ var _ = Describe("ControlPlaneConfig validation", func() {
 		It("should require a name of a load balancer provider that is part of the constraints", func() {
 			controlPlane.LoadBalancerProvider = "bar"
 
-			errorList := ValidateControlPlaneConfigAgainstCloudProfile(controlPlane, region, floatingPool, cloudProfile, cloudProfileConfig, nilPath)
+			errorList := ValidateControlPlaneConfigAgainstCloudProfile(controlPlane, domain, region, floatingPool, cloudProfile, cloudProfileConfig, nilPath)
 
 			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":  Equal(field.ErrorTypeNotSupported),
@@ -169,7 +170,7 @@ var _ = Describe("ControlPlaneConfig validation", func() {
 			}
 			controlPlane.LoadBalancerProvider = lbProvider1
 
-			errorList := ValidateControlPlaneConfigAgainstCloudProfile(controlPlane, differentRegion, "", cloudProfile, cloudProfileConfig, nilPath)
+			errorList := ValidateControlPlaneConfigAgainstCloudProfile(controlPlane, domain, differentRegion, "", cloudProfile, cloudProfileConfig, nilPath)
 
 			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":  Equal(field.ErrorTypeNotSupported),
@@ -202,7 +203,7 @@ var _ = Describe("ControlPlaneConfig validation", func() {
 			}
 			controlPlane.LoadBalancerProvider = lbProvider1
 
-			errorList := ValidateControlPlaneConfigAgainstCloudProfile(controlPlane, region, floatingPool, cloudProfile, cloudProfileConfig, nilPath)
+			errorList := ValidateControlPlaneConfigAgainstCloudProfile(controlPlane, domain, region, floatingPool, cloudProfile, cloudProfileConfig, nilPath)
 
 			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":  Equal(field.ErrorTypeNotSupported),
@@ -235,7 +236,7 @@ var _ = Describe("ControlPlaneConfig validation", func() {
 			}
 			controlPlane.LoadBalancerProvider = lbProvider2
 
-			errorList := ValidateControlPlaneConfigAgainstCloudProfile(controlPlane, differentRegion, "", cloudProfile, cloudProfileConfig, nilPath)
+			errorList := ValidateControlPlaneConfigAgainstCloudProfile(controlPlane, domain, differentRegion, "", cloudProfile, cloudProfileConfig, nilPath)
 
 			Expect(errorList).To(BeEmpty())
 		})
@@ -243,7 +244,7 @@ var _ = Describe("ControlPlaneConfig validation", func() {
 		It("should require a name of a zone that is part of the regions", func() {
 			controlPlane.Zone = "bar"
 
-			errorList := ValidateControlPlaneConfigAgainstCloudProfile(controlPlane, region, floatingPool, cloudProfile, cloudProfileConfig, nilPath)
+			errorList := ValidateControlPlaneConfigAgainstCloudProfile(controlPlane, domain, region, floatingPool, cloudProfile, cloudProfileConfig, nilPath)
 
 			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":  Equal(field.ErrorTypeNotSupported),
@@ -254,7 +255,7 @@ var _ = Describe("ControlPlaneConfig validation", func() {
 		It("should pass because no load balancer class is configured in cloud profile", func() {
 			cloudProfileConfig.Constraints.FloatingPools[0].LoadBalancerClasses = nil
 
-			errorList := ValidateControlPlaneConfigAgainstCloudProfile(controlPlane, region, floatingPool, cloudProfile, cloudProfileConfig, nilPath)
+			errorList := ValidateControlPlaneConfigAgainstCloudProfile(controlPlane, domain, region, floatingPool, cloudProfile, cloudProfileConfig, nilPath)
 
 			Expect(errorList).To(BeEmpty())
 		})
@@ -262,7 +263,7 @@ var _ = Describe("ControlPlaneConfig validation", func() {
 		It("should pass because load balancer class is configured correctly in control plane", func() {
 			controlPlane.LoadBalancerClasses = []api.LoadBalancerClass{loadBalancerClass}
 
-			errorList := ValidateControlPlaneConfigAgainstCloudProfile(controlPlane, region, floatingPool, cloudProfile, cloudProfileConfig, nilPath)
+			errorList := ValidateControlPlaneConfigAgainstCloudProfile(controlPlane, domain, region, floatingPool, cloudProfile, cloudProfileConfig, nilPath)
 
 			Expect(errorList).To(BeEmpty())
 		})
@@ -281,7 +282,7 @@ var _ = Describe("ControlPlaneConfig validation", func() {
 
 			controlPlane.LoadBalancerClasses = []api.LoadBalancerClass{lbClasses[1], lbClasses[0]}
 
-			errorList := ValidateControlPlaneConfigAgainstCloudProfile(controlPlane, region, floatingPool, cloudProfile, cloudProfileConfig, nilPath)
+			errorList := ValidateControlPlaneConfigAgainstCloudProfile(controlPlane, domain, region, floatingPool, cloudProfile, cloudProfileConfig, nilPath)
 
 			Expect(errorList).To(ConsistOf(
 				PointTo(MatchFields(IgnoreExtras, Fields{
@@ -320,7 +321,7 @@ var _ = Describe("ControlPlaneConfig validation", func() {
 
 			controlPlane.LoadBalancerClasses = []api.LoadBalancerClass{lbClasses[1]}
 
-			errorList := ValidateControlPlaneConfigAgainstCloudProfile(controlPlane, differentRegion, fpName, cloudProfile, cloudProfileConfig, nilPath)
+			errorList := ValidateControlPlaneConfigAgainstCloudProfile(controlPlane, domain, differentRegion, fpName, cloudProfile, cloudProfileConfig, nilPath)
 
 			Expect(errorList).To(BeEmpty())
 		})
@@ -341,7 +342,7 @@ var _ = Describe("ControlPlaneConfig validation", func() {
 
 			controlPlane.LoadBalancerClasses = []api.LoadBalancerClass{lbClasses[1]}
 
-			errorList := ValidateControlPlaneConfigAgainstCloudProfile(controlPlane, region, fpName, cloudProfile, cloudProfileConfig, nilPath)
+			errorList := ValidateControlPlaneConfigAgainstCloudProfile(controlPlane, domain, region, fpName, cloudProfile, cloudProfileConfig, nilPath)
 
 			Expect(errorList).To(BeEmpty())
 		})
@@ -359,7 +360,7 @@ var _ = Describe("ControlPlaneConfig validation", func() {
 
 			controlPlane.LoadBalancerClasses = []api.LoadBalancerClass{lbClasses[0]}
 
-			errorList := ValidateControlPlaneConfigAgainstCloudProfile(controlPlane, region, floatingPool, cloudProfile, cloudProfileConfig, nilPath)
+			errorList := ValidateControlPlaneConfigAgainstCloudProfile(controlPlane, domain, region, floatingPool, cloudProfile, cloudProfileConfig, nilPath)
 
 			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":  Equal(field.ErrorTypeNotSupported),
@@ -381,8 +382,38 @@ var _ = Describe("ControlPlaneConfig validation", func() {
 
 			controlPlane.LoadBalancerClasses = append(controlPlane.LoadBalancerClasses, lbClasses[0])
 
-			errorList := ValidateControlPlaneConfigAgainstCloudProfile(controlPlane, region, floatingPool, cloudProfile, cloudProfileConfig, nilPath)
+			errorList := ValidateControlPlaneConfigAgainstCloudProfile(controlPlane, domain, region, floatingPool, cloudProfile, cloudProfileConfig, nilPath)
 
+			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":  Equal(field.ErrorTypeNotSupported),
+				"Field": Equal("loadBalancerClasses[0]"),
+			}))))
+		})
+
+		It("should forbid using a load balancer class from another domain", func() {
+			differentDomain := "domain2"
+			lbClasses := []api.LoadBalancerClass{
+				{Name: "asia-lbClass1"},
+				{Name: "asia-lbClass2"},
+				{Name: "asia-lbClass2"},
+			}
+			cloudProfileConfig.Constraints.FloatingPools = []api.FloatingPool{
+				{
+					Name:                floatingPool,
+					LoadBalancerClasses: []api.LoadBalancerClass{loadBalancerClass},
+				},
+				{
+					Name:                floatingPool,
+					Domain:              &domain,
+					LoadBalancerClasses: lbClasses,
+				},
+			}
+
+			controlPlane.LoadBalancerClasses = append(controlPlane.LoadBalancerClasses, lbClasses[0])
+
+			errorList := ValidateControlPlaneConfigAgainstCloudProfile(controlPlane, domain, region, floatingPool, cloudProfile, cloudProfileConfig, nilPath)
+			Expect(errorList).To(BeEmpty())
+			errorList = ValidateControlPlaneConfigAgainstCloudProfile(controlPlane, differentDomain, region, floatingPool, cloudProfile, cloudProfileConfig, nilPath)
 			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":  Equal(field.ErrorTypeNotSupported),
 				"Field": Equal("loadBalancerClasses[0]"),
@@ -393,7 +424,7 @@ var _ = Describe("ControlPlaneConfig validation", func() {
 			controlPlane.LoadBalancerClasses = []api.LoadBalancerClass{loadBalancerClass}
 			cloudProfileConfig.Constraints.FloatingPools = nil
 
-			errorList := ValidateControlPlaneConfigAgainstCloudProfile(controlPlane, region, floatingPool, cloudProfile, cloudProfileConfig, nilPath)
+			errorList := ValidateControlPlaneConfigAgainstCloudProfile(controlPlane, domain, region, floatingPool, cloudProfile, cloudProfileConfig, nilPath)
 
 			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":  Equal(field.ErrorTypeInvalid),
@@ -406,7 +437,7 @@ var _ = Describe("ControlPlaneConfig validation", func() {
 			lbClass.FloatingNetworkID = nil
 			controlPlane.LoadBalancerClasses = []api.LoadBalancerClass{lbClass}
 
-			errorList := ValidateControlPlaneConfigAgainstCloudProfile(controlPlane, region, floatingPool, cloudProfile, cloudProfileConfig, nilPath)
+			errorList := ValidateControlPlaneConfigAgainstCloudProfile(controlPlane, domain, region, floatingPool, cloudProfile, cloudProfileConfig, nilPath)
 
 			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":  Equal(field.ErrorTypeNotSupported),

--- a/pkg/apis/openstack/validation/infrastructure_test.go
+++ b/pkg/apis/openstack/validation/infrastructure_test.go
@@ -15,11 +15,14 @@
 package validation_test
 
 import (
+	"strings"
+
 	api "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack"
 	. "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack/validation"
 
 	. "github.com/gardener/gardener/pkg/utils/validation/gomega"
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -147,6 +150,7 @@ var _ = Describe("InfrastructureConfig validation", func() {
 	Describe("#ValidateInfrastructureConfigAgainstCloudProfile", func() {
 		var (
 			region             = "europe"
+			domain             = "dummy"
 			cloudProfileConfig *api.CloudProfileConfig
 		)
 
@@ -166,7 +170,7 @@ var _ = Describe("InfrastructureConfig validation", func() {
 		It("should allow using a regional floating pool from the same region", func() {
 			infrastructureConfig.FloatingPoolName = floatingPoolName1
 
-			errorList := ValidateInfrastructureConfigAgainstCloudProfile(infrastructureConfig, region, cloudProfileConfig, nilPath)
+			errorList := ValidateInfrastructureConfigAgainstCloudProfile(infrastructureConfig, domain, region, cloudProfileConfig, nilPath)
 
 			Expect(errorList).To(BeEmpty())
 		})
@@ -175,7 +179,7 @@ var _ = Describe("InfrastructureConfig validation", func() {
 			cloudProfileConfig.Constraints.FloatingPools[0].Name = "*"
 			infrastructureConfig.FloatingPoolName = floatingPoolName1
 
-			errorList := ValidateInfrastructureConfigAgainstCloudProfile(infrastructureConfig, region, cloudProfileConfig, nilPath)
+			errorList := ValidateInfrastructureConfigAgainstCloudProfile(infrastructureConfig, domain, region, cloudProfileConfig, nilPath)
 
 			Expect(errorList).To(BeEmpty())
 		})
@@ -196,31 +200,7 @@ var _ = Describe("InfrastructureConfig validation", func() {
 			}
 			infrastructureConfig.FloatingPoolName = floatingPoolName1
 
-			errorList := ValidateInfrastructureConfigAgainstCloudProfile(infrastructureConfig, differentRegion, cloudProfileConfig, nilPath)
-
-			Expect(errorList).To(ConsistOfFields(Fields{
-				"Type":  Equal(field.ErrorTypeNotSupported),
-				"Field": Equal("floatingPoolName"),
-			}))
-		})
-
-		It("should forbid using the non-regional floating pool name if region is specified", func() {
-			floatingPoolName2 := "fp2"
-
-			cloudProfileConfig.Constraints = api.Constraints{
-				FloatingPools: []api.FloatingPool{
-					{
-						Name: floatingPoolName2,
-					},
-					{
-						Name:   floatingPoolName1,
-						Region: &region,
-					},
-				},
-			}
-			infrastructureConfig.FloatingPoolName = floatingPoolName2
-
-			errorList := ValidateInfrastructureConfigAgainstCloudProfile(infrastructureConfig, region, cloudProfileConfig, nilPath)
+			errorList := ValidateInfrastructureConfigAgainstCloudProfile(infrastructureConfig, domain, differentRegion, cloudProfileConfig, nilPath)
 
 			Expect(errorList).To(ConsistOfFields(Fields{
 				"Type":  Equal(field.ErrorTypeNotSupported),
@@ -234,7 +214,7 @@ var _ = Describe("InfrastructureConfig validation", func() {
 			}
 			infrastructureConfig.FloatingPoolName = floatingPoolName1
 
-			errorList := ValidateInfrastructureConfigAgainstCloudProfile(infrastructureConfig, region, cloudProfileConfig, nilPath)
+			errorList := ValidateInfrastructureConfigAgainstCloudProfile(infrastructureConfig, domain, region, cloudProfileConfig, nilPath)
 
 			Expect(errorList).To(ConsistOfFields(Fields{
 				"Type":  Equal(field.ErrorTypeNotSupported),
@@ -242,7 +222,7 @@ var _ = Describe("InfrastructureConfig validation", func() {
 			}))
 		})
 
-		It("should allow using the non-regional floating pool name if region not specified", func() {
+		It("should only allow using a global floating pool name if different from other regional fp", func() {
 			differentRegion := "asia"
 			floatingPoolName2 := "fp2"
 
@@ -259,9 +239,109 @@ var _ = Describe("InfrastructureConfig validation", func() {
 			}
 			infrastructureConfig.FloatingPoolName = floatingPoolName2
 
-			errorList := ValidateInfrastructureConfigAgainstCloudProfile(infrastructureConfig, differentRegion, cloudProfileConfig, nilPath)
-
+			errorList := ValidateInfrastructureConfigAgainstCloudProfile(infrastructureConfig, domain, region, cloudProfileConfig, nilPath)
+			Expect(errorList).To(ConsistOfFields(Fields{
+				"Type":  Equal(field.ErrorTypeNotSupported),
+				"Field": Equal("floatingPoolName"),
+			}))
+			errorList = ValidateInfrastructureConfigAgainstCloudProfile(infrastructureConfig, domain, differentRegion, cloudProfileConfig, nilPath)
 			Expect(errorList).To(BeEmpty())
+		})
+
+		It("should only allow using a global floating pool name if no restricted fp are present", func() {
+			differentRegion := "asia"
+			differentDomain := "domain2"
+			floatingPoolName2 := "fp2"
+
+			cloudProfileConfig.Constraints = api.Constraints{
+				FloatingPools: []api.FloatingPool{
+					{
+						Name: floatingPoolName2,
+					},
+					{
+						Name:   floatingPoolName1,
+						Region: &region,
+						Domain: &domain,
+					},
+				},
+			}
+			infrastructureConfig.FloatingPoolName = floatingPoolName2
+
+			errorList := ValidateInfrastructureConfigAgainstCloudProfile(infrastructureConfig, domain, region, cloudProfileConfig, nilPath)
+			Expect(errorList).To(ConsistOfFields(Fields{
+				"Type":  Equal(field.ErrorTypeNotSupported),
+				"Field": Equal("floatingPoolName"),
+			}))
+			errorList = ValidateInfrastructureConfigAgainstCloudProfile(infrastructureConfig, differentDomain, region, cloudProfileConfig, nilPath)
+			Expect(errorList).To(BeEmpty())
+			errorList = ValidateInfrastructureConfigAgainstCloudProfile(infrastructureConfig, differentDomain, differentRegion, cloudProfileConfig, nilPath)
+			Expect(errorList).To(BeEmpty())
+			errorList = ValidateInfrastructureConfigAgainstCloudProfile(infrastructureConfig, domain, differentRegion, cloudProfileConfig, nilPath)
+			Expect(errorList).To(BeEmpty())
+		})
+
+		It("should only allow domain and region specific floating pool name for this domain and region", func() {
+			differentRegion := "asia"
+			differentDomain := "domain2"
+			floatingPoolName2 := "fp2"
+
+			cloudProfileConfig.Constraints = api.Constraints{
+				FloatingPools: []api.FloatingPool{
+					{
+						Name: floatingPoolName2,
+					},
+					{
+						Name:   floatingPoolName1,
+						Region: &region,
+						Domain: &domain,
+					},
+				},
+			}
+			infrastructureConfig.FloatingPoolName = floatingPoolName1
+
+			errorList := ValidateInfrastructureConfigAgainstCloudProfile(infrastructureConfig, domain, region, cloudProfileConfig, nilPath)
+			Expect(errorList).To(BeEmpty())
+			errorList = ValidateInfrastructureConfigAgainstCloudProfile(infrastructureConfig, differentDomain, region, cloudProfileConfig, nilPath)
+			Expect(errorList).To(ConsistOfFields(Fields{
+				"Type":  Equal(field.ErrorTypeNotSupported),
+				"Field": Equal("floatingPoolName"),
+			}))
+			errorList = ValidateInfrastructureConfigAgainstCloudProfile(infrastructureConfig, differentDomain, differentRegion, cloudProfileConfig, nilPath)
+			Expect(errorList).To(ConsistOfFields(Fields{
+				"Type":  Equal(field.ErrorTypeNotSupported),
+				"Field": Equal("floatingPoolName"),
+			}))
+			errorList = ValidateInfrastructureConfigAgainstCloudProfile(infrastructureConfig, domain, differentRegion, cloudProfileConfig, nilPath)
+			Expect(errorList).To(ConsistOfFields(Fields{
+				"Type":  Equal(field.ErrorTypeNotSupported),
+				"Field": Equal("floatingPoolName"),
+			}))
+		})
+
+		It("should only allow domain specific floating pool name for this domain", func() {
+			differentDomain := "domain2"
+			floatingPoolName2 := "fp2"
+
+			cloudProfileConfig.Constraints = api.Constraints{
+				FloatingPools: []api.FloatingPool{
+					{
+						Name: floatingPoolName2,
+					},
+					{
+						Name:   floatingPoolName1,
+						Domain: &domain,
+					},
+				},
+			}
+			infrastructureConfig.FloatingPoolName = floatingPoolName1
+
+			errorList := ValidateInfrastructureConfigAgainstCloudProfile(infrastructureConfig, domain, region, cloudProfileConfig, nilPath)
+			Expect(errorList).To(BeEmpty())
+			errorList = ValidateInfrastructureConfigAgainstCloudProfile(infrastructureConfig, differentDomain, region, cloudProfileConfig, nilPath)
+			Expect(errorList).To(ConsistOfFields(Fields{
+				"Type":  Equal(field.ErrorTypeNotSupported),
+				"Field": Equal("floatingPoolName"),
+			}))
 		})
 
 		It("should allow using an arbitrary non-regional floating pool name if region not specified (wildcard case)", func() {
@@ -281,9 +361,126 @@ var _ = Describe("InfrastructureConfig validation", func() {
 			}
 			infrastructureConfig.FloatingPoolName = someFloatingPool
 
-			errorList := ValidateInfrastructureConfigAgainstCloudProfile(infrastructureConfig, differentRegion, cloudProfileConfig, nilPath)
+			errorList := ValidateInfrastructureConfigAgainstCloudProfile(infrastructureConfig, domain, differentRegion, cloudProfileConfig, nilPath)
 
 			Expect(errorList).To(BeEmpty())
 		})
+	})
+
+	Describe("#FindFloatingPool", func() {
+		domain1 := "domain1"
+		domain2 := "domain2"
+		domain3 := "domain3"
+		domain4 := "domain4"
+		regionA := "regionA"
+		regionB := "regionB"
+		regionC := "regionC"
+		regionD := "regionD"
+
+		fpglobal := api.FloatingPool{Name: "fpglobal"}
+		fp1 := api.FloatingPool{Name: "fp1", Domain: &domain1}
+		fpA := api.FloatingPool{Name: "fpA", Region: &regionA}
+		fp1A := api.FloatingPool{Name: "fp1A", Domain: &domain1, Region: &regionA}
+		fp3 := api.FloatingPool{Name: "fp3", Domain: &domain3}
+		fpC := api.FloatingPool{Name: "fpC", Region: &regionC}
+		fp4 := api.FloatingPool{Name: "fp4D", Domain: &domain4}
+		fpD := api.FloatingPool{Name: "fp4D", Region: &regionD}
+		fpWild := api.FloatingPool{Name: "fpwild*", Domain: &domain1, Region: &regionA}
+
+		pools12 := []api.FloatingPool{fpglobal, fp1, fpA, fp1A, fpWild}
+		pools34 := []api.FloatingPool{fp3, fpC, fp4, fpD}
+
+		nonConstraining := true
+		fpglobaladd := api.FloatingPool{Name: "fpglobaladd*", NonConstraining: &nonConstraining}
+		fp1add := api.FloatingPool{Name: "fp1add", Domain: &domain1, NonConstraining: &nonConstraining}
+		pools12add := []api.FloatingPool{fpglobal, fp1, fpA, fp1A, fp1add, fpglobaladd}
+
+		vvNone := []string{}
+		vvGlobal := []string{"fpglobal"}
+		vv1 := []string{"fp1"}
+		vvA := []string{"fpA"}
+		vv1A := []string{"fp1A", "fpwild*"}
+		vvGlobalAdd := []string{"fpglobal", "fpglobaladd*"}
+
+		valuesToString := func(values []string) string {
+			if len(values) == 0 {
+				return ""
+			}
+			return "supported values: \"" + strings.Join(values, "\", \"") + "\""
+		}
+
+		DescribeTable("FindFloatingPool table",
+			func(pools []api.FloatingPool, fpName string, domain string, region string, expectedFp *api.FloatingPool, expectedValidValues []string) {
+				found, errorList := FindFloatingPool(pools, domain, region, fpName, nilPath)
+				if expectedFp != nil {
+					Expect(found).To(Equal(expectedFp))
+					Expect(errorList).To(BeEmpty())
+				} else {
+					Expect(found).To(BeNil())
+					Expect(errorList).To(ConsistOfFields(Fields{
+						"Type":     Equal(field.ErrorTypeNotSupported),
+						"BadValue": Equal(fpName),
+						"Detail":   Equal(valuesToString(expectedValidValues)),
+					}))
+				}
+			},
+
+			Entry("global unrestricted 1A", pools12, "fpglobal", domain1, regionA, nil, vv1A),
+			Entry("global unrestricted 1B", pools12, "fpglobal", domain1, regionB, nil, vv1),
+			Entry("global unrestricted 2A", pools12, "fpglobal", domain2, regionA, nil, vvA),
+			Entry("global unrestricted 2B", pools12, "fpglobal", domain2, regionB, &fpglobal, nil),
+
+			Entry("domain restricted 1A", pools12, "fp1", domain1, regionA, nil, vv1A),
+			Entry("domain restricted 1B", pools12, "fp1", domain1, regionB, &fp1, nil),
+			Entry("domain restricted 2A", pools12, "fp1", domain2, regionA, nil, vvA),
+			Entry("domain restricted 2B", pools12, "fp1", domain2, regionB, nil, vvGlobal),
+
+			Entry("region restricted 1A", pools12, "fpA", domain1, regionA, nil, vv1A),
+			Entry("region restricted 1B", pools12, "fpA", domain1, regionB, nil, vv1),
+			Entry("region restricted 2A", pools12, "fpA", domain2, regionA, &fpA, nil),
+			Entry("region restricted 2B", pools12, "fpA", domain2, regionB, nil, vvGlobal),
+
+			Entry("domain&region restricted 1A", pools12, "fp1A", domain1, regionA, &fp1A, nil),
+			Entry("domain&region restricted 1B", pools12, "fp1A", domain1, regionB, nil, vv1),
+			Entry("domain&region restricted 2A", pools12, "fp1A", domain2, regionA, nil, vvA),
+			Entry("domain&region restricted 2B", pools12, "fp1A", domain2, regionB, nil, vvGlobal),
+
+			Entry("wildcard 1A", pools12, "fpwildfoo", domain1, regionA, &fpWild, nil),
+			Entry("wildcard 1B", pools12, "fpwildfoo", domain1, regionB, nil, vv1),
+			Entry("wildcard 2A", pools12, "fpwildfoo", domain2, regionA, nil, vvA),
+			Entry("wildcard 2B", pools12, "fpwildfoo", domain2, regionB, nil, vvGlobal),
+
+			Entry("unknown", pools12, "fpunknown", domain1, regionA, nil, vv1A),
+			Entry("unknown", []api.FloatingPool{}, "fp", domain1, regionA, nil, vvNone),
+
+			Entry("domain restricted 3B", pools34, "fp3", domain3, regionB, &fp3, nil),
+			Entry("domain restricted 3C", pools34, "fp3", domain3, regionC, nil, vvNone),
+			Entry("domain restricted 4D", pools34, "fp4D", domain4, regionD, &fpD, nil),
+
+			Entry("region restricted 2C", pools34, "fpC", domain2, regionC, &fpC, nil),
+			Entry("region restricted 3C", pools34, "fpC", domain3, regionC, nil, vvNone),
+			Entry("region restricted 4D", pools34, "fp4D", domain4, regionD, &fpD, nil), // result is fpD because region preferred in intersection cause, but same fp name as &fp4
+
+			Entry("domain/region restricted 1D unknown", pools34, "fpunknown", domain1, regionD, nil, []string{"fp4D"}),
+			Entry("domain/region restricted 3D unknown", pools34, "fpunknown", domain3, regionD, nil, vvNone),
+			Entry("domain/region restricted 4A unknown", pools34, "fpunknown", domain4, regionA, nil, []string{"fp4D"}),
+			Entry("domain/region restricted 4C unknown", pools34, "fpunknown", domain4, regionC, nil, vvNone),
+			Entry("domain/region restricted 4D unknown", pools34, "fpunknown", domain4, regionD, nil, []string{"fp4D"}),
+
+			Entry("no non-constraining 1A", pools12, "fp1add", domain1, regionA, nil, vv1A),
+			Entry("non-constraining 1A", pools12add, "fp1add", domain1, regionA, &fp1add, nil),
+			Entry("non-constraining 1B", pools12add, "fp1add", domain1, regionB, &fp1add, nil),
+			Entry("non-constraining 2A", pools12add, "fp1add", domain2, regionA, nil, []string{"fpA", "fpglobaladd*"}),
+			Entry("non-constraining 2B", pools12add, "fp1add", domain2, regionB, nil, vvGlobalAdd),
+
+			Entry("no non-constraining - global 1A", pools12, "fpglobaladdfoo", domain1, regionA, nil, vv1A),
+			Entry("non-constraining - global 1A", pools12add, "fpglobaladdfoo", domain1, regionA, &fpglobaladd, nil),
+			Entry("non-constraining - global 1B", pools12add, "fpglobaladdfoo", domain1, regionB, &fpglobaladd, nil),
+			Entry("non-constraining - global 2A", pools12add, "fpglobaladdfoo", domain2, regionA, &fpglobaladd, nil),
+			Entry("non-constraining - unknown 1A", pools12add, "fpunknown", domain1, regionA, nil, []string{"fp1A", "fp1add", "fpglobaladd*"}),
+			Entry("non-constraining - unknown 1B", pools12add, "fpunknown", domain1, regionB, nil, []string{"fp1", "fp1add", "fpglobaladd*"}),
+			Entry("non-constraining - unknown 2A", pools12add, "fpunknown", domain2, regionA, nil, []string{"fpA", "fpglobaladd*"}),
+			Entry("non-constraining - unknown 2B", pools12add, "fpunknown", domain2, regionB, nil, []string{"fpglobal", "fpglobaladd*"}),
+		)
 	})
 })

--- a/pkg/apis/openstack/zz_generated.deepcopy.go
+++ b/pkg/apis/openstack/zz_generated.deepcopy.go
@@ -180,6 +180,16 @@ func (in *FloatingPool) DeepCopyInto(out *FloatingPool) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.Domain != nil {
+		in, out := &in.Domain, &out.Domain
+		*out = new(string)
+		**out = **in
+	}
+	if in.NonConstraining != nil {
+		in, out := &in.NonConstraining, &out.NonConstraining
+		*out = new(bool)
+		**out = **in
+	}
 	if in.LoadBalancerClasses != nil {
 		in, out := &in.LoadBalancerClasses, &out.LoadBalancerClasses
 		*out = make([]LoadBalancerClass, len(*in))

--- a/pkg/internal/credentials.go
+++ b/pkg/internal/credentials.go
@@ -18,8 +18,10 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/gardener/gardener-extension-provider-openstack/pkg/openstack"
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+
+	"github.com/gardener/gardener-extension-provider-openstack/pkg/openstack"
 
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -32,6 +34,16 @@ type Credentials struct {
 	Username   string
 	Password   string
 	AuthURL    string
+}
+
+// GetCredentials computes for a given context and infrastructure the corresponding credentials object.
+func GetCredentialsBySecretBinding(ctx context.Context, c client.Client, secretBindingKey client.ObjectKey) (*Credentials, error) {
+	binding := &gardencorev1beta1.SecretBinding{}
+	if err := c.Get(ctx, secretBindingKey, binding); err != nil {
+		return nil, err
+	}
+
+	return GetCredentials(ctx, c, binding.SecretRef)
 }
 
 // GetCredentials computes for a given context and infrastructure the corresponding credentials object.


### PR DESCRIPTION
**What this PR does / why we need it**:
Add an optional domain field to FloatingPool to allow configuring that the given floating pool is only available in the specified domain.
The cloud profile validation now checks the specified floatingpools for consistent combinations of name/region/domain.
The shoot validation prevents using floating pools from a different region/domain combination.

Example:

```yaml
apiVersion: core.gardener.cloud/v1beta1
kind: CloudProfile
metadata:
  name: openstack
spec:
  type: openstack
  ...
  providerConfig:
    apiVersion: openstack.provider.extensions.gardener.cloud/v1alpha1
    kind: CloudProfileConfig
    ...
    constraints:
      floatingPools:
      - name: fp-pool-1 #valid in `domain1` domain in `eu-1` region
        region: eu-1
        domain: domain1
      - name: fp-pool-2 # valid in all domains in `eu-1` region (but not for domain `domain1`)
        region: eu-1
      - name: fp-pool-3 # valid in all domains and all regions (but not for region `eu-1`)
      loadBalancerProviders:
      - name: haproxy
```

**Which issue(s) this PR fixes**:
Fixes #73

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
added optional domain field to floatingpools in the cloud profile constraints
```
