### PR TITLE
Move credentials methods from pkg/internal to pkg/openstack

### DIFF
--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -21,7 +21,7 @@ import (
 
 	api "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack"
 	"github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack/helper"
-	"github.com/gardener/gardener-extension-provider-openstack/pkg/internal"
+	"github.com/gardener/gardener-extension-provider-openstack/pkg/openstack"
 	openstacktypes "github.com/gardener/gardener-extension-provider-openstack/pkg/openstack"
 	"github.com/gardener/gardener-extension-provider-openstack/pkg/utils"
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
@@ -154,7 +154,7 @@ func (vp *valuesProvider) GetConfigChartValues(
 	}
 
 	// Get credentials
-	credentials, err := internal.GetCredentials(ctx, vp.Client(), cp.Spec.SecretRef)
+	credentials, err := openstack.GetCredentials(ctx, vp.Client(), cp.Spec.SecretRef)
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not get service account from secret '%s/%s'", cp.Spec.SecretRef.Namespace, cp.Spec.SecretRef.Name)
 	}
@@ -208,7 +208,7 @@ func getConfigChartValues(
 	infraStatus *api.InfrastructureStatus,
 	cloudProfileConfig *api.CloudProfileConfig,
 	cp *extensionsv1alpha1.ControlPlane,
-	c *internal.Credentials,
+	c *openstack.Credentials,
 	cluster *extensionscontroller.Cluster,
 ) (map[string]interface{}, error) {
 	// Get the first subnet with purpose "nodes"

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -21,7 +21,6 @@ import (
 
 	api "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack"
 	"github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack/helper"
-	"github.com/gardener/gardener-extension-provider-openstack/pkg/internal"
 	"github.com/gardener/gardener-extension-provider-openstack/pkg/openstack"
 
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
@@ -64,7 +63,7 @@ func (w *workerDelegate) GenerateMachineDeployments(ctx context.Context) (worker
 }
 
 func (w *workerDelegate) generateMachineClassSecretData(ctx context.Context) (map[string][]byte, error) {
-	credentials, err := internal.GetCredentials(ctx, w.Client(), w.worker.Spec.SecretRef)
+	credentials, err := openstack.GetCredentials(ctx, w.Client(), w.worker.Spec.SecretRef)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/internal/infrastructure/infrastructure.go
+++ b/pkg/internal/infrastructure/infrastructure.go
@@ -17,13 +17,13 @@ package infrastructure
 import (
 	"context"
 
-	"github.com/gardener/gardener-extension-provider-openstack/pkg/internal"
+	"github.com/gardener/gardener-extension-provider-openstack/pkg/openstack"
 
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // GetCredentialsFromInfrastructure retrieves the ServiceAccount from the Secret referenced in the given Infrastructure.
-func GetCredentialsFromInfrastructure(ctx context.Context, c client.Client, config *extensionsv1alpha1.Infrastructure) (*internal.Credentials, error) {
-	return internal.GetCredentials(ctx, c, config.Spec.SecretRef)
+func GetCredentialsFromInfrastructure(ctx context.Context, c client.Client, config *extensionsv1alpha1.Infrastructure) (*openstack.Credentials, error) {
+	return openstack.GetCredentials(ctx, c, config.Spec.SecretRef)
 }

--- a/pkg/internal/infrastructure/terraform.go
+++ b/pkg/internal/infrastructure/terraform.go
@@ -20,7 +20,7 @@ import (
 	api "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack"
 	"github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack/helper"
 	apiv1alpha1 "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack/v1alpha1"
-	"github.com/gardener/gardener-extension-provider-openstack/pkg/internal"
+	"github.com/gardener/gardener-extension-provider-openstack/pkg/openstack"
 	openstacktypes "github.com/gardener/gardener-extension-provider-openstack/pkg/openstack"
 	"github.com/gardener/gardener/extensions/pkg/controller"
 	"github.com/gardener/gardener/extensions/pkg/terraformer"
@@ -60,7 +60,7 @@ var StatusTypeMeta = metav1.TypeMeta{
 // ComputeTerraformerChartValues computes the values for the OpenStack Terraformer chart.
 func ComputeTerraformerChartValues(
 	infra *extensionsv1alpha1.Infrastructure,
-	credentials *internal.Credentials,
+	credentials *openstack.Credentials,
 	config *api.InfrastructureConfig,
 	cluster *controller.Cluster,
 ) (map[string]interface{}, error) {
@@ -126,7 +126,7 @@ func ComputeTerraformerChartValues(
 func RenderTerraformerChart(
 	renderer chartrenderer.Interface,
 	infra *extensionsv1alpha1.Infrastructure,
-	credentials *internal.Credentials,
+	credentials *openstack.Credentials,
 	config *api.InfrastructureConfig,
 	cluster *controller.Cluster,
 ) (*TerraformFiles, error) {

--- a/pkg/internal/infrastructure/terraform_test.go
+++ b/pkg/internal/infrastructure/terraform_test.go
@@ -19,7 +19,7 @@ import (
 
 	api "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack"
 	apiv1alpha1 "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack/v1alpha1"
-	"github.com/gardener/gardener-extension-provider-openstack/pkg/internal"
+	"github.com/gardener/gardener-extension-provider-openstack/pkg/openstack"
 	"github.com/gardener/gardener/extensions/pkg/controller"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
@@ -38,7 +38,7 @@ var _ = Describe("Terraform", func() {
 		cloudProfileConfigJSON []byte
 		config                 *api.InfrastructureConfig
 		cluster                *controller.Cluster
-		credentials            *internal.Credentials
+		credentials            *openstack.Credentials
 
 		keystoneURL = "foo-bar.com"
 		dnsServers  = []string{"a", "b"}
@@ -106,7 +106,7 @@ var _ = Describe("Terraform", func() {
 			},
 		}
 
-		credentials = &internal.Credentials{Username: "user", Password: "secret"}
+		credentials = &openstack.Credentials{Username: "user", Password: "secret"}
 	})
 
 	Describe("#ComputeTerraformerChartValues", func() {

--- a/pkg/internal/terraform.go
+++ b/pkg/internal/terraform.go
@@ -18,8 +18,9 @@ import (
 	"time"
 
 	"github.com/gardener/gardener-extension-provider-openstack/pkg/imagevector"
-	"github.com/gardener/gardener/extensions/pkg/terraformer"
+	"github.com/gardener/gardener-extension-provider-openstack/pkg/openstack"
 
+	"github.com/gardener/gardener/extensions/pkg/terraformer"
 	"github.com/gardener/gardener/pkg/logger"
 	"k8s.io/client-go/rest"
 )
@@ -33,7 +34,7 @@ const (
 
 // TerraformerVariablesEnvironmentFromCredentials computes the Terraformer variables environment from the
 // given Credentials.
-func TerraformerVariablesEnvironmentFromCredentials(creds *Credentials) map[string]string {
+func TerraformerVariablesEnvironmentFromCredentials(creds *openstack.Credentials) map[string]string {
 	return map[string]string{
 		TerraformVarNameUserName: creds.Username,
 		TerraformVarNamePassword: creds.Password,
@@ -64,7 +65,7 @@ func NewTerraformerWithAuth(
 	purpose,
 	namespace,
 	name string,
-	creds *Credentials,
+	creds *openstack.Credentials,
 ) (terraformer.Terraformer, error) {
 	tf, err := NewTerraformer(restConfig, purpose, namespace, name)
 	if err != nil {

--- a/pkg/internal/terraform_test.go
+++ b/pkg/internal/terraform_test.go
@@ -15,6 +15,8 @@
 package internal
 
 import (
+	"github.com/gardener/gardener-extension-provider-openstack/pkg/openstack"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -23,12 +25,13 @@ var _ = Describe("Terraform", func() {
 	var (
 		username    string
 		password    string
-		credentials *Credentials
+		credentials *openstack.Credentials
 	)
+
 	BeforeEach(func() {
 		username = "user"
 		password = "password"
-		credentials = &Credentials{Username: username, Password: password}
+		credentials = &openstack.Credentials{Username: username, Password: password}
 	})
 
 	Describe("#TerraformerVariablesEnvironmentFromCredentials", func() {

--- a/pkg/openstack/client/swift.go
+++ b/pkg/openstack/client/swift.go
@@ -17,7 +17,7 @@ package client
 import (
 	"context"
 
-	"github.com/gardener/gardener-extension-provider-openstack/pkg/internal"
+	os "github.com/gardener/gardener-extension-provider-openstack/pkg/openstack"
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack"
@@ -31,7 +31,7 @@ import (
 
 // NewStorageClientFromSecretRef retrieves the openstack client from specified by the secret reference.
 func NewStorageClientFromSecretRef(ctx context.Context, c client.Client, secretRef corev1.SecretReference, region string) (*StorageClient, error) {
-	credentials, err := internal.GetCredentials(ctx, c, secretRef)
+	credentials, err := os.GetCredentials(ctx, c, secretRef)
 	if err != nil {
 		return nil, err
 	}
@@ -40,7 +40,7 @@ func NewStorageClientFromSecretRef(ctx context.Context, c client.Client, secretR
 }
 
 // newStorageClientFromCredentials create the storage client from credentials.
-func newStorageClientFromCredentials(credentials *internal.Credentials, region string) (*StorageClient, error) {
+func newStorageClientFromCredentials(credentials *os.Credentials, region string) (*StorageClient, error) {
 	opts := &clientconfig.ClientOpts{
 		AuthInfo: &clientconfig.AuthInfo{
 			AuthURL:     credentials.AuthURL,

--- a/pkg/openstack/credentials.go
+++ b/pkg/openstack/credentials.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package internal
+package openstack
 
 import (
 	"context"
@@ -20,9 +20,6 @@ import (
 
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-
-	"github.com/gardener/gardener-extension-provider-openstack/pkg/openstack"
-
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -60,23 +57,23 @@ func ExtractCredentials(secret *corev1.Secret) (*Credentials, error) {
 	if secret.Data == nil {
 		return nil, fmt.Errorf("secret does not contain any data")
 	}
-	domainName, err := getRequired(secret.Data, openstack.DomainName)
+	domainName, err := getRequired(secret.Data, DomainName)
 	if err != nil {
 		return nil, err
 	}
-	tenantName, err := getRequired(secret.Data, openstack.TenantName)
+	tenantName, err := getRequired(secret.Data, TenantName)
 	if err != nil {
 		return nil, err
 	}
-	userName, err := getRequired(secret.Data, openstack.UserName)
+	userName, err := getRequired(secret.Data, UserName)
 	if err != nil {
 		return nil, err
 	}
-	password, err := getRequired(secret.Data, openstack.Password)
+	password, err := getRequired(secret.Data, Password)
 	if err != nil {
 		return nil, err
 	}
-	authURL := secret.Data[openstack.AuthURL]
+	authURL := secret.Data[AuthURL]
 
 	return &Credentials{
 		DomainName: domainName,

--- a/pkg/validator/shoot_handler.go
+++ b/pkg/validator/shoot_handler.go
@@ -19,6 +19,8 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/gardener/gardener-extension-provider-openstack/pkg/openstack"
+
 	"github.com/gardener/gardener/extensions/pkg/util"
 	"github.com/gardener/gardener/pkg/apis/core"
 	"github.com/go-logr/logr"
@@ -27,9 +29,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
-
-	"github.com/gardener/gardener-extension-provider-openstack/pkg/internal"
-	"github.com/gardener/gardener-extension-provider-openstack/pkg/openstack"
 )
 
 // Shoot validates shoots
@@ -52,7 +51,7 @@ func (v *Shoot) Handle(ctx context.Context, req admission.Request) admission.Res
 	}
 
 	// Get credentials
-	credentials, err := internal.GetCredentialsBySecretBinding(ctx, v.client, client.ObjectKey{Namespace: shoot.Namespace, Name: shoot.Spec.SecretBindingName})
+	credentials, err := openstack.GetCredentialsBySecretBinding(ctx, v.client, client.ObjectKey{Namespace: shoot.Namespace, Name: shoot.Spec.SecretBindingName})
 	if err != nil {
 		v.Logger.Error(err, "could not get credentials from SecretBindingName %s", shoot.Spec.SecretBindingName)
 		return admission.Errored(http.StatusBadRequest, err)

--- a/pkg/validator/shoot_validator.go
+++ b/pkg/validator/shoot_validator.go
@@ -18,17 +18,16 @@ import (
 	"context"
 	"fmt"
 
-	"k8s.io/apimachinery/pkg/api/equality"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
 	"github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack"
 	openstackvalidation "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack/validation"
 
 	"github.com/gardener/gardener/pkg/apis/core"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type validationContext struct {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker
-->
/area quality
/kind bug
/priority normal
/platform openstack

**What this PR does / why we need it**:
This PR fixes a bug that caused the validator-openstack to crash because it was depending on the `charts` directory. However, the `charts` directory is only present in the `provider-openstack`.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
A bug has been fixed that caused the `validator-openstack` to crash due to an invalid dependency on the OpenStack's `charts/images.yaml` file.
```
