### PR TITLE
Add region information to cloud-provider config

### DIFF
--- a/charts/internal/cloud-provider-config/templates/_cloud-provider-config-global.tpl
+++ b/charts/internal/cloud-provider-config/templates/_cloud-provider-config-global.tpl
@@ -4,4 +4,5 @@ domain-name="{{ .Values.domainName }}"
 tenant-name="{{ .Values.tenantName }}"
 username="{{ .Values.username }}"
 password="{{ .Values.password }}"
+region="{{ .Values.region }}"
 {{- end -}}

--- a/charts/internal/cloud-provider-config/values.yaml
+++ b/charts/internal/cloud-provider-config/values.yaml
@@ -5,6 +5,7 @@ domainName: fooDomain
 tenantName: fooTenant
 username: barUser
 password: barPass
+region: eu
 # [LoadBalancer]
 lbProvider: foobar
 # floatingNetworkID: foo-bar-123

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -411,6 +411,7 @@ func getConfigChartValues(
 		"tenantName":        c.TenantName,
 		"username":          c.Username,
 		"password":          c.Password,
+		"region":            cp.Spec.Region,
 		"lbProvider":        cpConfig.LoadBalancerProvider,
 		"floatingNetworkID": infraStatus.Networks.FloatingPool.ID,
 		"subnetID":          subnet.ID,

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -44,6 +44,7 @@ import (
 const (
 	namespace = "test"
 	authURL   = "someurl"
+	region    = "europe"
 )
 
 var (
@@ -80,6 +81,7 @@ func controlPlane(floatingPoolID string, cfg *api.ControlPlaneConfig) *extension
 					Raw: encode(cfg),
 				},
 			},
+			Region: region,
 			InfrastructureProviderStatus: &runtime.RawExtension{
 				Raw: encode(&api.InfrastructureStatus{
 					Networks: api.NetworkStatus{
@@ -244,6 +246,7 @@ var _ = Describe("ValuesProvider", func() {
 			"tenantName":        "tenant-name",
 			"username":          "username",
 			"password":          "password",
+			"region":            region,
 			"subnetID":          "subnet-acbd1234",
 			"lbProvider":        "load-balancer-provider",
 			"floatingNetworkID": "floating-network-id",
@@ -303,14 +306,7 @@ var _ = Describe("ValuesProvider", func() {
 					},
 				)
 
-				configChartValues = map[string]interface{}{
-					"kubernetesVersion": "1.13.4",
-					"domainName":        "domain-name",
-					"tenantName":        "tenant-name",
-					"username":          "username",
-					"password":          "password",
-					"subnetID":          "subnet-acbd1234",
-					"lbProvider":        "load-balancer-provider",
+				configValues = utils.MergeMaps(configChartValues, map[string]interface{}{
 					"floatingNetworkID": floatingNetworkID,
 					"floatingSubnetID":  floatingSubnetID,
 					"floatingClasses": []map[string]interface{}{
@@ -334,16 +330,12 @@ var _ = Describe("ValuesProvider", func() {
 							"subnetID": subnetID,
 						},
 					},
-					"authUrl":        authURL,
-					"dhcpDomain":     dhcpDomain,
-					"requestTimeout": requestTimeout,
-					"useOctavia":     useOctavia,
-				}
+				})
 			)
 
 			values, err := vp.GetConfigChartValues(ctx, cp, clusterK8sLessThan119)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(values).To(Equal(configChartValues))
+			Expect(values).To(Equal(configValues))
 		})
 	})
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker
-->
/area usability
/kind enhancement
/priority normal
/platform openstack

**What this PR does / why we need it**:
With this PR we add the region information to the cloud-provider config. This is required to enable the OpenStack cloud controllers to detect the correct Keystone endpoint in case the OpenStack environment has multiple regions.

**Special notes for your reviewer**:
/cc @timuthy @vasu1124 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
The OpenStack cloud controllers are now correctly bootstrapping and behaving in case the underlying OpenStack environment supports multiple regions.
```
