### PR TITLE
Workaround storage class changes

### DIFF
--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -326,11 +326,11 @@ func (vp *valuesProvider) GetControlPlaneChartValues(
 	}
 	checksums[openstack.CloudProviderConfigName] = util.ComputeChecksum(cpConfigSecret.Data)
 
-	cpDiskConfnigSecret := &corev1.Secret{}
-	if err := vp.Client().Get(ctx, kutil.Key(cp.Namespace, openstack.CloudProviderDiskConfigName), cpDiskConfnigSecret); err != nil {
+	cpDiskConfigSecret := &corev1.Secret{}
+	if err := vp.Client().Get(ctx, kutil.Key(cp.Namespace, openstack.CloudProviderDiskConfigName), cpDiskConfigSecret); err != nil {
 		return nil, err
 	}
-	checksums[openstack.CloudProviderDiskConfigName] = util.ComputeChecksum(cpDiskConfnigSecret.Data)
+	checksums[openstack.CloudProviderDiskConfigName] = util.ComputeChecksum(cpDiskConfigSecret.Data)
 
 	// TODO: Remove this code in a future version again.
 	if err := vp.deleteLegacyCloudProviderConfigMaps(ctx, cp.Namespace); err != nil {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker
-->
/area quality
/kind enhancement
/priority normal
/platform openstack

**What this PR does / why we need it**:
After https://github.com/gardener/gardener-extension-provider-openstack/commit/3bf9f686ea6838aef2d87cbe1ff75f459037594b (introduced in #65) the `StorageClass`es cannot be applied for existing clusters anymore. The reason is that we had removed the `availability` parameter, however, `StorageClass`es are immutable.

This PR deletes such old existing `StorageClass`es to allow them being recreated with the correct specification. It is done as part of the `Worker` controller because the shoot's kube-apiserver might not be up and running in the `ControlPlane` reconciliation.

**Special notes for your reviewer**:
/cc @RaphaelVogel @mvladev 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
