### PR TITLE
[ci:component:github.com/gardener/terraformer:v1.1.0->v1.2.0]

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -2,7 +2,7 @@ images:
 - name: terraformer
   sourceRepository: github.com/gardener/terraformer
   repository: eu.gcr.io/gardener-project/gardener/terraformer
-  tag: "v1.1.0"
+  tag: "v1.2.0"
 
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes/cloud-provider-openstack


### PR DESCRIPTION
*Release Notes*:
``` improvement operator github.com/gardener/terraformer #41 @dkistner
The OpenStack terraform provider is now used in version v1.28.0.
```