### PR TITLE
[ci:component:github.com/gardener/machine-controller-manager:v0.30.0->v0.31.0]

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -21,7 +21,7 @@ images:
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager
-  tag: "v0.30.0"
+  tag: "v0.31.0"
 
 - name: csi-driver-cinder
   sourceRepository: github.com/kubernetes/cloud-provider-openstack


### PR DESCRIPTION
*Release Notes*:
``` improvement operator github.com/gardener/machine-controller-manager #475 @MSSedusch
Azure: Fixes regression when using a VM image resource id instead of an URN (for example an image from a shared image gallery)
```

``` improvement operator github.com/gardener/machine-controller-manager #471 @mvladev
CRDs are now generated with full OpenAPI schema.
```