### PR TITLE
Nit: Add missing CRD under example/

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Please take a look [here](https://github.com/gardener/gardener/blob/master/docs/
 
 You can run the controller locally on your machine by executing `make start`.
 
-Static code checks and tests can be executed by running `VERIFY=true make all`. We are using Go modules for Golang package dependency management and [Ginkgo](https://github.com/onsi/ginkgo)/[Gomega](https://github.com/onsi/gomega) for testing.
+Static code checks and tests can be executed by running `make verify`. We are using Go modules for Golang package dependency management and [Ginkgo](https://github.com/onsi/ginkgo)/[Gomega](https://github.com/onsi/gomega) for testing.
 
 ## Feedback and Support
 

--- a/example/20-crd-controlplane.yaml
+++ b/example/20-crd-controlplane.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: controlplanes.extensions.gardener.cloud
+spec:
+  group: extensions.gardener.cloud
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    plural: controlplanes
+    singular: controlplane
+    kind: ControlPlane
+    shortNames:
+    - cp
+  additionalPrinterColumns:
+  - name: Type
+    type: string
+    description: The control plane type.
+    JSONPath: .spec.type
+  - name: State
+    type: string
+    JSONPath: .status.lastOperation.state
+  - name: Age
+    type: date
+    JSONPath: .metadata.creationTimestamp
+  subresources:
+    status: {}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker
-->
/area open-source
/priority normal
/platform openstack

**What this PR does / why we need it**:
I started a new setup on kind and applied the CRDs under example, but `make start` complained `"no matches for kind \"ControlPlane\" in version \"extensions.gardener.cloud/v1alpha1\"`.


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
