### PR TITLE
WIP: Allow option to re-use existing Openstack Network

### DIFF
--- a/charts/internal/openstack-infra/values.yaml
+++ b/charts/internal/openstack-infra/values.yaml
@@ -7,6 +7,7 @@ openstack:
 
 create:
   router: true
+  network: true
 
 sshPublicKey: sshkey-12345
 
@@ -21,6 +22,7 @@ clusterName: test-namespace
 
 networks:
   workers: 10.250.0.0/19
+  # name: test-network
 
 outputKeys:
   routerID: router_id


### PR DESCRIPTION


**How to categorize this PR?**
/area networking 
/kind cleanup 
/kind enhancement
/priority normal
/platform openstack

**What this PR does / why we need it**:
- Adds option to re-use existing Openstack VPC when creating a shoot (https://github.com/gardener/gardener-extension-provider-openstack/issues/99)
- Follows up from https://github.com/gardener/gardener-extension-provider-openstack/pull/112 with more TF v0.12 language changes

**Which issue(s) this PR fixes**:
Fixes #99 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
Allow option to re-use existing Openstack Network when creating a shoot
```
