### PR TITLE
[ci:component:github.com/gardener/terraformer:v1.2.0->v1.3.0]

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -2,7 +2,7 @@ images:
 - name: terraformer
   sourceRepository: github.com/gardener/terraformer
   repository: eu.gcr.io/gardener-project/gardener/terraformer
-  tag: "v1.2.0"
+  tag: "v1.3.0"
 
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes/cloud-provider-openstack


### PR DESCRIPTION
*Release Notes*:
``` improvement operator github.com/gardener/terraformer #42 @ialidzhikov
`terraform-provider-aws` is now updated to `2.68.0`.
```

``` improvement operator github.com/gardener/terraformer #42 @ialidzhikov
`terraform-provider-google` and `terraform-provider-google-beta` are now updated to `3.27.0`.
```