### PR TITLE
StorageClasses now allow volume expansion

### DIFF
--- a/charts/internal/shoot-storageclasses/templates/storageclasses.yaml
+++ b/charts/internal/shoot-storageclasses/templates/storageclasses.yaml
@@ -6,6 +6,7 @@ metadata:
   name: default-class
   annotations:
     storageclass.kubernetes.io/is-default-class: "false"
+allowVolumeExpansion: true
 provisioner: cinder.csi.openstack.org
 ---
 apiVersion: {{ include "storageclassversion" . }}
@@ -14,5 +15,6 @@ metadata:
   name: default
   annotations:
     storageclass.kubernetes.io/is-default-class: "true"
+allowVolumeExpansion: true
 provisioner: cinder.csi.openstack.org
 {{- end }}

--- a/charts/internal/shoot-storageclasses/templates/storageclasses_legacy.yaml
+++ b/charts/internal/shoot-storageclasses/templates/storageclasses_legacy.yaml
@@ -6,6 +6,7 @@ metadata:
   name: default-class
   annotations:
     storageclass.kubernetes.io/is-default-class: "false"
+allowVolumeExpansion: true
 provisioner: kubernetes.io/cinder
 ---
 apiVersion: {{ include "storageclassversion" . }}
@@ -14,5 +15,6 @@ metadata:
   name: default
   annotations:
     storageclass.kubernetes.io/is-default-class: "true"
+allowVolumeExpansion: true
 provisioner: kubernetes.io/cinder
 {{- end }}


### PR DESCRIPTION
**How to categorize this PR?**

/area storage
/kind enhancement
/priority normal
/platform openstack

**What this PR does / why we need it**:

Allows claims for Cinder volumes to be resized.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

`AllowVolumeExpansion` is [not immutable](https://github.com/kubernetes/kubernetes/blob/6c6fd9c575457885dfbd07fe5df43df9a4e08a22/pkg/apis/storage/validation/validation.go#L59-L76).

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
`StorageClasses` now allow for expansion of PVCs.
```
