### PR TITLE
Populate worker-configuration in machine deployment

### DIFF
--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -198,16 +198,17 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 			)
 
 			machineDeployments = append(machineDeployments, worker.MachineDeployment{
-				Name:           deploymentName,
-				ClassName:      className,
-				SecretName:     className,
-				Minimum:        worker.DistributeOverZones(zoneIdx, pool.Minimum, zoneLen),
-				Maximum:        worker.DistributeOverZones(zoneIdx, pool.Maximum, zoneLen),
-				MaxSurge:       worker.DistributePositiveIntOrPercent(zoneIdx, pool.MaxSurge, zoneLen, pool.Maximum),
-				MaxUnavailable: worker.DistributePositiveIntOrPercent(zoneIdx, pool.MaxUnavailable, zoneLen, pool.Minimum),
-				Labels:         pool.Labels,
-				Annotations:    pool.Annotations,
-				Taints:         pool.Taints,
+				Name:                 deploymentName,
+				ClassName:            className,
+				SecretName:           className,
+				Minimum:              worker.DistributeOverZones(zoneIdx, pool.Minimum, zoneLen),
+				Maximum:              worker.DistributeOverZones(zoneIdx, pool.Maximum, zoneLen),
+				MaxSurge:             worker.DistributePositiveIntOrPercent(zoneIdx, pool.MaxSurge, zoneLen, pool.Maximum),
+				MaxUnavailable:       worker.DistributePositiveIntOrPercent(zoneIdx, pool.MaxUnavailable, zoneLen, pool.Minimum),
+				Labels:               pool.Labels,
+				Annotations:          pool.Annotations,
+				Taints:               pool.Taints,
+				MachineConfiguration: genericworkeractuator.ReadMachineConfiguration(pool),
 			})
 
 			machineClassSpec["name"] = className

--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -19,6 +19,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
+	"strings"
+	"time"
 
 	api "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack"
 	apiv1alpha1 "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack/v1alpha1"
@@ -123,6 +125,8 @@ var _ = Describe("Machines", func() {
 				zone1 string
 				zone2 string
 
+				machineConfiguration *machinev1alpha1.MachineConfiguration
+
 				workerPoolHash1 string
 				workerPoolHash2 string
 
@@ -178,6 +182,8 @@ var _ = Describe("Machines", func() {
 
 				zone1 = region + "a"
 				zone2 = region + "b"
+
+				machineConfiguration = &machinev1alpha1.MachineConfiguration{}
 
 				shootVersionMajorMinor = "1.2"
 				shootVersion = shootVersionMajorMinor + ".3"
@@ -396,40 +402,44 @@ var _ = Describe("Machines", func() {
 
 					machineDeployments = worker.MachineDeployments{
 						{
-							Name:           machineClassNamePool1Zone1,
-							ClassName:      machineClassWithHashPool1Zone1,
-							SecretName:     machineClassWithHashPool1Zone1,
-							Minimum:        worker.DistributeOverZones(0, minPool1, 2),
-							Maximum:        worker.DistributeOverZones(0, maxPool1, 2),
-							MaxSurge:       worker.DistributePositiveIntOrPercent(0, maxSurgePool1, 2, maxPool1),
-							MaxUnavailable: worker.DistributePositiveIntOrPercent(0, maxUnavailablePool1, 2, minPool1),
+							Name:                 machineClassNamePool1Zone1,
+							ClassName:            machineClassWithHashPool1Zone1,
+							SecretName:           machineClassWithHashPool1Zone1,
+							Minimum:              worker.DistributeOverZones(0, minPool1, 2),
+							Maximum:              worker.DistributeOverZones(0, maxPool1, 2),
+							MaxSurge:             worker.DistributePositiveIntOrPercent(0, maxSurgePool1, 2, maxPool1),
+							MaxUnavailable:       worker.DistributePositiveIntOrPercent(0, maxUnavailablePool1, 2, minPool1),
+							MachineConfiguration: machineConfiguration,
 						},
 						{
-							Name:           machineClassNamePool1Zone2,
-							ClassName:      machineClassWithHashPool1Zone2,
-							SecretName:     machineClassWithHashPool1Zone2,
-							Minimum:        worker.DistributeOverZones(1, minPool1, 2),
-							Maximum:        worker.DistributeOverZones(1, maxPool1, 2),
-							MaxSurge:       worker.DistributePositiveIntOrPercent(1, maxSurgePool1, 2, maxPool1),
-							MaxUnavailable: worker.DistributePositiveIntOrPercent(1, maxUnavailablePool1, 2, minPool1),
+							Name:                 machineClassNamePool1Zone2,
+							ClassName:            machineClassWithHashPool1Zone2,
+							SecretName:           machineClassWithHashPool1Zone2,
+							Minimum:              worker.DistributeOverZones(1, minPool1, 2),
+							Maximum:              worker.DistributeOverZones(1, maxPool1, 2),
+							MaxSurge:             worker.DistributePositiveIntOrPercent(1, maxSurgePool1, 2, maxPool1),
+							MaxUnavailable:       worker.DistributePositiveIntOrPercent(1, maxUnavailablePool1, 2, minPool1),
+							MachineConfiguration: machineConfiguration,
 						},
 						{
-							Name:           machineClassNamePool2Zone1,
-							ClassName:      machineClassWithHashPool2Zone1,
-							SecretName:     machineClassWithHashPool2Zone1,
-							Minimum:        worker.DistributeOverZones(0, minPool2, 2),
-							Maximum:        worker.DistributeOverZones(0, maxPool2, 2),
-							MaxSurge:       worker.DistributePositiveIntOrPercent(0, maxSurgePool2, 2, maxPool2),
-							MaxUnavailable: worker.DistributePositiveIntOrPercent(0, maxUnavailablePool2, 2, minPool2),
+							Name:                 machineClassNamePool2Zone1,
+							ClassName:            machineClassWithHashPool2Zone1,
+							SecretName:           machineClassWithHashPool2Zone1,
+							Minimum:              worker.DistributeOverZones(0, minPool2, 2),
+							Maximum:              worker.DistributeOverZones(0, maxPool2, 2),
+							MaxSurge:             worker.DistributePositiveIntOrPercent(0, maxSurgePool2, 2, maxPool2),
+							MaxUnavailable:       worker.DistributePositiveIntOrPercent(0, maxUnavailablePool2, 2, minPool2),
+							MachineConfiguration: machineConfiguration,
 						},
 						{
-							Name:           machineClassNamePool2Zone2,
-							ClassName:      machineClassWithHashPool2Zone2,
-							SecretName:     machineClassWithHashPool2Zone2,
-							Minimum:        worker.DistributeOverZones(1, minPool2, 2),
-							Maximum:        worker.DistributeOverZones(1, maxPool2, 2),
-							MaxSurge:       worker.DistributePositiveIntOrPercent(1, maxSurgePool2, 2, maxPool2),
-							MaxUnavailable: worker.DistributePositiveIntOrPercent(1, maxUnavailablePool2, 2, minPool2),
+							Name:                 machineClassNamePool2Zone2,
+							ClassName:            machineClassWithHashPool2Zone2,
+							SecretName:           machineClassWithHashPool2Zone2,
+							Minimum:              worker.DistributeOverZones(1, minPool2, 2),
+							Maximum:              worker.DistributeOverZones(1, maxPool2, 2),
+							MaxSurge:             worker.DistributePositiveIntOrPercent(1, maxSurgePool2, 2, maxPool2),
+							MaxUnavailable:       worker.DistributePositiveIntOrPercent(1, maxUnavailablePool2, 2, minPool2),
+							MachineConfiguration: machineConfiguration,
 						},
 					}
 				}
@@ -593,6 +603,36 @@ var _ = Describe("Machines", func() {
 				result, err := workerDelegate.GenerateMachineDeployments(context.TODO())
 				Expect(err).To(HaveOccurred())
 				Expect(result).To(BeNil())
+			})
+
+			It("should set expected machineControllerManager settings on machine deployment", func() {
+				expectGetSecretCallToWork(c, openstackDomainName, openstackTenantName, openstackUserName, openstackPassword)
+
+				testDrainTimeout := metav1.Duration{Duration: 10 * time.Minute}
+				testHealthTimeout := metav1.Duration{Duration: 20 * time.Minute}
+				testCreationTimeout := metav1.Duration{Duration: 30 * time.Minute}
+				testMaxEvictRetries := int32(30)
+				testNodeConditions := []string{"ReadonlyFilesystem", "KernelDeadlock", "DiskPressure"}
+				w.Spec.Pools[0].MachineControllerManagerSettings = &gardencorev1beta1.MachineControllerManagerSettings{
+					MachineDrainTimeout:    &testDrainTimeout,
+					MachineCreationTimeout: &testCreationTimeout,
+					MachineHealthTimeout:   &testHealthTimeout,
+					MaxEvictRetries:        &testMaxEvictRetries,
+					NodeConditions:         testNodeConditions,
+				}
+
+				workerDelegate, _ = NewWorkerDelegate(common.NewClientContext(c, scheme, decoder), chartApplier, "", w, cluster)
+
+				result, err := workerDelegate.GenerateMachineDeployments(context.TODO())
+				resultSettings := result[0].MachineConfiguration
+				resultNodeConditions := strings.Join(testNodeConditions, ",")
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resultSettings.MachineDrainTimeout).To(Equal(&testDrainTimeout))
+				Expect(resultSettings.MachineCreationTimeout).To(Equal(&testCreationTimeout))
+				Expect(resultSettings.MachineHealthTimeout).To(Equal(&testHealthTimeout))
+				Expect(resultSettings.MaxEvictRetries).To(Equal(&testMaxEvictRetries))
+				Expect(resultSettings.NodeConditions).To(Equal(&resultNodeConditions))
 			})
 		})
 	})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement
/priority normal
/platform openstack

**What this PR does / why we need it**:  This PR populates the controller-configurations on the machine-deployment from worker-object. 

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener-extension-provider-aws/issues/148

**Special notes for your reviewer**:
The following dependencies need to be resolved.
- [x] Vendor the MCM 0.33.0
- [x] https://github.com/gardener/gardener/pull/2563 should be merged.
- [x]  g/g with the #2563 change should be vendored. 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Worker extension allows configuring following parameters on machine-deployment: drainTimeout, creationTimeout, healthTimeout, maxEvictRetries, nodeConditions.
```
