### PR TITLE
Recreate storage classes if update is failing

### DIFF
--- a/charts/internal/shoot-storageclasses/templates/storageclasses.yaml
+++ b/charts/internal/shoot-storageclasses/templates/storageclasses.yaml
@@ -6,6 +6,7 @@ metadata:
   name: default-class
   annotations:
     storageclass.kubernetes.io/is-default-class: "false"
+    resources.gardener.cloud/delete-on-invalid-update: "true"
 allowVolumeExpansion: true
 provisioner: cinder.csi.openstack.org
 ---
@@ -15,6 +16,7 @@ metadata:
   name: default
   annotations:
     storageclass.kubernetes.io/is-default-class: "true"
+    resources.gardener.cloud/delete-on-invalid-update: "true"
 allowVolumeExpansion: true
 provisioner: cinder.csi.openstack.org
 {{- end }}

--- a/charts/internal/shoot-storageclasses/templates/storageclasses_legacy.yaml
+++ b/charts/internal/shoot-storageclasses/templates/storageclasses_legacy.yaml
@@ -6,6 +6,7 @@ metadata:
   name: default-class
   annotations:
     storageclass.kubernetes.io/is-default-class: "false"
+    resources.gardener.cloud/delete-on-invalid-update: "true"
 allowVolumeExpansion: true
 provisioner: kubernetes.io/cinder
 ---
@@ -15,6 +16,7 @@ metadata:
   name: default
   annotations:
     storageclass.kubernetes.io/is-default-class: "true"
+    resources.gardener.cloud/delete-on-invalid-update: "true"
 allowVolumeExpansion: true
 provisioner: kubernetes.io/cinder
 {{- end }}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity robustness storage
/kind enhancement
/priority normal
/topology shoot
/platform openstack

**What this PR does / why we need it**:
Recreate storage classes if update if failing

**Which issue(s) this PR fixes**:
Ref https://github.com/gardener/gardener-resource-manager/pull/69

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The `StorageClass`es  in the shoot cluster managed by Gardener are now re-created in case the update request failed due to changed immutable fields.
```
