### PR TITLE
Support for Kubernetes 1.19

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This extension controller supports the following Kubernetes versions:
 
 | Version         | Support     | Conformance test results |
 | --------------- | ----------- | ------------------------ |
+| Kubernetes 1.19 | 1.19.0+     | N/A |
 | Kubernetes 1.18 | 1.18.0+     | [![Gardener v1.18 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.18%20OpenStack/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.18%20OpenStack) |
 | Kubernetes 1.17 | 1.17.0+     | [![Gardener v1.17 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.17%20OpenStack/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.17%20OpenStack) |
 | Kubernetes 1.16 | 1.16.0+     | [![Gardener v1.16 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.16%20OpenStack/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.16%20OpenStack) |

--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -30,11 +30,11 @@ images:
 - name: csi-provisioner
   sourceRepository: github.com/kubernetes-csi/external-provisioner
   repository: quay.io/k8scsi/csi-provisioner
-  tag: "v1.6.0"
+  tag: "v2.0.0"
 - name: csi-attacher
   sourceRepository: github.com/kubernetes-csi/external-attacher
   repository: quay.io/k8scsi/csi-attacher
-  tag: "v2.2.0"
+  tag: "v3.0.0"
 - name: csi-snapshotter
   sourceRepository: github.com/kubernetes-csi/external-snapshotter
   repository: quay.io/k8scsi/csi-snapshotter
@@ -50,8 +50,8 @@ images:
 - name: csi-node-driver-registrar
   sourceRepository: github.com/kubernetes-csi/node-driver-registrar
   repository: quay.io/k8scsi/csi-node-driver-registrar
-  tag: "v1.3.0"
+  tag: "v2.0.0"
 - name: csi-liveness-probe
   sourceRepository: github.com/kubernetes-csi/livenessprobe
   repository: quay.io/k8scsi/livenessprobe
-  tag: "v2.0.0"
+  tag: "v2.1.0"

--- a/charts/internal/cloud-provider-config/templates/cloud-provider-disk-config.yaml
+++ b/charts/internal/cloud-provider-config/templates/cloud-provider-disk-config.yaml
@@ -2,6 +2,10 @@
 [Global]
 {{ include "cloud-provider-config-credentials" . }}
 {{ include "cloud-provider-config-meta" . }}
+{{- if semverCompare ">= 1.19-0" .Values.kubernetesVersion }}
+[BlockStorage]
+rescan-on-resize={{ .Values.rescanBlockStorageOnResize }}
+{{- end }}
 {{- end -}}
 ---
 apiVersion: v1

--- a/charts/internal/cloud-provider-config/values.yaml
+++ b/charts/internal/cloud-provider-config/values.yaml
@@ -14,6 +14,7 @@ lbProvider: foobar
 dhcpDomain: foobar
 requestTimeout: 2s
 useOctavia: false
+rescanBlockStorageOnResize: false
 # floatingClasses:
 # - name: A
 #   floatingNetworkID: "1234"

--- a/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/deployment-csi-driver-controller.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/deployment-csi-driver-controller.yaml
@@ -85,8 +85,7 @@ spec:
         - --kubeconfig=/var/lib/csi-provisioner/kubeconfig
         - --feature-gates=Topology=true
         - --volume-name-prefix=pv-{{ .Release.Namespace }}
-        - --enable-leader-election
-        - --leader-election-type=leases
+        - --leader-election
         - --leader-election-namespace=kube-system
         - --v=5
         env:

--- a/charts/internal/shoot-system-components/charts/csi-driver-node/templates/clusterrole-csi-attacher.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/templates/clusterrole-csi-attacher.yaml
@@ -19,3 +19,6 @@ rules:
 - apiGroups: [""]
   resources: ["events"]
   verbs: ["create", "patch", "update"]
+- apiGroups: ["storage.k8s.io"]
+  resources: ["volumeattachments/status"]
+  verbs: ["patch"]

--- a/charts/internal/shoot-system-components/charts/csi-driver-node/templates/clusterrole-csi-provisioner.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/templates/clusterrole-csi-provisioner.yaml
@@ -28,3 +28,6 @@ rules:
 - apiGroups: [""]
   resources: ["nodes"]
   verbs: ["get", "list", "watch"]
+- apiGroups: ["storage.k8s.io"]
+  resources: ["volumeattachments"]
+  verbs: ["get", "list", "watch"]

--- a/docs/usage-as-operator.md
+++ b/docs/usage-as-operator.md
@@ -19,6 +19,9 @@ This may help when you have for example a long list of load balancers in your en
 
 In case your OpenStack system uses [Octavia](https://docs.openstack.org/octavia/latest/) for network load balancing then you have to set the `useOctavia` field to `true` such that the cloud-controller-manager for OpenStack gets correctly configured (it defaults to `false`).
 
+Some hypervisors (especially those which are VMware-based) don't automatically send a new volume size to a Linux kernel when a volume is resized and in-use.
+For those hypervisors you can enable the storage plugin interacting with Cinder to telling the SCSI block device to refresh its information to provide information about it's updated size to the kernel. You might need to enable this behavior depending on the underlying hypervisor of your OpenStack installation. The `rescanBlockStorageOnResize` field controls this. Please note that it only applies for Kubernetes versions where CSI is used.
+
 The cloud profile config also contains constraints for floating pools and load balancer providers that can be used in shoots.
 
 An example `CloudProfileConfig` for the OpenStack extension looks as follows:
@@ -42,6 +45,7 @@ machineImages:
 # - 10.10.10.12
 # requestTimeout: 60s
 # useOctavia: true
+# rescanBlockStorageOnResize: true
 constraints:
   floatingPools:
   - name: fp-pool-1
@@ -83,7 +87,7 @@ constraints:
 ```
 
 Please note that it is possible to configure a region mapping for keystone URLs, floating pools, and load balancer providers.
-Additionally, floating pools can be constrainted to a keystone domain by specifying the `domain` field. 
+Additionally, floating pools can be constrainted to a keystone domain by specifying the `domain` field.
 Floating pool names may also contains simple wildcard expressions, like `*` or `fp-pool-*` or `*-fp-pool`. Please note that the `*` must be either single or at the beginning or at the end. Consequently, `fp-*-pool` is not possible/allowed.
 The default behavior is that, if found, the regional (and/or domain restricted) entry is taken.
 If no entry for the given region exists then the fallback value is the most matching entry (w.r.t. wildcard matching) in the list without a `region` field (or the `keystoneURL` value for the keystone URLs).

--- a/hack/api-reference/api.md
+++ b/hack/api-reference/api.md
@@ -141,6 +141,19 @@ string
 </tr>
 <tr>
 <td>
+<code>rescanBlockStorageOnResize</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>RescanBlockStorageOnResize specifies whether the storage plugin scans and checks new block device size before it resizes
+the filesystem.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>useOctavia</code></br>
 <em>
 bool

--- a/pkg/apis/openstack/types_cloudprofile.go
+++ b/pkg/apis/openstack/types_cloudprofile.go
@@ -42,6 +42,9 @@ type CloudProfileConfig struct {
 	MachineImages []MachineImages
 	// RequestTimeout specifies the HTTP timeout against the OpenStack API.
 	RequestTimeout *string
+	// RescanBlockStorageOnResize specifies whether the storage plugin scans and checks new block device size before it resizes
+	// the filesystem.
+	RescanBlockStorageOnResize *bool
 	// UseOctavia specifies whether the OpenStack Octavia network load balancing is used.
 	UseOctavia *bool
 }

--- a/pkg/apis/openstack/v1alpha1/types_cloudprofile.go
+++ b/pkg/apis/openstack/v1alpha1/types_cloudprofile.go
@@ -46,6 +46,10 @@ type CloudProfileConfig struct {
 	// RequestTimeout specifies the HTTP timeout against the OpenStack API.
 	// +optional
 	RequestTimeout *string `json:"requestTimeout,omitempty"`
+	// RescanBlockStorageOnResize specifies whether the storage plugin scans and checks new block device size before it resizes
+	// the filesystem.
+	// +optional
+	RescanBlockStorageOnResize *bool `json:"rescanBlockStorageOnResize,omitempty"`
 	// UseOctavia specifies whether the OpenStack Octavia network load balancing is used.
 	// +optional
 	UseOctavia *bool `json:"useOctavia,omitempty"`

--- a/pkg/apis/openstack/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/openstack/v1alpha1/zz_generated.conversion.go
@@ -298,6 +298,7 @@ func autoConvert_v1alpha1_CloudProfileConfig_To_openstack_CloudProfileConfig(in 
 	out.KeyStoneURLs = *(*[]openstack.KeyStoneURL)(unsafe.Pointer(&in.KeyStoneURLs))
 	out.MachineImages = *(*[]openstack.MachineImages)(unsafe.Pointer(&in.MachineImages))
 	out.RequestTimeout = (*string)(unsafe.Pointer(in.RequestTimeout))
+	out.RescanBlockStorageOnResize = (*bool)(unsafe.Pointer(in.RescanBlockStorageOnResize))
 	out.UseOctavia = (*bool)(unsafe.Pointer(in.UseOctavia))
 	return nil
 }
@@ -317,6 +318,7 @@ func autoConvert_openstack_CloudProfileConfig_To_v1alpha1_CloudProfileConfig(in 
 	out.KeyStoneURLs = *(*[]KeyStoneURL)(unsafe.Pointer(&in.KeyStoneURLs))
 	out.MachineImages = *(*[]MachineImages)(unsafe.Pointer(&in.MachineImages))
 	out.RequestTimeout = (*string)(unsafe.Pointer(in.RequestTimeout))
+	out.RescanBlockStorageOnResize = (*bool)(unsafe.Pointer(in.RescanBlockStorageOnResize))
 	out.UseOctavia = (*bool)(unsafe.Pointer(in.UseOctavia))
 	return nil
 }

--- a/pkg/apis/openstack/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/openstack/v1alpha1/zz_generated.deepcopy.go
@@ -79,6 +79,11 @@ func (in *CloudProfileConfig) DeepCopyInto(out *CloudProfileConfig) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.RescanBlockStorageOnResize != nil {
+		in, out := &in.RescanBlockStorageOnResize, &out.RescanBlockStorageOnResize
+		*out = new(bool)
+		**out = **in
+	}
 	if in.UseOctavia != nil {
 		in, out := &in.UseOctavia, &out.UseOctavia
 		*out = new(bool)

--- a/pkg/apis/openstack/zz_generated.deepcopy.go
+++ b/pkg/apis/openstack/zz_generated.deepcopy.go
@@ -79,6 +79,11 @@ func (in *CloudProfileConfig) DeepCopyInto(out *CloudProfileConfig) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.RescanBlockStorageOnResize != nil {
+		in, out := &in.RescanBlockStorageOnResize, &out.RescanBlockStorageOnResize
+		*out = new(bool)
+		**out = **in
+	}
 	if in.UseOctavia != nil {
 		in, out := &in.UseOctavia, &out.UseOctavia
 		*out = new(bool)

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -407,19 +407,20 @@ func getConfigChartValues(
 	}
 
 	values := map[string]interface{}{
-		"kubernetesVersion": cluster.Shoot.Spec.Kubernetes.Version,
-		"domainName":        c.DomainName,
-		"tenantName":        c.TenantName,
-		"username":          c.Username,
-		"password":          c.Password,
-		"region":            cp.Spec.Region,
-		"lbProvider":        cpConfig.LoadBalancerProvider,
-		"floatingNetworkID": infraStatus.Networks.FloatingPool.ID,
-		"subnetID":          subnet.ID,
-		"authUrl":           keyStoneURL,
-		"dhcpDomain":        cloudProfileConfig.DHCPDomain,
-		"requestTimeout":    cloudProfileConfig.RequestTimeout,
-		"useOctavia":        cloudProfileConfig.UseOctavia != nil && *cloudProfileConfig.UseOctavia,
+		"kubernetesVersion":          cluster.Shoot.Spec.Kubernetes.Version,
+		"domainName":                 c.DomainName,
+		"tenantName":                 c.TenantName,
+		"username":                   c.Username,
+		"password":                   c.Password,
+		"region":                     cp.Spec.Region,
+		"lbProvider":                 cpConfig.LoadBalancerProvider,
+		"floatingNetworkID":          infraStatus.Networks.FloatingPool.ID,
+		"subnetID":                   subnet.ID,
+		"authUrl":                    keyStoneURL,
+		"dhcpDomain":                 cloudProfileConfig.DHCPDomain,
+		"requestTimeout":             cloudProfileConfig.RequestTimeout,
+		"useOctavia":                 cloudProfileConfig.UseOctavia != nil && *cloudProfileConfig.UseOctavia,
+		"rescanBlockStorageOnResize": cloudProfileConfig.RescanBlockStorageOnResize != nil && *cloudProfileConfig.RescanBlockStorageOnResize,
 	}
 
 	if cpConfig.LoadBalancerClasses == nil {

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -114,14 +114,16 @@ var _ = Describe("ValuesProvider", func() {
 
 		cp = defaultControlPlane()
 
-		cidr       = "10.250.0.0/19"
-		useOctavia = true
+		cidr                       = "10.250.0.0/19"
+		useOctavia                 = true
+		rescanBlockStorageOnResize = true
 
 		cloudProfileConfig = &api.CloudProfileConfig{
-			KeyStoneURL:    authURL,
-			DHCPDomain:     dhcpDomain,
-			RequestTimeout: requestTimeout,
-			UseOctavia:     pointer.BoolPtr(useOctavia),
+			KeyStoneURL:                authURL,
+			DHCPDomain:                 dhcpDomain,
+			RequestTimeout:             requestTimeout,
+			UseOctavia:                 pointer.BoolPtr(useOctavia),
+			RescanBlockStorageOnResize: pointer.BoolPtr(rescanBlockStorageOnResize),
 		}
 		cloudProfileConfigJSON, _ = json.Marshal(cloudProfileConfig)
 
@@ -243,19 +245,20 @@ var _ = Describe("ValuesProvider", func() {
 
 	Describe("#GetConfigChartValues", func() {
 		configChartValues := map[string]interface{}{
-			"kubernetesVersion": "1.13.4",
-			"domainName":        "domain-name",
-			"tenantName":        "tenant-name",
-			"username":          "username",
-			"password":          "password",
-			"region":            region,
-			"subnetID":          "subnet-acbd1234",
-			"lbProvider":        "load-balancer-provider",
-			"floatingNetworkID": "floating-network-id",
-			"authUrl":           authURL,
-			"dhcpDomain":        dhcpDomain,
-			"requestTimeout":    requestTimeout,
-			"useOctavia":        useOctavia,
+			"kubernetesVersion":          "1.13.4",
+			"domainName":                 "domain-name",
+			"tenantName":                 "tenant-name",
+			"username":                   "username",
+			"password":                   "password",
+			"region":                     region,
+			"subnetID":                   "subnet-acbd1234",
+			"lbProvider":                 "load-balancer-provider",
+			"floatingNetworkID":          "floating-network-id",
+			"authUrl":                    authURL,
+			"dhcpDomain":                 dhcpDomain,
+			"requestTimeout":             requestTimeout,
+			"useOctavia":                 useOctavia,
+			"rescanBlockStorageOnResize": rescanBlockStorageOnResize,
 		}
 
 		It("should return correct config chart values", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source usability
/kind enhancement
/priority normal
/platform aws

**What this PR does / why we need it**:
This PR adds support for 1.19 to the extension.
CSI will be used for 1.19 shoots. Older shoots will keep using the in-tree legacy volume provisioners.

**Which issue(s) this PR fixes**:
Part of gardener/gardener#2629

**Special notes for your reviewer**:
* I have successfully validated the functionality as follows:
  * :white_check_mark: Create new clusters with versions < 1.19
  * :white_check_mark: Create new clusters with version  = 1.19
  * :white_check_mark: Upgrade old clusters from version 1.18 to version 1.19
  * :white_check_mark: Delete clusters with versions < 1.19
  * :white_check_mark: Delete clusters with version  = 1.19

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy user
The OpenStack extension does now support shoot clusters with Kubernetes version 1.19. You should consider the [Kubernetes release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.19.md) before upgrading to 1.19. Please note that the OpenStack Cinder CSI driver will be used for 1.19 shoots. It is compatible with the legacy volume provisioners, however, you might want to update your storage classes and volume handling accordingly. Please find more information about CSI in the official Kubernetes documentation.
```
