### PR TITLE
Change volumeBindingMode to WaitForFirstConsumer

### DIFF
--- a/charts/internal/shoot-storageclasses/templates/storageclasses_legacy.yaml
+++ b/charts/internal/shoot-storageclasses/templates/storageclasses_legacy.yaml
@@ -9,6 +9,11 @@ metadata:
     resources.gardener.cloud/delete-on-invalid-update: "true"
 allowVolumeExpansion: true
 provisioner: kubernetes.io/cinder
+{{- if semverCompare ">= 1.12-0" .Capabilities.KubeVersion.GitVersion }}
+volumeBindingMode: WaitForFirstConsumer
+{{- else }}
+volumeBindingMode: Immediate
+{{- end }}
 ---
 apiVersion: {{ include "storageclassversion" . }}
 kind: StorageClass
@@ -19,4 +24,9 @@ metadata:
     resources.gardener.cloud/delete-on-invalid-update: "true"
 allowVolumeExpansion: true
 provisioner: kubernetes.io/cinder
+{{- if semverCompare ">= 1.12-0" .Capabilities.KubeVersion.GitVersion }}
+volumeBindingMode: WaitForFirstConsumer
+{{- else }}
+volumeBindingMode: Immediate
+{{- end }}
 {{- end }}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area storage
/kind task
/priority normal
/platform openstack

**What this PR does / why we need it**:
Change volumeBindingMode to WaitForFirstConsumer.

**Which issue(s) this PR fixes**:
Fixes #139 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The `volumeBindingMode` of the StorageClasses managed by Gardener is now switched to `WaitForFirstConsumer`.
```
