### PR TITLE
Use WaitForFirstConsumer also for CSI StorageClasses

### DIFF
--- a/charts/internal/shoot-storageclasses/templates/storageclasses.yaml
+++ b/charts/internal/shoot-storageclasses/templates/storageclasses.yaml
@@ -9,6 +9,7 @@ metadata:
     resources.gardener.cloud/delete-on-invalid-update: "true"
 allowVolumeExpansion: true
 provisioner: cinder.csi.openstack.org
+volumeBindingMode: WaitForFirstConsumer
 ---
 apiVersion: {{ include "storageclassversion" . }}
 kind: StorageClass
@@ -19,4 +20,5 @@ metadata:
     resources.gardener.cloud/delete-on-invalid-update: "true"
 allowVolumeExpansion: true
 provisioner: cinder.csi.openstack.org
+volumeBindingMode: WaitForFirstConsumer
 {{- end }}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area storage
/kind task
/priority normal
/platform openstack

**What this PR does / why we need it**:
I was assuming that all CSI StorageClasses are configured with .volumeBindingMode=WaitForFirstConsumer but that is not the case for the cinder ones.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener-extension-provider-openstack/pull/137/files


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
The CSI StorageClasses (with provisioner `cinder.csi.openstack.org`) do now also specify `WaitForFirstConsumer` for volumeBindingMode.
```
