### PR TITLE
Webhook ensurer does not remove or add /etc/ssl directory for kube apiserver deployments

### DIFF
--- a/pkg/webhook/controlplane/ensurer_test.go
+++ b/pkg/webhook/controlplane/ensurer_test.go
@@ -500,11 +500,7 @@ func checkKubeAPIServerDeployment(dep *appsv1.Deployment, annotations map[string
 		Expect(c.Command).To(test.ContainElementWithPrefixContaining("--enable-admission-plugins=", "PersistentVolumeLabel", ","))
 		Expect(c.Command).To(Not(test.ContainElementWithPrefixContaining("--disable-admission-plugins=", "PersistentVolumeLabel", ",")))
 		Expect(c.VolumeMounts).To(ContainElement(cloudProviderDiskConfigVolumeMount))
-		Expect(c.VolumeMounts).To(ContainElement(etcSSLVolumeMount))
-		Expect(c.VolumeMounts).To(ContainElement(usrShareCACertificatesVolumeMount))
 		Expect(dep.Spec.Template.Spec.Volumes).To(ContainElement(cloudProviderDiskConfigVolume))
-		Expect(dep.Spec.Template.Spec.Volumes).To(ContainElement(etcSSLVolume))
-		Expect(dep.Spec.Template.Spec.Volumes).To(ContainElement(usrShareCACertificatesVolume))
 		Expect(dep.Spec.Template.Annotations).To(Equal(annotations))
 		if k8sVersionAtLeast119 {
 			Expect(c.Command).To(ContainElement("--feature-gates=CSIMigration=true,CSIMigrationOpenStack=true"))
@@ -516,11 +512,7 @@ func checkKubeAPIServerDeployment(dep *appsv1.Deployment, annotations map[string
 		Expect(c.Command).NotTo(test.ContainElementWithPrefixContaining("--enable-admission-plugins=", "PersistentVolumeLabel", ","))
 		Expect(c.Command).To(test.ContainElementWithPrefixContaining("--disable-admission-plugins=", "PersistentVolumeLabel", ","))
 		Expect(c.VolumeMounts).NotTo(ContainElement(cloudProviderDiskConfigVolumeMount))
-		Expect(c.VolumeMounts).NotTo(ContainElement(etcSSLVolumeMount))
-		Expect(c.VolumeMounts).NotTo(ContainElement(usrShareCACertificatesVolumeMount))
 		Expect(dep.Spec.Template.Spec.Volumes).NotTo(ContainElement(cloudProviderDiskConfigVolume))
-		Expect(dep.Spec.Template.Spec.Volumes).NotTo(ContainElement(etcSSLVolume))
-		Expect(dep.Spec.Template.Spec.Volumes).NotTo(ContainElement(usrShareCACertificatesVolume))
 		Expect(dep.Spec.Template.Annotations).To(BeNil())
 	}
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement
/priority normal
/platform openstack

**What this PR does / why we need it**:
The provider extension webhook does no longer touch the `/etc/ssl/` directories on the host. 
 Mounting `/etc/ssl/` is always required for the Kube API Server for making OIDC or webhook requests.
 Gardener now always includes the aforementioned mount with [this PR](https://github.com/gardener/gardener/pull/2791).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The Webhook ensurer does not remove or add the /etc/ssl directory for kube apiserver deployments any more.  This is done by the Gardenlet for version >= 1.10.0.
```
