### PR TITLE
Fix volume fsType handling for CSI volumes

### DIFF
--- a/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/deployment-csi-driver-controller.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/deployment-csi-driver-controller.yaml
@@ -85,6 +85,7 @@ spec:
         - --kubeconfig=/var/lib/csi-provisioner/kubeconfig
         - --feature-gates=Topology=true
         - --volume-name-prefix=pv-{{ .Release.Namespace }}
+        - --default-fstype=ext4
         - --leader-election
         - --leader-election-namespace=kube-system
         - --v=5


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area storage
/kind bug
/priority normal
/platform openstack

**What this PR does / why we need it**:
Currently for v1.19 the guestbook test is failing with:

```
$ k -n gardener-e2e-v2xt6 get po
NAME             READY   STATUS             RESTARTS   AGE
redis-master-0   0/1     CrashLoopBackOff   5          4m13s

$ k -n gardener-e2e-v2xt6 logs redis-master-0
 06:57:52.24 INFO  ==> ** Starting Redis **
1:C 11 Sep 2020 06:57:52.256 # oO0OoO0OoO0Oo Redis is starting oO0OoO0OoO0Oo
1:C 11 Sep 2020 06:57:52.256 # Redis version=5.0.7, bits=64, commit=00000000, modified=0, pid=1, just started
1:C 11 Sep 2020 06:57:52.256 # Configuration loaded
1:M 11 Sep 2020 06:57:52.257 # Can't open the append-only file: Permission denied
```

Investigation shows that the fsType is no longer present in the PV spec for v1.19:

Before the fix for PV with k/k v1.19.

```yaml
   csi:
      driver: cinder.csi.openstack.org
      volumeAttributes:
        storage.kubernetes.io/csiProvisionerIdentity: 1599816861990-1847-cinder.csi.openstack.org
      volumeHandle: 41dc69a8-c853-4b19-b9bd-fb234d6ad618
```

After the fix:

```yaml
   csi:
      driver: cinder.csi.openstack.org
      fsType: ext4
      volumeAttributes:
        storage.kubernetes.io/csiProvisionerIdentity: 1599816861990-1847-cinder.csi.openstack.org
      volumeHandle: 41dc69a8-c853-4b19-b9bd-fb234d6ad618
```

Basically this afterwards is causing the fsGroup field to be not respected when the volume is mounted to the Pod.

For Pod with configured:
```yaml
  securityContext:
    fsGroup: 1001
```

Current:

```
$ cd /data
$ ls -la
total 24
drwxr-xr-x. 3 root root  4096 Sep 11 06:54 .
drwxr-xr-x  1 root root  4096 Sep 11 08:36 ..
drwx------. 2 root root 16384 Sep 11 06:54 lost+found
```

Expected:

```
$ cd /data
$ ls -la
total 28
drwxrwsr-x. 3 root 1001  4096 Sep 11 09:09 .
drwxr-xr-x. 1 root root  4096 Sep 11 09:05 ..
-rw-r--r--. 1 1001 1001     0 Sep 11 09:05 appendonly.aof
drwxrws---. 2 root 1001 16384 Sep 11 09:05 lost+found
-rw-r--r--. 1 1001 1001     0 Sep 11 09:09 test.txt
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Ref https://github.com/kubernetes-csi/external-provisioner/pull/400

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
An issue causing CSI PV to do not have set `spec.csi.fsType` is now fixed. The csi-provisioner is now started with `--default-fstype=ext4` which is the default fstype to be used when there is no fstype specified in the StorageClass.
```
