### PR TITLE
Use separate Secret for csi-driver-controller

### DIFF
--- a/charts/internal/cloud-provider-config/templates/cloud-provider-disk-config-csi.yaml
+++ b/charts/internal/cloud-provider-config/templates/cloud-provider-disk-config-csi.yaml
@@ -1,0 +1,19 @@
+{{- define "cloud-provider-disk-config-csi" -}}
+[Global]
+{{ include "cloud-provider-config-credentials" . }}
+{{ include "cloud-provider-config-meta" . }}
+
+[BlockStorage]
+rescan-on-resize={{ .Values.rescanBlockStorageOnResize }}
+{{- end -}}
+{{- if semverCompare ">= 1.19-0" .Values.kubernetesVersion }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cloud-provider-disk-config-csi
+  namespace: {{ .Release.Namespace }}
+type: Opaque
+data:
+  cloudprovider.conf: {{ include "cloud-provider-disk-config-csi" . | b64enc }}
+{{- end }}

--- a/charts/internal/cloud-provider-config/templates/cloud-provider-disk-config.yaml
+++ b/charts/internal/cloud-provider-config/templates/cloud-provider-disk-config.yaml
@@ -2,10 +2,6 @@
 [Global]
 {{ include "cloud-provider-config-credentials" . }}
 {{ include "cloud-provider-config-meta" . }}
-{{- if semverCompare ">= 1.19-0" .Values.kubernetesVersion }}
-[BlockStorage]
-rescan-on-resize={{ .Values.rescanBlockStorageOnResize }}
-{{- end }}
 {{- end -}}
 ---
 apiVersion: v1

--- a/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/deployment-csi-driver-controller.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/deployment-csi-driver-controller.yaml
@@ -200,7 +200,7 @@ spec:
           path: /usr/share/ca-certificates
       - name: cloud-provider-config
         secret:
-          secretName: cloud-provider-disk-config
+          secretName: cloud-provider-disk-config-csi
       # Host certificates are mounted to accommodate OpenStack endpoints that might be served with a certificate
       # signed by a CA that is not globally trusted.
       - name: etc-ssl

--- a/pkg/openstack/types.go
+++ b/pkg/openstack/types.go
@@ -58,11 +58,13 @@ const (
 	// Region is a constant for the key in a backup secret that holds the Openstack region.
 	Region = "region"
 
-	// CloudProviderConfigName is the name of the configmap containing the cloud provider config.
+	// CloudProviderConfigName is the name of the secret containing the cloud provider config.
 	CloudProviderConfigName = "cloud-provider-config"
-	// CloudProviderDiskConfigName is the name of the configmap containing the cloud provider config for disk/volume handling.
+	// CloudProviderDiskConfigName is the name of the secret containing the cloud provider config for disk/volume handling. It is used by kube-controller-manager.
 	CloudProviderDiskConfigName = "cloud-provider-disk-config"
-	// CloudProviderConfigDataKey is the key storing the cloud provider config as value in the cloud provider configmap.
+	// CloudProviderCSIDiskConfigName is the name of the secret containing the cloud provider config for disk/volume handling. It is used by csi-driver-controller.
+	CloudProviderCSIDiskConfigName = "cloud-provider-disk-config-csi"
+	// CloudProviderConfigDataKey is the key storing the cloud provider config as value in the cloud provider secret.
 	CloudProviderConfigDataKey = "cloudprovider.conf"
 	// CloudControllerManagerName is a constant for the name of the CloudController deployed by the worker controller.
 	CloudControllerManagerName = "cloud-controller-manager"

--- a/pkg/webhook/controlplane/ensurer.go
+++ b/pkg/webhook/controlplane/ensurer.go
@@ -395,7 +395,7 @@ func (e *ensurer) EnsureKubeletCloudProviderConfig(ctx context.Context, ectx gen
 	secret := corev1.Secret{}
 	if err := e.client.Get(ctx, kutil.Key(namespace, openstack.CloudProviderDiskConfigName), &secret); err != nil {
 		if apierrors.IsNotFound(err) {
-			e.logger.Info("configmap not found", "name", openstack.CloudProviderDiskConfigName, "namespace", namespace)
+			e.logger.Info("secret not found", "name", openstack.CloudProviderDiskConfigName, "namespace", namespace)
 			return nil
 		}
 		return errors.Wrapf(err, "could not get secret '%s/%s'", namespace, openstack.CloudProviderDiskConfigName)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area storage
/kind bug
/priority normal
/platform openstack

**What this PR does / why we need it**:
Currently the csi-driver-controller and kube-controller-manager are mounting the Secret `cloud-provider-disk-config`. 
Recently this Secret was updated with CSI specific configuration (`[BlockStorage]`). This configuration is unknown to kube-controller-manager and it panics with:

```
F0913 10:57:56.155544       1 controllermanager.go:244] error building controller context: cloud provider could not be initialized: could not init cloud provider "openstack": warning:
can't store data at section "BlockStorage", variable "rescan-on-resize"
```

This PR reverts the kube-controller-manager Secret and creates a new Secret that is used by the csi-driver-controller.

**Which issue(s) this PR fixes**:
Fixes #144

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
An issue causing kube-controller-manager to panic when upgrading an OpenStack cluster from `v1.18` to `v1.19` is now fixed.
``` 
