### PR TITLE
Ensure that shoot kube-apiserver has no incompatible mount of usr/share/ca-certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,14 @@ Please take a look [here](https://github.com/gardener/gardener/blob/master/docs/
 
 ----
 
+## Compatibility 
+
+The following lists known compatibility issues of this extension controller with other Gardener components.
+
+| OpenStack Extension | Gardener | Action | Notes |
+| ----- | ----- | --- |  --------------- |
+| `< v1.12.0` | `> v1.10.0` |  Please update the provider version to `>= v1.12.0` or disable the feature gate `MountHostCADirectories` in the Gardenlet. | Applies if feature flag `MountHostCADirectories` in the Gardenlet is enabled. This is to prevent duplicate volume mounts to `/usr/share/ca-certificates` in the Shoot API Server. |
+
 ## How to start using or developing this extension controller locally
 
 You can run the controller locally on your machine by executing `make start`.

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1,0 +1,5 @@
+## Compatibility 
+
+| Openstack Extension | Gardener | Notes |
+| --- | ----------- | --- |
+| `>= v1.12.0` | `>v1.10.0` | Applies if feature flag `MountHostCADirectories` in the Gardenlet is enabled. This is to prevent duplicate volume mounts to `/usr/share/ca-certificates` in the Shoot API Server.  |

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1,5 +1,0 @@
-## Compatibility 
-
-| Openstack Extension | Gardener | Notes |
-| --- | ----------- | --- |
-| `>= v1.12.0` | `>v1.10.0` | Applies if feature flag `MountHostCADirectories` in the Gardenlet is enabled. This is to prevent duplicate volume mounts to `/usr/share/ca-certificates` in the Shoot API Server.  |

--- a/pkg/webhook/controlplane/ensurer.go
+++ b/pkg/webhook/controlplane/ensurer.go
@@ -261,6 +261,12 @@ func ensureKubeAPIServerVolumeMounts(c *corev1.Container, csiEnabled, csiMigrati
 	}
 
 	c.VolumeMounts = extensionswebhook.EnsureVolumeMountWithName(c.VolumeMounts, cloudProviderDiskConfigVolumeMount)
+
+	// TODO: remove this in a future version.
+	// previous openstack versions (no CSI) ensure a volume mount with name `usr-share-ca-certificates` with path `/usr/share/ca-certificates`
+	// however Gardener version > 1.10.0 adds (if feature flag `MountHostCADirectories` is enabled) an API Server volume with name `usr-share-cacerts` also with path `/usr/share/ca-certificates`
+	// volume mount `usr-share-ca-certificates` needs to be removed to not have a duplicate `/usr/share/ca-certificates` mount
+	c.VolumeMounts = extensionswebhook.EnsureNoVolumeMountWithName(c.VolumeMounts, usrShareCACertificatesVolumeMount.Name)
 }
 
 func ensureKubeControllerManagerVolumeMounts(c *corev1.Container, csiEnabled, csiMigrationComplete bool) {
@@ -285,6 +291,12 @@ func ensureKubeAPIServerVolumes(ps *corev1.PodSpec, csiEnabled, csiMigrationComp
 	}
 
 	ps.Volumes = extensionswebhook.EnsureVolumeWithName(ps.Volumes, cloudProviderDiskConfigVolume)
+
+	// TODO: remove this in a future version.
+	// previous openstack versions (no CSI) ensure a volume with name `usr-share-ca-certificates` with path `/usr/share/ca-certificates`
+	// however Gardener version > 1.10.0 adds (if feature flag `MountHostCADirectories` is enabled) an API Server volume with name `usr-share-cacerts` also with path `/usr/share/ca-certificates`
+	// volume `usr-share-ca-certificates` needs to be removed to not have a duplicate `/usr/share/ca-certificates` mount
+	ps.Volumes = extensionswebhook.EnsureNoVolumeWithName(ps.Volumes, usrShareCACertificatesVolume.Name)
 }
 
 func ensureKubeControllerManagerVolumes(ps *corev1.PodSpec, csiEnabled, csiMigrationComplete bool) {

--- a/pkg/webhook/controlplane/ensurer_test.go
+++ b/pkg/webhook/controlplane/ensurer_test.go
@@ -500,7 +500,9 @@ func checkKubeAPIServerDeployment(dep *appsv1.Deployment, annotations map[string
 		Expect(c.Command).To(test.ContainElementWithPrefixContaining("--enable-admission-plugins=", "PersistentVolumeLabel", ","))
 		Expect(c.Command).To(Not(test.ContainElementWithPrefixContaining("--disable-admission-plugins=", "PersistentVolumeLabel", ",")))
 		Expect(c.VolumeMounts).To(ContainElement(cloudProviderDiskConfigVolumeMount))
+		Expect(c.VolumeMounts).NotTo(ContainElement(usrShareCACertificatesVolumeMount))
 		Expect(dep.Spec.Template.Spec.Volumes).To(ContainElement(cloudProviderDiskConfigVolume))
+		Expect(dep.Spec.Template.Spec.Volumes).NotTo(ContainElement(usrShareCACertificatesVolume))
 		Expect(dep.Spec.Template.Annotations).To(Equal(annotations))
 		if k8sVersionAtLeast119 {
 			Expect(c.Command).To(ContainElement("--feature-gates=CSIMigration=true,CSIMigrationOpenStack=true"))


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/priority normal
/platform openstack

**What this PR does / why we need it**:

Previous openstack versions  ensure a volume mount on the shoot kube-apiserver with name `usr-share-ca-certificates` with path `/usr/share/ca-certificates for Shoots that does not use CSI or is not yet migrated. 

However Gardener version > 1.10.0 always adds a volume mount for Shoots with Kubernetes version > 1.17 with name `usr-share-cacerts` also with path `/usr/share/ca-certificates`.

This is problematic for Shoots where the provider ensures the `usr-share-ca-certificates` path
- All existing & new Kubernetes versions 1.17.x  & 1.18.x 
- 1.19.x that are not migrated yet to CSI. 

The existing volume mount `usr-share-ca-certificates` needs to be removed to not have a duplicate `/usr/share/ca-certificates` mount.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```action operator
The openstack provider extension is incompatible with Gardener  version > v1.10.0 (if feature flag `MountHostCADirectories` is enabled on the Gardenlet) for Openstack Shoots with certain Kubernetes versions (>= 1.17.x, 1.18.x, 1.19.x without CSI migration complete).  Please consult the compatibility notes under `/docs/compatibility.md`
```
