### PR TITLE
Set CSI controller sidecar containers timeout

### DIFF
--- a/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/deployment-csi-driver-controller.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/deployment-csi-driver-controller.yaml
@@ -157,7 +157,7 @@ spec:
         - --kubeconfig=/var/lib/csi-resizer/kubeconfig
         - --leader-election=true
         - --leader-election-namespace=kube-system
-        - --timeout={{ .Values.timeout }}
+        - --csiTimeout={{ .Values.timeout }}
         - --v=5
         env:
         - name: ADDRESS

--- a/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/deployment-csi-driver-controller.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/deployment-csi-driver-controller.yaml
@@ -88,6 +88,7 @@ spec:
         - --default-fstype=ext4
         - --leader-election
         - --leader-election-namespace=kube-system
+        - --timeout={{ .Values.timeout }}
         - --v=5
         env:
         - name: ADDRESS
@@ -110,6 +111,7 @@ spec:
         - --kubeconfig=/var/lib/csi-attacher/kubeconfig
         - --leader-election
         - --leader-election-namespace=kube-system
+        - --timeout={{ .Values.timeout }}
         - --v=5
         env:
         - name: ADDRESS
@@ -132,6 +134,7 @@ spec:
         - --kubeconfig=/var/lib/csi-snapshotter/kubeconfig
         - --leader-election
         - --leader-election-namespace=kube-system
+        - --timeout={{ .Values.timeout }}
         - --snapshot-name-prefix={{ .Release.Namespace }}
         env:
         - name: CSI_ENDPOINT
@@ -154,6 +157,7 @@ spec:
         - --kubeconfig=/var/lib/csi-resizer/kubeconfig
         - --leader-election=true
         - --leader-election-namespace=kube-system
+        - --timeout={{ .Values.timeout }}
         - --v=5
         env:
         - name: ADDRESS

--- a/charts/internal/seed-controlplane/charts/csi-driver-controller/values.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-driver-controller/values.yaml
@@ -11,6 +11,7 @@ images:
   csi-snapshot-controller: image-repository:image-tag
 
 socketPath: /var/lib/csi/sockets/pluginproxy
+timeout: 3m
 
 resources:
   driver:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->

/priority normal
/platform openstack

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #157 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
CSI sidecar containers timeout is now increased to `3m`.
```

cc @rfranzke 