### PR TITLE
added nodeVolumeAttachLimit

### DIFF
--- a/charts/internal/cloud-provider-config/templates/cloud-provider-disk-config-csi.yaml
+++ b/charts/internal/cloud-provider-config/templates/cloud-provider-disk-config-csi.yaml
@@ -5,6 +5,9 @@
 
 [BlockStorage]
 rescan-on-resize={{ .Values.rescanBlockStorageOnResize }}
+{{- if .Values.nodeVolumeAttachLimit }}
+node-volume-attach-limit={{ .Values.nodeVolumeAttachLimit }}
+{{- end -}}
 {{- end -}}
 {{- if semverCompare ">= 1.19-0" .Values.kubernetesVersion }}
 ---

--- a/charts/internal/cloud-provider-config/values.yaml
+++ b/charts/internal/cloud-provider-config/values.yaml
@@ -15,6 +15,7 @@ dhcpDomain: foobar
 requestTimeout: 2s
 useOctavia: false
 rescanBlockStorageOnResize: false
+# nodeVolumeAttachLimit: 25
 # floatingClasses:
 # - name: A
 #   floatingNetworkID: "1234"

--- a/docs/usage-as-operator.md
+++ b/docs/usage-as-operator.md
@@ -22,6 +22,10 @@ In case your OpenStack system uses [Octavia](https://docs.openstack.org/octavia/
 Some hypervisors (especially those which are VMware-based) don't automatically send a new volume size to a Linux kernel when a volume is resized and in-use.
 For those hypervisors you can enable the storage plugin interacting with Cinder to telling the SCSI block device to refresh its information to provide information about it's updated size to the kernel. You might need to enable this behavior depending on the underlying hypervisor of your OpenStack installation. The `rescanBlockStorageOnResize` field controls this. Please note that it only applies for Kubernetes versions where CSI is used.
 
+Some openstack configurations do not allow to attach more volumes than a specific amount to a single node. 
+To tell the k8s scheduler to not over schedule volumes on a node, you can set `nodeVolumeAttachLimit` which defaults to 256.
+See [CSI Cinder driver](https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/cinder-csi-plugin/using-cinder-csi-plugin.md#block-storage). 
+
 The cloud profile config also contains constraints for floating pools and load balancer providers that can be used in shoots.
 
 An example `CloudProfileConfig` for the OpenStack extension looks as follows:
@@ -46,6 +50,7 @@ machineImages:
 # requestTimeout: 60s
 # useOctavia: true
 # rescanBlockStorageOnResize: true
+# nodeVolumeAttachLimit: 30
 constraints:
   floatingPools:
   - name: fp-pool-1

--- a/hack/api-reference/api.md
+++ b/hack/api-reference/api.md
@@ -154,6 +154,18 @@ the filesystem.</p>
 </tr>
 <tr>
 <td>
+<code>nodeVolumeAttachLimit</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>NodeVolumeAttachLimit specifies how many volumes can be attached to a node.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>useOctavia</code></br>
 <em>
 bool

--- a/pkg/apis/openstack/types_cloudprofile.go
+++ b/pkg/apis/openstack/types_cloudprofile.go
@@ -45,6 +45,8 @@ type CloudProfileConfig struct {
 	// RescanBlockStorageOnResize specifies whether the storage plugin scans and checks new block device size before it resizes
 	// the filesystem.
 	RescanBlockStorageOnResize *bool
+	// NodeVolumeAttachLimit specifies how many volumes can be attached to a node.
+	NodeVolumeAttachLimit *int32
 	// UseOctavia specifies whether the OpenStack Octavia network load balancing is used.
 	UseOctavia *bool
 }

--- a/pkg/apis/openstack/v1alpha1/types_cloudprofile.go
+++ b/pkg/apis/openstack/v1alpha1/types_cloudprofile.go
@@ -50,6 +50,9 @@ type CloudProfileConfig struct {
 	// the filesystem.
 	// +optional
 	RescanBlockStorageOnResize *bool `json:"rescanBlockStorageOnResize,omitempty"`
+	// NodeVolumeAttachLimit specifies how many volumes can be attached to a node.
+	// +optional
+	NodeVolumeAttachLimit *int32 `json:"nodeVolumeAttachLimit,omitempty"`
 	// UseOctavia specifies whether the OpenStack Octavia network load balancing is used.
 	// +optional
 	UseOctavia *bool `json:"useOctavia,omitempty"`

--- a/pkg/apis/openstack/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/openstack/v1alpha1/zz_generated.conversion.go
@@ -299,6 +299,7 @@ func autoConvert_v1alpha1_CloudProfileConfig_To_openstack_CloudProfileConfig(in 
 	out.MachineImages = *(*[]openstack.MachineImages)(unsafe.Pointer(&in.MachineImages))
 	out.RequestTimeout = (*string)(unsafe.Pointer(in.RequestTimeout))
 	out.RescanBlockStorageOnResize = (*bool)(unsafe.Pointer(in.RescanBlockStorageOnResize))
+	out.NodeVolumeAttachLimit = (*int32)(unsafe.Pointer(in.NodeVolumeAttachLimit))
 	out.UseOctavia = (*bool)(unsafe.Pointer(in.UseOctavia))
 	return nil
 }
@@ -319,6 +320,7 @@ func autoConvert_openstack_CloudProfileConfig_To_v1alpha1_CloudProfileConfig(in 
 	out.MachineImages = *(*[]MachineImages)(unsafe.Pointer(&in.MachineImages))
 	out.RequestTimeout = (*string)(unsafe.Pointer(in.RequestTimeout))
 	out.RescanBlockStorageOnResize = (*bool)(unsafe.Pointer(in.RescanBlockStorageOnResize))
+	out.NodeVolumeAttachLimit = (*int32)(unsafe.Pointer(in.NodeVolumeAttachLimit))
 	out.UseOctavia = (*bool)(unsafe.Pointer(in.UseOctavia))
 	return nil
 }

--- a/pkg/apis/openstack/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/openstack/v1alpha1/zz_generated.deepcopy.go
@@ -84,6 +84,11 @@ func (in *CloudProfileConfig) DeepCopyInto(out *CloudProfileConfig) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.NodeVolumeAttachLimit != nil {
+		in, out := &in.NodeVolumeAttachLimit, &out.NodeVolumeAttachLimit
+		*out = new(int32)
+		**out = **in
+	}
 	if in.UseOctavia != nil {
 		in, out := &in.UseOctavia, &out.UseOctavia
 		*out = new(bool)

--- a/pkg/apis/openstack/zz_generated.deepcopy.go
+++ b/pkg/apis/openstack/zz_generated.deepcopy.go
@@ -84,6 +84,11 @@ func (in *CloudProfileConfig) DeepCopyInto(out *CloudProfileConfig) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.NodeVolumeAttachLimit != nil {
+		in, out := &in.NodeVolumeAttachLimit, &out.NodeVolumeAttachLimit
+		*out = new(int32)
+		**out = **in
+	}
 	if in.UseOctavia != nil {
 		in, out := &in.UseOctavia, &out.UseOctavia
 		*out = new(bool)

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -421,6 +421,7 @@ func getConfigChartValues(
 		"requestTimeout":             cloudProfileConfig.RequestTimeout,
 		"useOctavia":                 cloudProfileConfig.UseOctavia != nil && *cloudProfileConfig.UseOctavia,
 		"rescanBlockStorageOnResize": cloudProfileConfig.RescanBlockStorageOnResize != nil && *cloudProfileConfig.RescanBlockStorageOnResize,
+		"nodeVolumeAttachLimit":      cloudProfileConfig.NodeVolumeAttachLimit,
 	}
 
 	if cpConfig.LoadBalancerClasses == nil {

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -114,9 +114,10 @@ var _ = Describe("ValuesProvider", func() {
 
 		cp = defaultControlPlane()
 
-		cidr                       = "10.250.0.0/19"
-		useOctavia                 = true
-		rescanBlockStorageOnResize = true
+		cidr                             = "10.250.0.0/19"
+		useOctavia                       = true
+		rescanBlockStorageOnResize       = true
+		nodeVoluemAttachLimit      int32 = 25
 
 		cloudProfileConfig = &api.CloudProfileConfig{
 			KeyStoneURL:                authURL,
@@ -124,6 +125,7 @@ var _ = Describe("ValuesProvider", func() {
 			RequestTimeout:             requestTimeout,
 			UseOctavia:                 pointer.BoolPtr(useOctavia),
 			RescanBlockStorageOnResize: pointer.BoolPtr(rescanBlockStorageOnResize),
+			NodeVolumeAttachLimit:      pointer.Int32Ptr(nodeVoluemAttachLimit),
 		}
 		cloudProfileConfigJSON, _ = json.Marshal(cloudProfileConfig)
 
@@ -259,6 +261,7 @@ var _ = Describe("ValuesProvider", func() {
 			"requestTimeout":             requestTimeout,
 			"useOctavia":                 useOctavia,
 			"rescanBlockStorageOnResize": rescanBlockStorageOnResize,
+			"nodeVolumeAttachLimit":      pointer.Int32Ptr(nodeVoluemAttachLimit),
 		}
 
 		It("should return correct config chart values", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/area storage
/kind enhancement
/priority normal
/platform openstack

**What this PR does / why we need it**:
The introduced flag tells the CSI-Driver, that there is a upper limit for mounted volumes on a node. 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Added possibility to set nodeVolumeAttachLimit within the cloud profile.
```
