### PR TITLE
Add useSNAT option to CloudProfile

### DIFF
--- a/charts/internal/openstack-infra/templates/main.tf
+++ b/charts/internal/openstack-infra/templates/main.tf
@@ -27,6 +27,9 @@ resource "openstack_networking_router_v2" "router" {
   name                = "{{ required "clusterName is required" .Values.clusterName }}"
   region              = "{{ required "openstack.region is required" .Values.openstack.region }}"
   external_network_id = data.openstack_networking_network_v2.fip.id
+  {{ if .Values.router.enableSNAT -}}
+  enable_snat         = true
+  {{- end }}
   {{ if .Values.router.floatingPoolSubnetName -}}
   external_fixed_ip {
     subnet_id = data.openstack_networking_subnet_v2.fip_subnet.id

--- a/charts/internal/openstack-infra/values.yaml
+++ b/charts/internal/openstack-infra/values.yaml
@@ -12,6 +12,7 @@ sshPublicKey: sshkey-12345
 
 router:
   id: openstack_networking_router_v2.router.id
+  # enableSNAT: true
   # floatingPoolSubnetName: my-fip-subnet-name
 
 dnsServers:

--- a/docs/usage-as-operator.md
+++ b/docs/usage-as-operator.md
@@ -45,6 +45,7 @@ machineImages:
 # - 10.10.10.12
 # requestTimeout: 60s
 # useOctavia: true
+# useSNAT: true
 # rescanBlockStorageOnResize: true
 constraints:
   floatingPools:
@@ -97,6 +98,8 @@ with setting the optional field `nonConstraining` to `true`.
 Some OpenStack environments don't need these regional mappings, hence, the `region` and `keystoneURLs` fields are optional.
 If your OpenStack environment only has regional values and it doesn't make sense to provide a (non-regional) fallback then simply
 omit `keystoneURL` and always specify `region`.
+
+If Gardener creates and manages the router of a shoot cluster, it is additionally possible to specify that the [enable_snat](https://registry.terraform.io/providers/terraform-provider-openstack/openstack/latest/docs/resources/networking_router_v2#enable_snat) field is set to `true` via `useSNAT: true` in the `CloudProfileConfig`.
 
 ## Example `CloudProfile` manifest
 

--- a/hack/api-reference/api.md
+++ b/hack/api-reference/api.md
@@ -164,6 +164,18 @@ bool
 <p>UseOctavia specifies whether the OpenStack Octavia network load balancing is used.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>useSNAT</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>UseSNAT specifies whether S-NAT is supposed to be used for the Gardener managed OpenStack router.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="openstack.provider.extensions.gardener.cloud/v1alpha1.ControlPlaneConfig">ControlPlaneConfig

--- a/pkg/apis/openstack/types_cloudprofile.go
+++ b/pkg/apis/openstack/types_cloudprofile.go
@@ -47,6 +47,8 @@ type CloudProfileConfig struct {
 	RescanBlockStorageOnResize *bool
 	// UseOctavia specifies whether the OpenStack Octavia network load balancing is used.
 	UseOctavia *bool
+	// UseSNAT specifies whether S-NAT is supposed to be used for the Gardener managed OpenStack router.
+	UseSNAT *bool
 }
 
 // Constraints is an object containing constraints for the shoots.

--- a/pkg/apis/openstack/v1alpha1/types_cloudprofile.go
+++ b/pkg/apis/openstack/v1alpha1/types_cloudprofile.go
@@ -53,6 +53,9 @@ type CloudProfileConfig struct {
 	// UseOctavia specifies whether the OpenStack Octavia network load balancing is used.
 	// +optional
 	UseOctavia *bool `json:"useOctavia,omitempty"`
+	// UseSNAT specifies whether S-NAT is supposed to be used for the Gardener managed OpenStack router.
+	// +optional
+	UseSNAT *bool `json:"useSNAT,omitempty"`
 }
 
 // Constraints is an object containing constraints for the shoots.

--- a/pkg/apis/openstack/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/openstack/v1alpha1/zz_generated.conversion.go
@@ -300,6 +300,7 @@ func autoConvert_v1alpha1_CloudProfileConfig_To_openstack_CloudProfileConfig(in 
 	out.RequestTimeout = (*string)(unsafe.Pointer(in.RequestTimeout))
 	out.RescanBlockStorageOnResize = (*bool)(unsafe.Pointer(in.RescanBlockStorageOnResize))
 	out.UseOctavia = (*bool)(unsafe.Pointer(in.UseOctavia))
+	out.UseSNAT = (*bool)(unsafe.Pointer(in.UseSNAT))
 	return nil
 }
 
@@ -320,6 +321,7 @@ func autoConvert_openstack_CloudProfileConfig_To_v1alpha1_CloudProfileConfig(in 
 	out.RequestTimeout = (*string)(unsafe.Pointer(in.RequestTimeout))
 	out.RescanBlockStorageOnResize = (*bool)(unsafe.Pointer(in.RescanBlockStorageOnResize))
 	out.UseOctavia = (*bool)(unsafe.Pointer(in.UseOctavia))
+	out.UseSNAT = (*bool)(unsafe.Pointer(in.UseSNAT))
 	return nil
 }
 

--- a/pkg/apis/openstack/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/openstack/v1alpha1/zz_generated.deepcopy.go
@@ -89,6 +89,11 @@ func (in *CloudProfileConfig) DeepCopyInto(out *CloudProfileConfig) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.UseSNAT != nil {
+		in, out := &in.UseSNAT, &out.UseSNAT
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/openstack/zz_generated.deepcopy.go
+++ b/pkg/apis/openstack/zz_generated.deepcopy.go
@@ -89,6 +89,11 @@ func (in *CloudProfileConfig) DeepCopyInto(out *CloudProfileConfig) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.UseSNAT != nil {
+		in, out := &in.UseSNAT, &out.UseSNAT
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/internal/infrastructure/terraform.go
+++ b/pkg/internal/infrastructure/terraform.go
@@ -102,6 +102,10 @@ func ComputeTerraformerChartValues(
 		return nil, err
 	}
 
+	if cloudProfileConfig.UseSNAT != nil {
+		routerConfig["enableSNAT"] = *cloudProfileConfig.UseSNAT
+	}
+
 	workersCIDR := config.Networks.Workers
 	// Backwards compatibility - remove this code in a future version.
 	if workersCIDR == "" {

--- a/pkg/internal/infrastructure/terraform_test.go
+++ b/pkg/internal/infrastructure/terraform_test.go
@@ -18,6 +18,8 @@ import (
 	"encoding/json"
 	"strconv"
 
+	"k8s.io/utils/pointer"
+
 	api "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack"
 	apiv1alpha1 "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack/v1alpha1"
 	"github.com/gardener/gardener-extension-provider-openstack/pkg/openstack"
@@ -162,9 +164,14 @@ var _ = Describe("Terraform", func() {
 		})
 
 		It("should correctly compute the terraformer chart values with vpc creation", func() {
+			cloudProfileConfig.UseSNAT = pointer.BoolPtr(true)
+			cloudProfileConfigJSON, _ = json.Marshal(cloudProfileConfig)
+			cluster.CloudProfile.Spec.ProviderConfig.Raw = cloudProfileConfigJSON
+
 			config.Networks.Router = nil
 			expectedCreateValues["router"] = true
 			expectedRouterValues["id"] = DefaultRouterID
+			expectedRouterValues["enableSNAT"] = true
 
 			values, err := ComputeTerraformerChartValues(infra, credentials, config, cluster)
 			Expect(err).To(BeNil())


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement
/priority normal
/platform openstack

**What this PR does / why we need it**:
This PR adds a new option `useSNAT` to the provider's specific `CloudProfileConfig`. If set to `true`, Gardener creates the OpenStack Router with the [enable_snat](https://registry.terraform.io/providers/terraform-provider-openstack/openstack/latest/docs/resources/networking_router_v2#enable_snat) option.

**Which issue(s) this PR fixes**:
Fixes parts of #122

**Special notes for your reviewer**:
/cc @schrodit @vasu1124 @vlerenc @markbgrdt

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The OpenStack extension now created OpenStack routers with [enable_snat](https://registry.terraform.io/providers/terraform-provider-openstack/openstack/latest/docs/resources/networking_router_v2#enable_snat) if the corresponding option `.useSNAT` is set to `true` in the provider's `CloudProfileConfig`.
```
