### PR TITLE
Reuse existing network

### DIFF
--- a/charts/internal/machineclass/templates/machineclass.yaml
+++ b/charts/internal/machineclass/templates/machineclass.yaml
@@ -35,6 +35,7 @@ spec:
   imageName: {{ $machineClass.imageName }}
 {{- end }}
   networkID: {{ $machineClass.networkID }}
+  subnetID: {{ $machineClass.subnetID }}
   podNetworkCidr: {{ $machineClass.podNetworkCidr }}
 {{- if $machineClass.rootDiskSize }}
   rootDiskSize: {{ $machineClass.rootDiskSize }}

--- a/charts/internal/openstack-infra/values.yaml
+++ b/charts/internal/openstack-infra/values.yaml
@@ -7,6 +7,7 @@ openstack:
 
 create:
   router: true
+  network: false
 
 sshPublicKey: sshkey-12345
 
@@ -22,6 +23,7 @@ clusterName: test-namespace
 
 networks:
   workers: 10.250.0.0/19
+  id: 12345678-abcd-9876-a0b1-abcdef123456
 
 outputKeys:
   routerID: router_id

--- a/docs/usage-as-end-user.md
+++ b/docs/usage-as-end-user.md
@@ -40,15 +40,19 @@ kind: InfrastructureConfig
 floatingPoolName: MY-FLOATING-POOL
 # floatingPoolSubnetName: my-floating-pool-subnet-name
 networks:
+# id: 12345678-abcd-efef-08af-0123456789ab
+  workers: 10.250.0.0/19
 # router:
 #   id: 1234
-  workers: 10.250.0.0/19
 ```
 
 The `floatingPoolName` is the name of the floating pool you want to use for your shoot.
 If you don't know which floating pools are available look it up in the respective `CloudProfile`.
 
 With `floatingPoolSubnetName` you can explicitly define to which subnet in the floating pool network (defined via `floatingPoolName`) the router should be attached to.
+
+If `networks.id` is an optional field. If it is given, you can specify the uuid of an existing Neutron network (created manually, by other tooling, ...) that should be reused. A new subnet for the Shoot will get created in it get created.
+**Warning:** All subnets in the given network must have a router. A subnet without router may cause all subnets in the network to loose connectivity.
 
 The `networks.router` section describes whether you want to create the shoot cluster in an already existing router or whether to create a new one:
 

--- a/example/30-infrastructure.yaml
+++ b/example/30-infrastructure.yaml
@@ -61,7 +61,8 @@ spec:
     floatingPoolName: MY-FLOATING-POOL
     # floatingPoolSubnetName: my-floating-pool-subnet-name
     networks:
+    # id: 12345678-abcd-efef-08af-0123456789ab
+      workers: 10.250.0.0/19
     # router:
     #   id: 1234
-      workers: 10.250.0.0/19
   sshPublicKey: AAAA

--- a/hack/api-reference/api.md
+++ b/hack/api-reference/api.md
@@ -1115,6 +1115,18 @@ string
 <p>Workers is a CIDRs of a worker subnet (private) to create (used for the VMs).</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>id</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ID is the OpenStack UUID of an existing network that should be reused</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="openstack.provider.extensions.gardener.cloud/v1alpha1.NodeStatus">NodeStatus

--- a/pkg/apis/openstack/types_infrastructure.go
+++ b/pkg/apis/openstack/types_infrastructure.go
@@ -40,6 +40,8 @@ type Networks struct {
 	Worker string
 	// Workers is a CIDRs of a worker subnet (private) to create (used for the VMs).
 	Workers string
+	// ID is the name of an existing network that should be reused
+	ID *string
 }
 
 // Router indicates whether to use an existing router or create a new one.

--- a/pkg/apis/openstack/v1alpha1/types_infrastructure.go
+++ b/pkg/apis/openstack/v1alpha1/types_infrastructure.go
@@ -43,6 +43,9 @@ type Networks struct {
 	Worker string `json:"worker"`
 	// Workers is a CIDRs of a worker subnet (private) to create (used for the VMs).
 	Workers string `json:"workers"`
+	// ID is the OpenStack UUID of an existing network that should be reused
+	// +optional
+	ID *string `json:"id,omitempty"`
 }
 
 // Router indicates whether to use an existing router or create a new one.

--- a/pkg/apis/openstack/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/openstack/v1alpha1/zz_generated.conversion.go
@@ -704,6 +704,7 @@ func autoConvert_v1alpha1_Networks_To_openstack_Networks(in *Networks, out *open
 	out.Router = (*openstack.Router)(unsafe.Pointer(in.Router))
 	out.Worker = in.Worker
 	out.Workers = in.Workers
+	out.ID = (*string)(unsafe.Pointer(in.ID))
 	return nil
 }
 
@@ -716,6 +717,7 @@ func autoConvert_openstack_Networks_To_v1alpha1_Networks(in *openstack.Networks,
 	out.Router = (*Router)(unsafe.Pointer(in.Router))
 	out.Worker = in.Worker
 	out.Workers = in.Workers
+	out.ID = (*string)(unsafe.Pointer(in.ID))
 	return nil
 }
 

--- a/pkg/apis/openstack/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/openstack/v1alpha1/zz_generated.deepcopy.go
@@ -478,6 +478,11 @@ func (in *Networks) DeepCopyInto(out *Networks) {
 		*out = new(Router)
 		**out = **in
 	}
+	if in.ID != nil {
+		in, out := &in.ID, &out.ID
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/openstack/validation/infrastructure.go
+++ b/pkg/apis/openstack/validation/infrastructure.go
@@ -16,6 +16,7 @@ package validation
 
 import (
 	"reflect"
+	"regexp"
 	"sort"
 
 	api "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack"
@@ -59,6 +60,14 @@ func ValidateInfrastructureConfig(infra *api.InfrastructureConfig, nodesCIDR *st
 
 	if nodes != nil {
 		allErrs = append(allErrs, nodes.ValidateSubset(workerCIDR)...)
+	}
+
+	if infra.Networks.ID != nil {
+		const openStackUUIDRegExp = "[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}"
+		regex := regexp.MustCompile(openStackUUIDRegExp)
+		if !regex.MatchString(*infra.Networks.ID) {
+			allErrs = append(allErrs, field.Invalid(networksPath.Child("id"), infra.Networks.ID, "network id - if provided - must be an OpenStack UUID"))
+		}
 	}
 
 	if infra.Networks.Router != nil && len(infra.Networks.Router.ID) == 0 {

--- a/pkg/apis/openstack/zz_generated.deepcopy.go
+++ b/pkg/apis/openstack/zz_generated.deepcopy.go
@@ -478,6 +478,11 @@ func (in *Networks) DeepCopyInto(out *Networks) {
 		*out = new(Router)
 		**out = **in
 	}
+	if in.ID != nil {
+		in, out := &in.ID, &out.ID
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -124,6 +124,11 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 		return err
 	}
 
+	subnet, err := helper.FindSubnetByPurpose(infrastructureStatus.Networks.Subnets, api.PurposeNodes)
+	if err != nil {
+		return err
+	}
+
 	for _, pool := range w.worker.Spec.Pools {
 		zoneLen := int32(len(pool.Zones))
 
@@ -155,6 +160,7 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 				"machineType":      pool.MachineType,
 				"keyName":          infrastructureStatus.Node.KeyName,
 				"networkID":        infrastructureStatus.Networks.ID,
+				"subnetID":         subnet.ID,
 				"podNetworkCidr":   extensionscontroller.GetPodNetwork(w.cluster),
 				"securityGroups":   []string{nodesSecurityGroup.Name},
 				"tags": map[string]string{

--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -106,6 +106,7 @@ var _ = Describe("Machines", func() {
 				machineType       string
 				userData          []byte
 				networkID         string
+				subnetID          string
 				podCIDR           string
 				securityGroupName string
 
@@ -162,6 +163,7 @@ var _ = Describe("Machines", func() {
 				machineType = "large"
 				userData = []byte("some-user-data")
 				networkID = "network-id"
+				subnetID = "subnet-id"
 				podCIDR = "1.2.3.4/5"
 				securityGroupName = "nodes-sec-group"
 
@@ -272,6 +274,12 @@ var _ = Describe("Machines", func() {
 								},
 								Networks: api.NetworkStatus{
 									ID: networkID,
+									Subnets: []api.Subnet{
+										{
+											Purpose: api.PurposeNodes,
+											ID:      subnetID,
+										},
+									},
 								},
 							}),
 						},
@@ -350,6 +358,7 @@ var _ = Describe("Machines", func() {
 						"machineType":    machineType,
 						"keyName":        keyName,
 						"networkID":      networkID,
+						"subnetID":       subnetID,
 						"podNetworkCidr": podCIDR,
 						"securityGroups": []string{securityGroupName},
 						"tags": map[string]string{

--- a/pkg/internal/infrastructure/terraform_test.go
+++ b/pkg/internal/infrastructure/terraform_test.go
@@ -128,7 +128,8 @@ var _ = Describe("Terraform", func() {
 				"floatingPoolName": config.FloatingPoolName,
 			}
 			expectedCreateValues = map[string]interface{}{
-				"router": false,
+				"router":  false,
+				"network": true,
 			}
 			expectedRouterValues = map[string]interface{}{
 				"id": strconv.Quote("1"),
@@ -170,6 +171,7 @@ var _ = Describe("Terraform", func() {
 
 			config.Networks.Router = nil
 			expectedCreateValues["router"] = true
+
 			expectedRouterValues["id"] = DefaultRouterID
 			expectedRouterValues["enableSNAT"] = true
 
@@ -197,6 +199,28 @@ var _ = Describe("Terraform", func() {
 			expectedRouterValues["id"] = DefaultRouterID
 			expectedRouterValues["floatingPoolSubnetName"] = fipSubnetID
 			expectedOutputKeysValues["floatingSubnetID"] = TerraformOutputKeyFloatingSubnetID
+
+			values, err := ComputeTerraformerChartValues(infra, credentials, config, cluster)
+			Expect(err).To(BeNil())
+			Expect(values).To(Equal(map[string]interface{}{
+				"openstack":    expectedOpenStackValues,
+				"create":       expectedCreateValues,
+				"dnsServers":   dnsServers,
+				"sshPublicKey": string(infra.Spec.SSHPublicKey),
+				"router":       expectedRouterValues,
+				"clusterName":  infra.Namespace,
+				"networks":     expectedNetworkValues,
+				"outputKeys":   expectedOutputKeysValues,
+			}))
+		})
+
+		It("should correctly compute the terraformer chart values with a given network ID", func() {
+			networkID := "12345678-abcd-9876-a0b1-abcdef123456"
+
+			config.Networks.ID = &networkID
+
+			expectedCreateValues["network"] = false
+			expectedNetworkValues["id"] = networkID
 
 			values, err := ComputeTerraformerChartValues(infra, credentials, config, cluster)
 			Expect(err).To(BeNil())


### PR DESCRIPTION
**How to categorize this PR?**

/area networking
/kind enhancement
/priority normal
/platform openstack

**What this PR does / why we need it**:
This PR enhances the gardener extension provider for OpenStack to be able to deploy shoots into existing networks.

**Which issue(s) this PR fixes**:
Fixes #99 

**Special notes for your reviewer**:
This PR adds the network name field to the infratructure API and enables the terraformer to skip the network creation part. All MCM related activities will follow in a separate PR which will be linked to this one. 

**Release note**:

```improvement user
An existing Neutron network can be selected in a shoot's infrastructure configuration in the .spec.provider.infrastructureConfig.network.name field to have the shoot deployed into that network.
```