### PR TITLE
Clean up StorageClass update workaround

### DIFF
--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -26,13 +26,10 @@ import (
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
 	"github.com/gardener/gardener/extensions/pkg/controller/worker"
 	genericworkeractuator "github.com/gardener/gardener/extensions/pkg/controller/worker/genericactuator"
-	"github.com/gardener/gardener/extensions/pkg/util"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
-	storagev1beta1 "k8s.io/api/storage/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // MachineClassKind yields the name of the OpenStack machine class.
@@ -45,36 +42,8 @@ func (w *workerDelegate) MachineClassList() runtime.Object {
 	return &machinev1alpha1.OpenStackMachineClassList{}
 }
 
-// NewClientForShoot is exposed for testing.
-var NewClientForShoot = util.NewClientForShoot
-
 // DeployMachineClasses generates and creates the OpenStack specific machine classes.
 func (w *workerDelegate) DeployMachineClasses(ctx context.Context) error {
-	// TODO: Remove this in a future version. This is a hacky workaround for a problem introduced with
-	// https://github.com/gardener/gardener-extension-provider-openstack/commit/3bf9f686ea6838aef2d87cbe1ff75f459037594b:
-	// The StorageClasses are immutable, hence, for existing clusters the `availability` field cannot be removed. The
-	// only way is to delete the StorageClass and recreate it. The ControlPlane controller is generating the new StorageClass
-	// without the `availability` field. Hence, we have to check if there is an existing StorageClass with the field and
-	// delete it. We cannot do it in the ControlPlane controller itself as the shoot API server might not be up at this
-	// point in time, ref https://github.com/gardener/gardener/blob/master/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go#L213.
-	if !extensionscontroller.IsHibernated(w.cluster) {
-		_, shootClient, err := NewClientForShoot(ctx, w.Client(), w.cluster.ObjectMeta.Name, client.Options{})
-		if err != nil {
-			return err
-		}
-		storageClasses := &storagev1beta1.StorageClassList{}
-		if err := shootClient.List(ctx, storageClasses); err != nil {
-			return err
-		}
-		for _, storageClass := range storageClasses.Items {
-			if (storageClass.Name == "default" || storageClass.Name == "default-class") && storageClass.Parameters != nil && storageClass.Parameters["availability"] != "" {
-				if err := shootClient.Delete(ctx, storageClass.DeepCopy()); err != nil {
-					return err
-				}
-			}
-		}
-	}
-
 	if w.machineClasses == nil {
 		if err := w.generateMachineConfig(ctx); err != nil {
 			return err


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area storage
/kind cleanup
/priority normal
/platform openstack

**What this PR does / why we need it**:
Clean up the workaround introduced with https://github.com/gardener/gardener-extension-provider-openstack/pull/102.
I believe we no longer need it as StorageClass should be already adapted by the temporary workaround logic. We also introduced https://github.com/gardener/gardener-extension-provider-openstack/pull/130 which should re-create the StorageClasses on invalid updates.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
