### PR TITLE
Changing the default parameters handling and adding all properties to the test definition

### DIFF
--- a/.test-defs/provider-openstack.yaml
+++ b/.test-defs/provider-openstack.yaml
@@ -14,5 +14,6 @@ spec:
     --controlplane-provider-config-filepath=$CONTROLPLANE_PROVIDER_CONFIG_FILEPATH
     --floating-pool-name=$FLOATING_POOL_NAME
     --loadbalancer-provider=$LOADBALANCER_PROVIDER
+    --network-worker-cidr=$NETWORK_WORKER_CIDR
 
   image: golang:1.13.0

--- a/test/tm/generator.go
+++ b/test/tm/generator.go
@@ -21,6 +21,7 @@ import (
 	"reflect"
 
 	"github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack/v1alpha1"
+	"github.com/go-logr/logr"
 
 	"github.com/gardener/gardener/extensions/test/tm/generator"
 	"github.com/pkg/errors"
@@ -29,20 +30,39 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
-var (
-	infrastructureProviderConfigPath = flag.String("infrastructure-provider-config-filepath", "", "filepath to the provider specific infrastructure config")
-	controlplaneProviderConfigPath   = flag.String("controlplane-provider-config-filepath", "", "filepath to the provider specific controlplane config")
-
-	floatingPoolName  = flag.String("floating-pool-name", "", "set the name of the floating pool")
-	networkWorkerCidr = flag.String("network-worker-cidr", "10.250.0.0/19", "worker network cidr")
-
-	loadBalancerProvider = flag.String("loadbalancer-provider", "", "loadbalancer provider for the shoot's loadbalancers")
+const (
+	defaultNetworkWorkerCidr = "10.250.0.0/19"
 )
 
+var (
+	cfg    *GeneratorConfig
+	logger logr.Logger
+)
+
+type GeneratorConfig struct {
+	floatingPoolName                 string
+	loadBalancerProvider             string
+	networkWorkerCidr                string
+	infrastructureProviderConfigPath string
+	controlplaneProviderConfigPath   string
+}
+
+func addFlags() {
+	cfg = &GeneratorConfig{}
+	flag.StringVar(&cfg.infrastructureProviderConfigPath, "infrastructure-provider-config-filepath", "", "filepath to the provider specific infrastructure config")
+	flag.StringVar(&cfg.controlplaneProviderConfigPath, "controlplane-provider-config-filepath", "", "filepath to the provider specific controlplane config")
+
+	flag.StringVar(&cfg.floatingPoolName, "floating-pool-name", "", "set the name of the floating pool")
+	flag.StringVar(&cfg.networkWorkerCidr, "network-worker-cidr", "", "worker network cidr")
+
+	flag.StringVar(&cfg.loadBalancerProvider, "loadbalancer-provider", "", "loadbalancer provider for the shoot's loadbalancers")
+}
+
 func main() {
-	log.SetLogger(zap.Logger(false))
-	logger := log.Log.WithName("openstack-generator")
+	addFlags()
 	flag.Parse()
+	log.SetLogger(zap.Logger(false))
+	logger = log.Log.WithName("openstack-generator")
 	if err := validate(); err != nil {
 		logger.Error(err, "error validating input flags")
 		os.Exit(1)
@@ -53,9 +73,9 @@ func main() {
 			APIVersion: v1alpha1.SchemeGroupVersion.String(),
 			Kind:       reflect.TypeOf(v1alpha1.InfrastructureConfig{}).Name(),
 		},
-		FloatingPoolName: *floatingPoolName,
+		FloatingPoolName: cfg.floatingPoolName,
 		Networks: v1alpha1.Networks{
-			Workers: *networkWorkerCidr,
+			Workers: cfg.networkWorkerCidr,
 		},
 	}
 
@@ -64,35 +84,37 @@ func main() {
 			APIVersion: v1alpha1.SchemeGroupVersion.String(),
 			Kind:       reflect.TypeOf(v1alpha1.ControlPlaneConfig{}).Name(),
 		},
-		LoadBalancerProvider: *loadBalancerProvider,
+		LoadBalancerProvider: cfg.loadBalancerProvider,
 	}
 
-	if err := generator.MarshalAndWriteConfig(*infrastructureProviderConfigPath, infra); err != nil {
+	if err := generator.MarshalAndWriteConfig(cfg.infrastructureProviderConfigPath, infra); err != nil {
 		logger.Error(err, "unable to write infrastructure config")
 		os.Exit(1)
 	}
-	if err := generator.MarshalAndWriteConfig(*controlplaneProviderConfigPath, cp); err != nil {
+	if err := generator.MarshalAndWriteConfig(cfg.controlplaneProviderConfigPath, cp); err != nil {
 		logger.Error(err, "unable to write infrastructure config")
 		os.Exit(1)
 	}
-	logger.Info("successfully written openstack provider configuration", "infra", *infrastructureProviderConfigPath, "controlplane", *controlplaneProviderConfigPath)
+	logger.Info("successfully written openstack provider configuration", "infra", cfg.infrastructureProviderConfigPath, "controlplane", cfg.controlplaneProviderConfigPath)
 }
 
 func validate() error {
-	if err := generator.ValidateString(infrastructureProviderConfigPath); err != nil {
+	if err := generator.ValidateString(&cfg.infrastructureProviderConfigPath); err != nil {
 		return errors.Wrap(err, "error validating infrastructure provider config path")
 	}
-	if err := generator.ValidateString(controlplaneProviderConfigPath); err != nil {
+	if err := generator.ValidateString(&cfg.controlplaneProviderConfigPath); err != nil {
 		return errors.Wrap(err, "error validating controlplane provider config path")
 	}
-	if err := generator.ValidateString(networkWorkerCidr); err != nil {
-		return errors.Wrap(err, "error validating worker CIDR")
-	}
-	if err := generator.ValidateString(floatingPoolName); err != nil {
+	if err := generator.ValidateString(&cfg.floatingPoolName); err != nil {
 		return errors.Wrap(err, "error floating pool name")
 	}
-	if err := generator.ValidateString(loadBalancerProvider); err != nil {
+	if err := generator.ValidateString(&cfg.loadBalancerProvider); err != nil {
 		return errors.Wrap(err, "error loadbalancer provider")
+	}
+	//Optional Parameters
+	if err := generator.ValidateString(&cfg.networkWorkerCidr); err != nil {
+		logger.Info("Parameter network-worker-cidr is not set, using default.", "value", defaultNetworkWorkerCidr)
+		cfg.networkWorkerCidr = defaultNetworkWorkerCidr
 	}
 	return nil
 }


### PR DESCRIPTION
How to categorize this PR?
/kind enhancement
/priority normal
/platform openstack

What this PR does / why we need it:
This PR adds all properties to the "provider-openstack" test definition. In addition to this, as discussed in [PR:191,](https://github.com/gardener/gardener-extension-provider-aws/pull/191) the default parameters handling is changed.
This way one test definition will be used by the integration tests where shoots with different networks from the defaults must be created (e.g. for registering a new seed for the control plane migration) and it will preserve the default behaviour for other integration tests (e.g. for shoot creation) that relies on the default values.
Which issue(s) this PR fixes:
Fixes #

Special notes for your reviewer:

Release note:
```
NONE
```