### PR TITLE
Remove deprecated role label key from components

### DIFF
--- a/charts/internal/machine-controller-manager/seed/templates/deployment.yaml
+++ b/charts/internal/machine-controller-manager/seed/templates/deployment.yaml
@@ -5,7 +5,6 @@ metadata:
   name: machine-controller-manager
   namespace: {{ .Release.Namespace }}
   labels:
-    garden.sapcloud.io/role: controlplane
     app: kubernetes
     role: machine-controller-manager
 spec:
@@ -24,6 +23,7 @@ spec:
 {{- end }}
       labels:
         garden.sapcloud.io/role: controlplane
+        gardener.cloud/role: controlplane
         app: kubernetes
         role: machine-controller-manager
         networking.gardener.cloud/to-dns: allowed

--- a/charts/internal/seed-controlplane/charts/cloud-controller-manager/templates/cloud-controller-manager.yaml
+++ b/charts/internal/seed-controlplane/charts/cloud-controller-manager/templates/cloud-controller-manager.yaml
@@ -4,7 +4,6 @@ metadata:
   name: cloud-controller-manager
   namespace: {{ .Release.Namespace }}
   labels:
-    garden.sapcloud.io/role: controlplane
     app: kubernetes
     role: cloud-controller-manager
 spec:
@@ -22,6 +21,7 @@ spec:
 {{- end }}
       labels:
         garden.sapcloud.io/role: controlplane
+        gardener.cloud/role: controlplane
         app: kubernetes
         role: cloud-controller-manager
         networking.gardener.cloud/to-dns: allowed

--- a/test/e2e/netpol-gen/app/openstack.go
+++ b/test/e2e/netpol-gen/app/openstack.go
@@ -44,9 +44,8 @@ func NewCloudAware() np.CloudAware {
 		cloudControllerManagerNotSecured: &np.SourcePod{
 			Ports: np.NewSinglePort(10253),
 			Pod: np.NewPod("cloud-controller-manager-http", labels.Set{
-				"app":                     "kubernetes",
-				"garden.sapcloud.io/role": "controlplane",
-				"role":                    "cloud-controller-manager",
+				"app":  "kubernetes",
+				"role": "cloud-controller-manager",
 			}, "< 1.13"),
 			ExpectedPolicies: sets.NewString(
 				"allow-from-prometheus",
@@ -60,9 +59,8 @@ func NewCloudAware() np.CloudAware {
 		cloudControllerManagerSecured: &np.SourcePod{
 			Ports: np.NewSinglePort(10258),
 			Pod: np.NewPod("cloud-controller-manager-https", labels.Set{
-				"app":                     "kubernetes",
-				"garden.sapcloud.io/role": "controlplane",
-				"role":                    "cloud-controller-manager",
+				"app":  "kubernetes",
+				"role": "cloud-controller-manager",
 			}, ">= 1.13"),
 			ExpectedPolicies: sets.NewString(
 				"allow-from-prometheus",

--- a/test/e2e/networkpolicies/networkpolicy_test.go
+++ b/test/e2e/networkpolicies/networkpolicy_test.go
@@ -138,9 +138,8 @@ var _ = Describe("Network Policy Testing", func() {
 			Pod: networkpolicies.Pod{
 				Name: "cloud-controller-manager-http",
 				Labels: labels.Set{
-					"app":                     "kubernetes",
-					"garden.sapcloud.io/role": "controlplane",
-					"role":                    "cloud-controller-manager"},
+					"app":  "kubernetes",
+					"role": "cloud-controller-manager"},
 				ShootVersionConstraint: "< 1.13",
 				SeedClusterConstraints: sets.String(nil)},
 			Ports: []networkpolicies.Port{
@@ -158,9 +157,8 @@ var _ = Describe("Network Policy Testing", func() {
 			Pod: networkpolicies.Pod{
 				Name: "cloud-controller-manager-http",
 				Labels: labels.Set{
-					"app":                     "kubernetes",
-					"garden.sapcloud.io/role": "controlplane",
-					"role":                    "cloud-controller-manager"},
+					"app":  "kubernetes",
+					"role": "cloud-controller-manager"},
 				ShootVersionConstraint: "< 1.13",
 				SeedClusterConstraints: sets.String(nil)},
 			Port: networkpolicies.Port{
@@ -170,9 +168,8 @@ var _ = Describe("Network Policy Testing", func() {
 			Pod: networkpolicies.Pod{
 				Name: "cloud-controller-manager-https",
 				Labels: labels.Set{
-					"app":                     "kubernetes",
-					"garden.sapcloud.io/role": "controlplane",
-					"role":                    "cloud-controller-manager"},
+					"app":  "kubernetes",
+					"role": "cloud-controller-manager"},
 				ShootVersionConstraint: ">= 1.13",
 				SeedClusterConstraints: sets.String(nil)},
 			Ports: []networkpolicies.Port{
@@ -190,9 +187,8 @@ var _ = Describe("Network Policy Testing", func() {
 			Pod: networkpolicies.Pod{
 				Name: "cloud-controller-manager-https",
 				Labels: labels.Set{
-					"app":                     "kubernetes",
-					"garden.sapcloud.io/role": "controlplane",
-					"role":                    "cloud-controller-manager"},
+					"app":  "kubernetes",
+					"role": "cloud-controller-manager"},
 				ShootVersionConstraint: ">= 1.13",
 				SeedClusterConstraints: sets.String(nil)},
 			Port: networkpolicies.Port{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind cleanup
/priority normal
/platform openstack

**What this PR does / why we need it**:
Fore more details see https://github.com/gardener/gardener-extension-provider-aws/pull/230

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
