### PR TITLE
Update CSI driver and sidecar images

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -26,32 +26,32 @@ images:
 - name: csi-driver-cinder
   sourceRepository: github.com/kubernetes/cloud-provider-openstack
   repository: docker.io/k8scloudprovider/cinder-csi-plugin
-  tag: "v1.18.0"
+  tag: "v1.19.0"
 - name: csi-provisioner
   sourceRepository: github.com/kubernetes-csi/external-provisioner
-  repository: quay.io/k8scsi/csi-provisioner
-  tag: "v2.0.0"
+  repository: k8s.gcr.io/sig-storage/csi-provisioner
+  tag: "v2.0.4"
 - name: csi-attacher
   sourceRepository: github.com/kubernetes-csi/external-attacher
-  repository: quay.io/k8scsi/csi-attacher
-  tag: "v3.0.0"
+  repository: k8s.gcr.io/sig-storage/csi-attacher
+  tag: "v3.0.2"
 - name: csi-snapshotter
   sourceRepository: github.com/kubernetes-csi/external-snapshotter
-  repository: quay.io/k8scsi/csi-snapshotter
+  repository: k8s.gcr.io/sig-storage/csi-snapshotter
   tag: "v2.1.1"
 - name: csi-snapshot-controller
   sourceRepository: github.com/kubernetes-csi/external-snapshotter
-  repository: quay.io/k8scsi/snapshot-controller
+  repository: k8s.gcr.io/sig-storage/snapshot-controller
   tag: "v2.1.1"
 - name: csi-resizer
   sourceRepository: github.com/kubernetes-csi/external-resizer
-  repository: quay.io/k8scsi/csi-resizer
+  repository: k8s.gcr.io/sig-storage/csi-resizer
   tag: "v0.5.0"
 - name: csi-node-driver-registrar
   sourceRepository: github.com/kubernetes-csi/node-driver-registrar
-  repository: quay.io/k8scsi/csi-node-driver-registrar
-  tag: "v2.0.0"
+  repository: k8s.gcr.io/sig-storage/csi-node-driver-registrar
+  tag: "v2.0.1"
 - name: csi-liveness-probe
   sourceRepository: github.com/kubernetes-csi/livenessprobe
-  repository: quay.io/k8scsi/livenessprobe
+  repository: k8s.gcr.io/sig-storage/livenessprobe
   tag: "v2.1.0"

--- a/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/deployment-csi-driver-controller.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/deployment-csi-driver-controller.yaml
@@ -43,7 +43,7 @@ spec:
         - --endpoint=$(CSI_ENDPOINT)
         - --cloud-config=/etc/kubernetes/cloudprovider/cloudprovider.conf
         - --cluster={{ .Release.Namespace }}
-        - --v=5
+        - --v=3
         env:
         - name: CSI_ENDPOINT
           value: unix://{{ .Values.socketPath }}/csi.sock


### PR DESCRIPTION
/area storage
/kind enhancement
/priority normal
/platform openstack

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```dependency user
The following images are updated:
- docker.io/k8scloudprovider/cinder-csi-plugin: v1.18.0 -> v1.19.0
- k8s.gcr.io/sig-storage/csi-provisioner: v2.0.0 -> v2.0.4
- k8s.gcr.io/sig-storage/csi-attacher: v3.0.0 -> v3.0.2
- k8s.gcr.io/sig-storage/csi-node-driver-registrar: v2.0.0 -> v2.0.1
```
