### PR TITLE
Fix occm version for Kubernetes >= 1.18

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -12,7 +12,7 @@ images:
   sourceRepository: github.com/kubernetes/cloud-provider-openstack
   repository: k8scloudprovider/openstack-cloud-controller-manager
   tag: "v1.17.0"
-  targetVersion: ">= 1.15"
+  targetVersion: ">= 1.15, < 1.18"
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes/cloud-provider-openstack
   repository: k8scloudprovider/openstack-cloud-controller-manager


### PR DESCRIPTION
/kind bug
/priority normal
/platform openstack

Similarly to https://github.com/gardener/gardener-extension-provider-alicloud/issues/208, currently provider-openstack will deploy occm@v1.17 even for Kubernetes >= 1.18.

https://github.com/gardener/gardener-extension-provider-openstack/blob/97f277aca370214636f21a41ee4624262a5f69d3/charts/images.yaml#L11-L20

Currently for a v1.19 cluster, the deployed occm version is v1.17.0:

```
$ k -n shoot--foo--bar get po cloud-controller-manager-b5f86b65f-5lzcr -o yaml | grep image
    image: k8scloudprovider/openstack-cloud-controller-manager:v1.17.0
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
An issue causing provider-openstack to deploy wrong version of the cloud-controller-manager for Kubernetes >= 1.18 clusters is now fixed.
```
