### PR TITLE
[release-v1.14] get missing auth_aul from cloudprofile

### DIFF
--- a/pkg/controller/worker/actuator.go
+++ b/pkg/controller/worker/actuator.go
@@ -76,7 +76,17 @@ func (d *delegateFactory) WorkerDelegate(ctx context.Context, worker *extensions
 		return nil, err
 	}
 
-	openstackClient, err := client.NewOpenStackClientFromSecretRef(ctx, d.Client(), worker.Spec.SecretRef)
+	cloudProfileConfig, err := helper.CloudProfileConfigFromCluster(cluster)
+	if err != nil {
+		return nil, err
+	}
+
+	keyStoneURL, err := helper.FindKeyStoneURL(cloudProfileConfig.KeyStoneURLs, cloudProfileConfig.KeyStoneURL, worker.Spec.Region)
+	if err != nil {
+		return nil, err
+	}
+
+	openstackClient, err := client.NewOpenStackClientFromSecretRef(ctx, d.Client(), worker.Spec.SecretRef, &keyStoneURL)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create openstack client")
 	}

--- a/pkg/openstack/client/client.go
+++ b/pkg/openstack/client/client.go
@@ -18,6 +18,7 @@ package client
 
 import (
 	"context"
+	"strings"
 
 	os "github.com/gardener/gardener-extension-provider-openstack/pkg/openstack"
 	"github.com/gophercloud/gophercloud"
@@ -61,12 +62,15 @@ func NewOpenstackClientFromCredentials(credentials *os.Credentials) (Factory, er
 
 // NewOpenStackClientFromSecretRef returns a Factory implementation that can be used to create clients for OpenStack services.
 // The credentials are fetched from the Kubernetes secret referenced by <secretRef>.
-func NewOpenStackClientFromSecretRef(ctx context.Context, c client.Client, secretRef corev1.SecretReference) (Factory, error) {
+func NewOpenStackClientFromSecretRef(ctx context.Context, c client.Client, secretRef corev1.SecretReference, keyStoneUrl *string) (Factory, error) {
 	creds, err := os.GetCredentials(ctx, c, secretRef)
 	if err != nil {
 		return nil, err
 	}
 
+	if len(strings.TrimSpace(creds.AuthURL)) == 0 && keyStoneUrl != nil {
+		creds.AuthURL = *keyStoneUrl
+	}
 	return NewOpenstackClientFromCredentials(creds)
 }
 

--- a/pkg/openstack/client/swift.go
+++ b/pkg/openstack/client/swift.go
@@ -27,7 +27,7 @@ import (
 
 // NewStorageClientFromSecretRef retrieves the openstack client from specified by the secret reference.
 func NewStorageClientFromSecretRef(ctx context.Context, c client.Client, secretRef corev1.SecretReference, region string) (Storage, error) {
-	base, err := NewOpenStackClientFromSecretRef(ctx, c, secretRef)
+	base, err := NewOpenStackClientFromSecretRef(ctx, c, secretRef, nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/priority normal
/platform openstack

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fix a bug, where a missing "auth_url" field from the credentials secret would block the creation of a shoot. In case this field is now missing from the provided credentials, the auth_url is taken from the `CloudProfile` used instead.
```
