### PR TITLE
Use occm@v1.19 for Kubernetes >= 1.19

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -16,8 +16,13 @@ images:
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes/cloud-provider-openstack
   repository: k8scloudprovider/openstack-cloud-controller-manager
-  tag: "v1.18.0"
-  targetVersion: ">= 1.18"
+  tag: "v1.18.2"
+  targetVersion: "1.18.x"
+- name: cloud-controller-manager
+  sourceRepository: github.com/kubernetes/cloud-provider-openstack
+  repository: k8scloudprovider/openstack-cloud-controller-manager
+  tag: "v1.19.2"
+  targetVersion: ">= 1.19"
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager


### PR DESCRIPTION
/priority normal
/platform openstack

Fixes #148

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
provider-openstack is now using openstack cloud-controller-manager@v1.19 for Kubernetes >= 1.19 clusters.
```
