### PR TITLE
Add cloudprovider webhook to add auth_url from cloudprofile

### DIFF
--- a/pkg/cmd/options.go
+++ b/pkg/cmd/options.go
@@ -22,6 +22,7 @@ import (
 	healthcheckcontroller "github.com/gardener/gardener-extension-provider-openstack/pkg/controller/healthcheck"
 	infrastructurecontroller "github.com/gardener/gardener-extension-provider-openstack/pkg/controller/infrastructure"
 	workercontroller "github.com/gardener/gardener-extension-provider-openstack/pkg/controller/worker"
+	cloudproviderwebhook "github.com/gardener/gardener-extension-provider-openstack/pkg/webhook/cloudprovider"
 	controlplanewebhook "github.com/gardener/gardener-extension-provider-openstack/pkg/webhook/controlplane"
 	controlplaneexposurewebhook "github.com/gardener/gardener-extension-provider-openstack/pkg/webhook/controlplaneexposure"
 
@@ -33,6 +34,7 @@ import (
 	extensionshealthcheckcontroller "github.com/gardener/gardener/extensions/pkg/controller/healthcheck"
 	extensionsinfrastructurecontroller "github.com/gardener/gardener/extensions/pkg/controller/infrastructure"
 	extensionsworkercontroller "github.com/gardener/gardener/extensions/pkg/controller/worker"
+	extensionscloudproviderwebhook "github.com/gardener/gardener/extensions/pkg/webhook/cloudprovider"
 	webhookcmd "github.com/gardener/gardener/extensions/pkg/webhook/cmd"
 	extensioncontrolplanewebhook "github.com/gardener/gardener/extensions/pkg/webhook/controlplane"
 )
@@ -55,5 +57,6 @@ func WebhookSwitchOptions() *webhookcmd.SwitchOptions {
 	return webhookcmd.NewSwitchOptions(
 		webhookcmd.Switch(extensioncontrolplanewebhook.WebhookName, controlplanewebhook.AddToManager),
 		webhookcmd.Switch(extensioncontrolplanewebhook.ExposureWebhookName, controlplaneexposurewebhook.AddToManager),
+		webhookcmd.Switch(extensionscloudproviderwebhook.WebhookName, cloudproviderwebhook.AddToManager),
 	)
 }

--- a/pkg/webhook/cloudprovider/add.go
+++ b/pkg/webhook/cloudprovider/add.go
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cloudprovider
+
+import(
+	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
+	"github.com/gardener/gardener/extensions/pkg/webhook/cloudprovider"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"github.com/gardener/gardener-extension-provider-openstack/pkg/openstack"
+)
+
+var logger = log.Log.WithName("openstack-cloudprovider-webhook")
+
+func AddToManager(mgr manager.Manager) (*extensionswebhook.Webhook, error){
+	logger.Info("adding webhook to manager")
+	return cloudprovider.New(mgr, cloudprovider.Args{
+		Provider: openstack.Type,
+		Mutator:  cloudprovider.NewMutator(logger, NewEnsurer(logger)),
+	})
+}

--- a/pkg/webhook/cloudprovider/add.go
+++ b/pkg/webhook/cloudprovider/add.go
@@ -1,33 +1,32 @@
-/*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package cloudprovider
 
-import(
+import (
+	"github.com/gardener/gardener-extension-provider-openstack/pkg/openstack"
+
 	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
 	"github.com/gardener/gardener/extensions/pkg/webhook/cloudprovider"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
-
-	"github.com/gardener/gardener-extension-provider-openstack/pkg/openstack"
 )
 
 var logger = log.Log.WithName("openstack-cloudprovider-webhook")
 
-func AddToManager(mgr manager.Manager) (*extensionswebhook.Webhook, error){
+// AddToManager creates the cloudprovider webhook and adds it to the manager.
+func AddToManager(mgr manager.Manager) (*extensionswebhook.Webhook, error) {
 	logger.Info("adding webhook to manager")
 	return cloudprovider.New(mgr, cloudprovider.Args{
 		Provider: openstack.Type,

--- a/pkg/webhook/cloudprovider/ensurer.go
+++ b/pkg/webhook/cloudprovider/ensurer.go
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cloudprovider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gardener/gardener/extensions/pkg/webhook/cloudprovider"
+	"github.com/gardener/gardener/extensions/pkg/webhook/controlplane/genericmutator"
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+
+	"github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack"
+	"github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack/helper"
+)
+
+const(
+	authUrlKey = "auth_url"
+)
+
+func NewEnsurer(logger logr.Logger) cloudprovider.Ensurer{
+	return &ensurer{
+		logger: logger,
+	}
+}
+
+type ensurer struct{
+	logger logr.Logger
+	decoder runtime.Decoder
+}
+
+func (e *ensurer) InjectScheme(scheme *runtime.Scheme) error {
+	e.decoder = serializer.NewCodecFactory(scheme).UniversalDecoder()
+	return nil
+}
+
+func (e *ensurer) EnsureCloudproviderSecret(
+	ctx context.Context,
+	ectx genericmutator.EnsurerContext,
+	new, _ *corev1.Secret,
+) error {
+	cluster, err := ectx.GetCluster(ctx)
+	if err != nil {
+		return err
+	}
+
+	cloudProfileConfig := &openstack.CloudProfileConfig{}
+	if _ , _, err := e.decoder.Decode(cluster.CloudProfile.Spec.ProviderConfig.Raw, nil, cloudProfileConfig); err != nil {
+		return err
+	}
+
+	keyStoneURL, err := helper.FindKeyStoneURL(cloudProfileConfig.KeyStoneURLs, cloudProfileConfig.KeyStoneURL, cluster.Shoot.Spec.Region)
+	if err != nil {
+		return fmt.Errorf("could not find KeyStoneUrl: %v", err)
+	}
+	new.Data[authUrlKey] = []byte(keyStoneURL)
+	return nil
+}
+
+
+

--- a/pkg/webhook/cloudprovider/ensurer.go
+++ b/pkg/webhook/cloudprovider/ensurer.go
@@ -1,18 +1,16 @@
-/*
- * Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package cloudprovider
 
@@ -20,29 +18,30 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack"
+	"github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack/helper"
+
 	"github.com/gardener/gardener/extensions/pkg/webhook/cloudprovider"
-	"github.com/gardener/gardener/extensions/pkg/webhook/controlplane/genericmutator"
+	gcontext "github.com/gardener/gardener/extensions/pkg/webhook/context"
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
-
-	"github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack"
-	"github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack/helper"
 )
 
-const(
+const (
 	authUrlKey = "auth_url"
 )
 
-func NewEnsurer(logger logr.Logger) cloudprovider.Ensurer{
+// NewEnsurer creates cloudprovider ensurer.
+func NewEnsurer(logger logr.Logger) cloudprovider.Ensurer {
 	return &ensurer{
 		logger: logger,
 	}
 }
 
-type ensurer struct{
-	logger logr.Logger
+type ensurer struct {
+	logger  logr.Logger
 	decoder runtime.Decoder
 }
 
@@ -53,7 +52,7 @@ func (e *ensurer) InjectScheme(scheme *runtime.Scheme) error {
 
 func (e *ensurer) EnsureCloudProviderSecret(
 	ctx context.Context,
-	ectx genericmutator.EnsurerContext,
+	ectx gcontext.GardenContext,
 	new, _ *corev1.Secret,
 ) error {
 	cluster, err := ectx.GetCluster(ctx)
@@ -71,7 +70,7 @@ func (e *ensurer) EnsureCloudProviderSecret(
 	if err != nil {
 		return fmt.Errorf("could not decode cluster object's providerConfig: %v", err)
 	}
-	if _ , _, err := e.decoder.Decode(raw, nil, config); err != nil {
+	if _, _, err := e.decoder.Decode(raw, nil, config); err != nil {
 		return fmt.Errorf("could not decode cluster object's providerConfig: %v", err)
 	}
 
@@ -86,6 +85,3 @@ func (e *ensurer) EnsureCloudProviderSecret(
 	new.Data[authUrlKey] = []byte(keyStoneURL)
 	return nil
 }
-
-
-

--- a/pkg/webhook/cloudprovider/ensurer_test.go
+++ b/pkg/webhook/cloudprovider/ensurer_test.go
@@ -1,3 +1,17 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package cloudprovider
 
 import (
@@ -6,9 +20,10 @@ import (
 
 	"github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack/install"
 	openstackv1alpha1 "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack/v1alpha1"
+
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
 	"github.com/gardener/gardener/extensions/pkg/webhook/cloudprovider"
-	"github.com/gardener/gardener/extensions/pkg/webhook/controlplane/genericmutator"
+	gcontext "github.com/gardener/gardener/extensions/pkg/webhook/context"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -26,7 +41,7 @@ func TestController(t *testing.T) {
 var _ = Describe("Ensurer", func() {
 	var (
 		ctx     = context.TODO()
-		ectx    genericmutator.EnsurerContext
+		ectx    gcontext.GardenContext
 		ensurer cloudprovider.Ensurer
 		scheme  *runtime.Scheme
 
@@ -37,7 +52,7 @@ var _ = Describe("Ensurer", func() {
 		scheme = runtime.NewScheme()
 		install.Install(scheme)
 
-		ectx = genericmutator.NewInternalEnsurerContext(
+		ectx = gcontext.NewInternalGardenContext(
 			&extensionscontroller.Cluster{
 				CloudProfile: &gardencorev1beta1.CloudProfile{
 					TypeMeta: metav1.TypeMeta{
@@ -77,7 +92,7 @@ var _ = Describe("Ensurer", func() {
 		var (
 			new = &corev1.Secret{}
 		)
-		ectx := genericmutator.NewInternalEnsurerContext(
+		ectx := gcontext.NewInternalGardenContext(
 			&extensionscontroller.Cluster{
 				CloudProfile: &gardencorev1beta1.CloudProfile{
 					Spec: gardencorev1beta1.CloudProfileSpec{

--- a/pkg/webhook/cloudprovider/ensurer_test.go
+++ b/pkg/webhook/cloudprovider/ensurer_test.go
@@ -1,0 +1,95 @@
+package cloudprovider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack/install"
+	openstackv1alpha1 "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack/v1alpha1"
+	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
+	"github.com/gardener/gardener/extensions/pkg/webhook/cloudprovider"
+	"github.com/gardener/gardener/extensions/pkg/webhook/controlplane/genericmutator"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
+)
+
+func TestController(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "CloudProvider Webhook Suite")
+}
+
+var _ = Describe("Ensurer", func() {
+	var (
+		ctx     = context.TODO()
+		ectx    genericmutator.EnsurerContext
+		ensurer cloudprovider.Ensurer
+		scheme  *runtime.Scheme
+
+		authUrl = "foo://bar"
+	)
+
+	BeforeEach(func() {
+		scheme = runtime.NewScheme()
+		install.Install(scheme)
+
+		ectx = genericmutator.NewInternalEnsurerContext(
+			&extensionscontroller.Cluster{
+				CloudProfile: &gardencorev1beta1.CloudProfile{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: gardencorev1beta1.GroupName,
+						Kind:       "CloudProfile",
+					},
+					Spec: gardencorev1beta1.CloudProfileSpec{
+						ProviderConfig: &runtime.RawExtension{
+							Object: &openstackv1alpha1.CloudProfileConfig{
+								TypeMeta: metav1.TypeMeta{
+									Kind:       "CloudProfileConfig",
+									APIVersion: openstackv1alpha1.SchemeGroupVersion.String(),
+								},
+								KeyStoneURL: authUrl,
+							},
+						},
+					},
+				},
+				Shoot: &gardencorev1beta1.Shoot{},
+			},
+		)
+		ensurer = NewEnsurer(logger)
+		err := ensurer.(inject.Scheme).InjectScheme(scheme)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("Should ensure auth_url if present in cluster object", func() {
+		var (
+			new = &corev1.Secret{}
+		)
+		err := ensurer.EnsureCloudProviderSecret(ctx, ectx, new, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(new.Data[authUrlKey])).To(Equal(authUrl))
+	})
+
+	It("Should return an error if no authURL is found", func() {
+		var (
+			new = &corev1.Secret{}
+		)
+		ectx := genericmutator.NewInternalEnsurerContext(
+			&extensionscontroller.Cluster{
+				CloudProfile: &gardencorev1beta1.CloudProfile{
+					Spec: gardencorev1beta1.CloudProfileSpec{
+						ProviderConfig: &runtime.RawExtension{
+							Object: &openstackv1alpha1.CloudProfileConfig{},
+						},
+					},
+				},
+				Shoot: &gardencorev1beta1.Shoot{},
+			},
+		)
+		err := ensurer.EnsureCloudProviderSecret(ctx, ectx, new, nil)
+		Expect(err).To(HaveOccurred())
+	})
+})

--- a/vendor/github.com/gardener/gardener/extensions/pkg/webhook/cloudprovider/cloudprovider.go
+++ b/vendor/github.com/gardener/gardener/extensions/pkg/webhook/cloudprovider/cloudprovider.go
@@ -1,0 +1,79 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cloudprovider
+
+import (
+	"github.com/gardener/gardener/extensions/pkg/webhook"
+	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+const (
+	// WebhookName is the name of the webhook.
+	WebhookName = "cloudprovider"
+)
+
+var (
+	logger = log.Log.WithName("cloudprovider-webhook")
+)
+
+// Args are the requirements to create a cloudprovider webhook.
+type Args struct {
+	Provider string
+	Mutator  webhook.Mutator
+}
+
+// New creates a new cloudprovider webhook.
+func New(mgr manager.Manager, args Args) (*webhook.Webhook, error) {
+	logger := logger.WithValues("cloud-provider", args.Provider)
+
+	types := []runtime.Object{&corev1.Secret{}}
+	handler, err := webhook.NewBuilder(mgr, logger).WithMutator(args.Mutator, types...).Build()
+	if err != nil {
+		return nil, err
+	}
+
+	namespaceSelector := buildSelector(args.Provider)
+	logger.Info("Creating webhook")
+
+	return &extensionswebhook.Webhook{
+		Name:     WebhookName,
+		Target:   extensionswebhook.TargetSeed,
+		Provider: args.Provider,
+		Types:    types,
+		Webhook:  &admission.Webhook{Handler: handler},
+		Path:     WebhookName,
+		Selector: namespaceSelector,
+	}, nil
+}
+
+func buildSelector(provider string) *metav1.LabelSelector {
+	return &metav1.LabelSelector{
+		MatchExpressions: []metav1.LabelSelectorRequirement{
+			{
+				Key:      v1beta1constants.LabelShootProvider,
+				Operator: metav1.LabelSelectorOpIn,
+				Values:   []string{provider},
+			},
+		},
+	}
+}

--- a/vendor/github.com/gardener/gardener/extensions/pkg/webhook/cloudprovider/mutator.go
+++ b/vendor/github.com/gardener/gardener/extensions/pkg/webhook/cloudprovider/mutator.go
@@ -1,0 +1,104 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cloudprovider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gardener/gardener/extensions/pkg/webhook"
+	gcontext "github.com/gardener/gardener/extensions/pkg/webhook/context"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
+)
+
+// Ensurer ensures that the cloudprovider secret conforms to the provider requirements.
+type Ensurer interface {
+	EnsureCloudProviderSecret(ctx context.Context, gctx gcontext.GardenContext, new, old *corev1.Secret) error
+}
+
+// NewMutator creates a new cloudprovider mutator.
+func NewMutator(logger logr.Logger, ensurer Ensurer) webhook.Mutator {
+	return &mutator{
+		logger:  logger.WithName("mutator"),
+		ensurer: ensurer,
+	}
+}
+
+type mutator struct {
+	client  client.Client
+	logger  logr.Logger
+	ensurer Ensurer
+}
+
+// InjectClient injects the client into the ensurer.
+func (m *mutator) InjectClient(client client.Client) error {
+	m.client = client
+	if _, err := inject.ClientInto(client, m.ensurer); err != nil {
+		return fmt.Errorf("could not inject the client into the ensurer: %v", err)
+	}
+	return nil
+}
+
+// InjectScheme injects the manager's scheme into the ensurer.
+func (m *mutator) InjectScheme(scheme *runtime.Scheme) error {
+	if _, err := inject.SchemeInto(scheme, m.ensurer); err != nil {
+		return fmt.Errorf("could not inject scheme into the ensurer: %v", err)
+	}
+	return nil
+}
+
+// Mutate validates and if needed mutates the given object.
+func (m *mutator) Mutate(ctx context.Context, new, old runtime.Object) error {
+	acc, err := meta.Accessor(new)
+	if err != nil {
+		return fmt.Errorf("could not create accessor during webhook: %v", err)
+	}
+
+	if acc.GetDeletionTimestamp() != nil {
+		return nil
+	}
+
+	newSecret, ok := new.(*corev1.Secret)
+	if !ok {
+		return fmt.Errorf("could not mutate: object is not of type %q", "Secret")
+	}
+	if newSecret.Name != v1beta1constants.SecretNameCloudProvider {
+		return nil
+	}
+
+	var oldSecret *corev1.Secret
+	if old != nil {
+		oldSecret, ok = old.(*corev1.Secret)
+		if !ok {
+			return fmt.Errorf("could not mutate: old object could not be casted to type %q", "Secret")
+		}
+	}
+
+	o, ok := new.(metav1.Object)
+	if !ok {
+		return fmt.Errorf("could not cast runtime object to %q", "metav1.Object")
+	}
+	etcx := gcontext.NewGardenContext(m.client, o)
+	webhook.LogMutation(m.logger, newSecret.Kind, newSecret.Namespace, newSecret.Name)
+	return m.ensurer.EnsureCloudProviderSecret(ctx, etcx, newSecret, oldSecret)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -82,6 +82,7 @@ github.com/gardener/gardener/extensions/pkg/predicate
 github.com/gardener/gardener/extensions/pkg/terraformer
 github.com/gardener/gardener/extensions/pkg/util
 github.com/gardener/gardener/extensions/pkg/webhook
+github.com/gardener/gardener/extensions/pkg/webhook/cloudprovider
 github.com/gardener/gardener/extensions/pkg/webhook/cmd
 github.com/gardener/gardener/extensions/pkg/webhook/context
 github.com/gardener/gardener/extensions/pkg/webhook/controlplane


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement
/priority normal
/platform openstack

**What this PR does / why we need it**:
Implements a webhook that will add the `auth_url` field found in the `cloudprofile` to the `cloudprovider` secret. 

`auth_url` is necessary to initiate a client for the provider API but `auth_url` - currently - can exists in two places:
+ in the cloudprofile.
+ in the cloudprovider secret.

The problem that we try to solve with this PR are:
a) we want the MCM's `machineclasses` to use directly the cloudprovider secret. Since `auth_url` could be missing and MCM does not have access to the cloudprofile, the change wouldn't work.
b) prepare for issue #197, without breaking backwards compatibility with MCM's `OpenstackMachineClass`. With this change the `auth_url` in the `cloudprovider` secret will always be overwritten by the value from the `CloudProfile`. 

**Which issue(s) this PR fixes**:
Preparation for #197 

**Special notes for your reviewer**:
Depends on https://github.com/gardener/gardener/pull/3348 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
