### PR TITLE
Only validate infra/controlPlane config against CloudProfile on change

### DIFF
--- a/pkg/apis/openstack/validation/controlplane_test.go
+++ b/pkg/apis/openstack/validation/controlplane_test.go
@@ -115,7 +115,7 @@ var _ = Describe("ControlPlaneConfig validation", func() {
 		It("should require a name of a load balancer provider that is part of the constraints", func() {
 			controlPlane.LoadBalancerProvider = "bar"
 
-			errorList := ValidateControlPlaneConfigAgainstCloudProfile(controlPlane, domain, region, floatingPool, cloudProfileConfig, nilPath)
+			errorList := ValidateControlPlaneConfigAgainstCloudProfile(nil, controlPlane, domain, region, floatingPool, cloudProfileConfig, nilPath)
 
 			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":  Equal(field.ErrorTypeNotSupported),
@@ -147,7 +147,7 @@ var _ = Describe("ControlPlaneConfig validation", func() {
 			}
 			controlPlane.LoadBalancerProvider = lbProvider1
 
-			errorList := ValidateControlPlaneConfigAgainstCloudProfile(controlPlane, domain, differentRegion, "", cloudProfileConfig, nilPath)
+			errorList := ValidateControlPlaneConfigAgainstCloudProfile(nil, controlPlane, domain, differentRegion, "", cloudProfileConfig, nilPath)
 
 			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":  Equal(field.ErrorTypeNotSupported),
@@ -180,7 +180,7 @@ var _ = Describe("ControlPlaneConfig validation", func() {
 			}
 			controlPlane.LoadBalancerProvider = lbProvider1
 
-			errorList := ValidateControlPlaneConfigAgainstCloudProfile(controlPlane, domain, region, floatingPool, cloudProfileConfig, nilPath)
+			errorList := ValidateControlPlaneConfigAgainstCloudProfile(nil, controlPlane, domain, region, floatingPool, cloudProfileConfig, nilPath)
 
 			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":  Equal(field.ErrorTypeNotSupported),
@@ -213,7 +213,7 @@ var _ = Describe("ControlPlaneConfig validation", func() {
 			}
 			controlPlane.LoadBalancerProvider = lbProvider2
 
-			errorList := ValidateControlPlaneConfigAgainstCloudProfile(controlPlane, domain, differentRegion, "", cloudProfileConfig, nilPath)
+			errorList := ValidateControlPlaneConfigAgainstCloudProfile(nil, controlPlane, domain, differentRegion, "", cloudProfileConfig, nilPath)
 
 			Expect(errorList).To(BeEmpty())
 		})
@@ -221,7 +221,7 @@ var _ = Describe("ControlPlaneConfig validation", func() {
 		It("should pass because no load balancer class is configured in cloud profile", func() {
 			cloudProfileConfig.Constraints.FloatingPools[0].LoadBalancerClasses = nil
 
-			errorList := ValidateControlPlaneConfigAgainstCloudProfile(controlPlane, domain, region, floatingPool, cloudProfileConfig, nilPath)
+			errorList := ValidateControlPlaneConfigAgainstCloudProfile(nil, controlPlane, domain, region, floatingPool, cloudProfileConfig, nilPath)
 
 			Expect(errorList).To(BeEmpty())
 		})
@@ -229,7 +229,7 @@ var _ = Describe("ControlPlaneConfig validation", func() {
 		It("should pass because load balancer class is configured correctly in control plane", func() {
 			controlPlane.LoadBalancerClasses = []api.LoadBalancerClass{loadBalancerClass}
 
-			errorList := ValidateControlPlaneConfigAgainstCloudProfile(controlPlane, domain, region, floatingPool, cloudProfileConfig, nilPath)
+			errorList := ValidateControlPlaneConfigAgainstCloudProfile(nil, controlPlane, domain, region, floatingPool, cloudProfileConfig, nilPath)
 
 			Expect(errorList).To(BeEmpty())
 		})
@@ -248,7 +248,7 @@ var _ = Describe("ControlPlaneConfig validation", func() {
 
 			controlPlane.LoadBalancerClasses = []api.LoadBalancerClass{lbClasses[1], lbClasses[0]}
 
-			errorList := ValidateControlPlaneConfigAgainstCloudProfile(controlPlane, domain, region, floatingPool, cloudProfileConfig, nilPath)
+			errorList := ValidateControlPlaneConfigAgainstCloudProfile(nil, controlPlane, domain, region, floatingPool, cloudProfileConfig, nilPath)
 
 			Expect(errorList).To(ConsistOf(
 				PointTo(MatchFields(IgnoreExtras, Fields{
@@ -287,7 +287,7 @@ var _ = Describe("ControlPlaneConfig validation", func() {
 
 			controlPlane.LoadBalancerClasses = []api.LoadBalancerClass{lbClasses[1]}
 
-			errorList := ValidateControlPlaneConfigAgainstCloudProfile(controlPlane, domain, differentRegion, fpName, cloudProfileConfig, nilPath)
+			errorList := ValidateControlPlaneConfigAgainstCloudProfile(nil, controlPlane, domain, differentRegion, fpName, cloudProfileConfig, nilPath)
 
 			Expect(errorList).To(BeEmpty())
 		})
@@ -308,7 +308,7 @@ var _ = Describe("ControlPlaneConfig validation", func() {
 
 			controlPlane.LoadBalancerClasses = []api.LoadBalancerClass{lbClasses[1]}
 
-			errorList := ValidateControlPlaneConfigAgainstCloudProfile(controlPlane, domain, region, fpName, cloudProfileConfig, nilPath)
+			errorList := ValidateControlPlaneConfigAgainstCloudProfile(nil, controlPlane, domain, region, fpName, cloudProfileConfig, nilPath)
 
 			Expect(errorList).To(BeEmpty())
 		})
@@ -326,7 +326,7 @@ var _ = Describe("ControlPlaneConfig validation", func() {
 
 			controlPlane.LoadBalancerClasses = []api.LoadBalancerClass{lbClasses[0]}
 
-			errorList := ValidateControlPlaneConfigAgainstCloudProfile(controlPlane, domain, region, floatingPool, cloudProfileConfig, nilPath)
+			errorList := ValidateControlPlaneConfigAgainstCloudProfile(nil, controlPlane, domain, region, floatingPool, cloudProfileConfig, nilPath)
 
 			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":  Equal(field.ErrorTypeNotSupported),
@@ -348,7 +348,7 @@ var _ = Describe("ControlPlaneConfig validation", func() {
 
 			controlPlane.LoadBalancerClasses = append(controlPlane.LoadBalancerClasses, lbClasses[0])
 
-			errorList := ValidateControlPlaneConfigAgainstCloudProfile(controlPlane, domain, region, floatingPool, cloudProfileConfig, nilPath)
+			errorList := ValidateControlPlaneConfigAgainstCloudProfile(nil, controlPlane, domain, region, floatingPool, cloudProfileConfig, nilPath)
 
 			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":  Equal(field.ErrorTypeNotSupported),
@@ -377,9 +377,9 @@ var _ = Describe("ControlPlaneConfig validation", func() {
 
 			controlPlane.LoadBalancerClasses = append(controlPlane.LoadBalancerClasses, lbClasses[0])
 
-			errorList := ValidateControlPlaneConfigAgainstCloudProfile(controlPlane, domain, region, floatingPool, cloudProfileConfig, nilPath)
+			errorList := ValidateControlPlaneConfigAgainstCloudProfile(nil, controlPlane, domain, region, floatingPool, cloudProfileConfig, nilPath)
 			Expect(errorList).To(BeEmpty())
-			errorList = ValidateControlPlaneConfigAgainstCloudProfile(controlPlane, differentDomain, region, floatingPool, cloudProfileConfig, nilPath)
+			errorList = ValidateControlPlaneConfigAgainstCloudProfile(nil, controlPlane, differentDomain, region, floatingPool, cloudProfileConfig, nilPath)
 			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":  Equal(field.ErrorTypeNotSupported),
 				"Field": Equal("loadBalancerClasses[0]"),
@@ -390,7 +390,7 @@ var _ = Describe("ControlPlaneConfig validation", func() {
 			controlPlane.LoadBalancerClasses = []api.LoadBalancerClass{loadBalancerClass}
 			cloudProfileConfig.Constraints.FloatingPools = nil
 
-			errorList := ValidateControlPlaneConfigAgainstCloudProfile(controlPlane, domain, region, floatingPool, cloudProfileConfig, nilPath)
+			errorList := ValidateControlPlaneConfigAgainstCloudProfile(nil, controlPlane, domain, region, floatingPool, cloudProfileConfig, nilPath)
 
 			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":  Equal(field.ErrorTypeInvalid),
@@ -403,12 +403,31 @@ var _ = Describe("ControlPlaneConfig validation", func() {
 			lbClass.FloatingNetworkID = nil
 			controlPlane.LoadBalancerClasses = []api.LoadBalancerClass{lbClass}
 
-			errorList := ValidateControlPlaneConfigAgainstCloudProfile(controlPlane, domain, region, floatingPool, cloudProfileConfig, nilPath)
+			errorList := ValidateControlPlaneConfigAgainstCloudProfile(nil, controlPlane, domain, region, floatingPool, cloudProfileConfig, nilPath)
 
 			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":  Equal(field.ErrorTypeNotSupported),
 				"Field": Equal("loadBalancerClasses[0]"),
 			}))))
+		})
+
+		It("should not validate anything if the load balancer provider was not changed", func() {
+			controlPlane.LoadBalancerProvider = "does-for-sure-not-exist-in-cloudprofile"
+			oldControlPlane := controlPlane.DeepCopy()
+
+			errorList := ValidateControlPlaneConfigAgainstCloudProfile(oldControlPlane, controlPlane, domain, region, floatingPool, cloudProfileConfig, nilPath)
+			Expect(errorList).To(BeEmpty())
+		})
+
+		It("should not validate anything if the load balancer classes were not changed", func() {
+			loadBalancerClassNotInCloudProfile := loadBalancerClass.DeepCopy()
+			loadBalancerClassNotInCloudProfile.Name = "does-for-sure-not-exist-in-cloudprofile"
+
+			controlPlane.LoadBalancerClasses = []api.LoadBalancerClass{*loadBalancerClassNotInCloudProfile}
+			oldControlPlane := controlPlane.DeepCopy()
+
+			errorList := ValidateControlPlaneConfigAgainstCloudProfile(oldControlPlane, controlPlane, domain, region, floatingPool, cloudProfileConfig, nilPath)
+			Expect(errorList).To(BeEmpty())
 		})
 	})
 })

--- a/pkg/apis/openstack/validation/infrastructure.go
+++ b/pkg/apis/openstack/validation/infrastructure.go
@@ -82,10 +82,12 @@ func ValidateInfrastructureConfigUpdate(oldConfig, newConfig *api.Infrastructure
 }
 
 // ValidateInfrastructureConfigAgainstCloudProfile validates the given InfrastructureConfig against constraints in the given CloudProfile.
-func ValidateInfrastructureConfigAgainstCloudProfile(infra *api.InfrastructureConfig, domain, shootRegion string, cloudProfileConfig *api.CloudProfileConfig, fldPath *field.Path) field.ErrorList {
+func ValidateInfrastructureConfigAgainstCloudProfile(oldInfra, infra *api.InfrastructureConfig, domain, shootRegion string, cloudProfileConfig *api.CloudProfileConfig, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	allErrs = append(allErrs, validateFloatingPoolNameConstraints(cloudProfileConfig.Constraints.FloatingPools, domain, shootRegion, infra.FloatingPoolName, fldPath)...)
+	if oldInfra == nil || oldInfra.FloatingPoolName != infra.FloatingPoolName {
+		allErrs = append(allErrs, validateFloatingPoolNameConstraints(cloudProfileConfig.Constraints.FloatingPools, domain, shootRegion, infra.FloatingPoolName, fldPath)...)
+	}
 
 	return allErrs
 }

--- a/pkg/apis/openstack/validation/infrastructure_test.go
+++ b/pkg/apis/openstack/validation/infrastructure_test.go
@@ -182,7 +182,7 @@ var _ = Describe("InfrastructureConfig validation", func() {
 		It("should allow using a regional floating pool from the same region", func() {
 			infrastructureConfig.FloatingPoolName = floatingPoolName1
 
-			errorList := ValidateInfrastructureConfigAgainstCloudProfile(infrastructureConfig, domain, region, cloudProfileConfig, nilPath)
+			errorList := ValidateInfrastructureConfigAgainstCloudProfile(nil, infrastructureConfig, domain, region, cloudProfileConfig, nilPath)
 
 			Expect(errorList).To(BeEmpty())
 		})
@@ -191,7 +191,7 @@ var _ = Describe("InfrastructureConfig validation", func() {
 			cloudProfileConfig.Constraints.FloatingPools[0].Name = "*"
 			infrastructureConfig.FloatingPoolName = floatingPoolName1
 
-			errorList := ValidateInfrastructureConfigAgainstCloudProfile(infrastructureConfig, domain, region, cloudProfileConfig, nilPath)
+			errorList := ValidateInfrastructureConfigAgainstCloudProfile(nil, infrastructureConfig, domain, region, cloudProfileConfig, nilPath)
 
 			Expect(errorList).To(BeEmpty())
 		})
@@ -212,7 +212,7 @@ var _ = Describe("InfrastructureConfig validation", func() {
 			}
 			infrastructureConfig.FloatingPoolName = floatingPoolName1
 
-			errorList := ValidateInfrastructureConfigAgainstCloudProfile(infrastructureConfig, domain, differentRegion, cloudProfileConfig, nilPath)
+			errorList := ValidateInfrastructureConfigAgainstCloudProfile(nil, infrastructureConfig, domain, differentRegion, cloudProfileConfig, nilPath)
 
 			Expect(errorList).To(ConsistOfFields(Fields{
 				"Type":  Equal(field.ErrorTypeNotSupported),
@@ -226,7 +226,7 @@ var _ = Describe("InfrastructureConfig validation", func() {
 			}
 			infrastructureConfig.FloatingPoolName = floatingPoolName1
 
-			errorList := ValidateInfrastructureConfigAgainstCloudProfile(infrastructureConfig, domain, region, cloudProfileConfig, nilPath)
+			errorList := ValidateInfrastructureConfigAgainstCloudProfile(nil, infrastructureConfig, domain, region, cloudProfileConfig, nilPath)
 
 			Expect(errorList).To(ConsistOfFields(Fields{
 				"Type":  Equal(field.ErrorTypeNotSupported),
@@ -251,12 +251,12 @@ var _ = Describe("InfrastructureConfig validation", func() {
 			}
 			infrastructureConfig.FloatingPoolName = floatingPoolName2
 
-			errorList := ValidateInfrastructureConfigAgainstCloudProfile(infrastructureConfig, domain, region, cloudProfileConfig, nilPath)
+			errorList := ValidateInfrastructureConfigAgainstCloudProfile(nil, infrastructureConfig, domain, region, cloudProfileConfig, nilPath)
 			Expect(errorList).To(ConsistOfFields(Fields{
 				"Type":  Equal(field.ErrorTypeNotSupported),
 				"Field": Equal("floatingPoolName"),
 			}))
-			errorList = ValidateInfrastructureConfigAgainstCloudProfile(infrastructureConfig, domain, differentRegion, cloudProfileConfig, nilPath)
+			errorList = ValidateInfrastructureConfigAgainstCloudProfile(nil, infrastructureConfig, domain, differentRegion, cloudProfileConfig, nilPath)
 			Expect(errorList).To(BeEmpty())
 		})
 
@@ -279,16 +279,16 @@ var _ = Describe("InfrastructureConfig validation", func() {
 			}
 			infrastructureConfig.FloatingPoolName = floatingPoolName2
 
-			errorList := ValidateInfrastructureConfigAgainstCloudProfile(infrastructureConfig, domain, region, cloudProfileConfig, nilPath)
+			errorList := ValidateInfrastructureConfigAgainstCloudProfile(nil, infrastructureConfig, domain, region, cloudProfileConfig, nilPath)
 			Expect(errorList).To(ConsistOfFields(Fields{
 				"Type":  Equal(field.ErrorTypeNotSupported),
 				"Field": Equal("floatingPoolName"),
 			}))
-			errorList = ValidateInfrastructureConfigAgainstCloudProfile(infrastructureConfig, differentDomain, region, cloudProfileConfig, nilPath)
+			errorList = ValidateInfrastructureConfigAgainstCloudProfile(nil, infrastructureConfig, differentDomain, region, cloudProfileConfig, nilPath)
 			Expect(errorList).To(BeEmpty())
-			errorList = ValidateInfrastructureConfigAgainstCloudProfile(infrastructureConfig, differentDomain, differentRegion, cloudProfileConfig, nilPath)
+			errorList = ValidateInfrastructureConfigAgainstCloudProfile(nil, infrastructureConfig, differentDomain, differentRegion, cloudProfileConfig, nilPath)
 			Expect(errorList).To(BeEmpty())
-			errorList = ValidateInfrastructureConfigAgainstCloudProfile(infrastructureConfig, domain, differentRegion, cloudProfileConfig, nilPath)
+			errorList = ValidateInfrastructureConfigAgainstCloudProfile(nil, infrastructureConfig, domain, differentRegion, cloudProfileConfig, nilPath)
 			Expect(errorList).To(BeEmpty())
 		})
 
@@ -311,19 +311,19 @@ var _ = Describe("InfrastructureConfig validation", func() {
 			}
 			infrastructureConfig.FloatingPoolName = floatingPoolName1
 
-			errorList := ValidateInfrastructureConfigAgainstCloudProfile(infrastructureConfig, domain, region, cloudProfileConfig, nilPath)
+			errorList := ValidateInfrastructureConfigAgainstCloudProfile(nil, infrastructureConfig, domain, region, cloudProfileConfig, nilPath)
 			Expect(errorList).To(BeEmpty())
-			errorList = ValidateInfrastructureConfigAgainstCloudProfile(infrastructureConfig, differentDomain, region, cloudProfileConfig, nilPath)
+			errorList = ValidateInfrastructureConfigAgainstCloudProfile(nil, infrastructureConfig, differentDomain, region, cloudProfileConfig, nilPath)
 			Expect(errorList).To(ConsistOfFields(Fields{
 				"Type":  Equal(field.ErrorTypeNotSupported),
 				"Field": Equal("floatingPoolName"),
 			}))
-			errorList = ValidateInfrastructureConfigAgainstCloudProfile(infrastructureConfig, differentDomain, differentRegion, cloudProfileConfig, nilPath)
+			errorList = ValidateInfrastructureConfigAgainstCloudProfile(nil, infrastructureConfig, differentDomain, differentRegion, cloudProfileConfig, nilPath)
 			Expect(errorList).To(ConsistOfFields(Fields{
 				"Type":  Equal(field.ErrorTypeNotSupported),
 				"Field": Equal("floatingPoolName"),
 			}))
-			errorList = ValidateInfrastructureConfigAgainstCloudProfile(infrastructureConfig, domain, differentRegion, cloudProfileConfig, nilPath)
+			errorList = ValidateInfrastructureConfigAgainstCloudProfile(nil, infrastructureConfig, domain, differentRegion, cloudProfileConfig, nilPath)
 			Expect(errorList).To(ConsistOfFields(Fields{
 				"Type":  Equal(field.ErrorTypeNotSupported),
 				"Field": Equal("floatingPoolName"),
@@ -347,9 +347,9 @@ var _ = Describe("InfrastructureConfig validation", func() {
 			}
 			infrastructureConfig.FloatingPoolName = floatingPoolName1
 
-			errorList := ValidateInfrastructureConfigAgainstCloudProfile(infrastructureConfig, domain, region, cloudProfileConfig, nilPath)
+			errorList := ValidateInfrastructureConfigAgainstCloudProfile(nil, infrastructureConfig, domain, region, cloudProfileConfig, nilPath)
 			Expect(errorList).To(BeEmpty())
-			errorList = ValidateInfrastructureConfigAgainstCloudProfile(infrastructureConfig, differentDomain, region, cloudProfileConfig, nilPath)
+			errorList = ValidateInfrastructureConfigAgainstCloudProfile(nil, infrastructureConfig, differentDomain, region, cloudProfileConfig, nilPath)
 			Expect(errorList).To(ConsistOfFields(Fields{
 				"Type":  Equal(field.ErrorTypeNotSupported),
 				"Field": Equal("floatingPoolName"),
@@ -373,8 +373,16 @@ var _ = Describe("InfrastructureConfig validation", func() {
 			}
 			infrastructureConfig.FloatingPoolName = someFloatingPool
 
-			errorList := ValidateInfrastructureConfigAgainstCloudProfile(infrastructureConfig, domain, differentRegion, cloudProfileConfig, nilPath)
+			errorList := ValidateInfrastructureConfigAgainstCloudProfile(nil, infrastructureConfig, domain, differentRegion, cloudProfileConfig, nilPath)
 
+			Expect(errorList).To(BeEmpty())
+		})
+
+		It("should not validate anything if the floating pool name was not changed", func() {
+			infrastructureConfig.FloatingPoolName = "does-for-sure-not-exist-in-cloudprofile"
+			oldInfrastructureConfig := infrastructureConfig.DeepCopy()
+
+			errorList := ValidateInfrastructureConfigAgainstCloudProfile(oldInfrastructureConfig, infrastructureConfig, domain, region, cloudProfileConfig, nilPath)
 			Expect(errorList).To(BeEmpty())
 		})
 	})

--- a/pkg/validator/serialization.go
+++ b/pkg/validator/serialization.go
@@ -16,13 +16,12 @@ package validator
 
 import (
 	"github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack"
-	"github.com/gardener/gardener/extensions/pkg/util"
 
+	"github.com/gardener/gardener/extensions/pkg/util"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
-func decodeControlPlaneConfig(decoder runtime.Decoder, cp *runtime.RawExtension, fldPath *field.Path) (*openstack.ControlPlaneConfig, error) {
+func decodeControlPlaneConfig(decoder runtime.Decoder, cp *runtime.RawExtension) (*openstack.ControlPlaneConfig, error) {
 	controlPlaneConfig := &openstack.ControlPlaneConfig{}
 	if err := util.Decode(decoder, cp.Raw, controlPlaneConfig); err != nil {
 		return nil, err
@@ -31,7 +30,7 @@ func decodeControlPlaneConfig(decoder runtime.Decoder, cp *runtime.RawExtension,
 	return controlPlaneConfig, nil
 }
 
-func decodeInfrastructureConfig(decoder runtime.Decoder, infra *runtime.RawExtension, fldPath *field.Path) (*openstack.InfrastructureConfig, error) {
+func decodeInfrastructureConfig(decoder runtime.Decoder, infra *runtime.RawExtension) (*openstack.InfrastructureConfig, error) {
 	infraConfig := &openstack.InfrastructureConfig{}
 	if err := util.Decode(decoder, infra.Raw, infraConfig); err != nil {
 		return nil, err
@@ -40,7 +39,7 @@ func decodeInfrastructureConfig(decoder runtime.Decoder, infra *runtime.RawExten
 	return infraConfig, nil
 }
 
-func decodeCloudProfileConfig(decoder runtime.Decoder, config *runtime.RawExtension, fldPath *field.Path) (*openstack.CloudProfileConfig, error) {
+func decodeCloudProfileConfig(decoder runtime.Decoder, config *runtime.RawExtension) (*openstack.CloudProfileConfig, error) {
 	cloudProfileConfig := &openstack.CloudProfileConfig{}
 	if err := util.Decode(decoder, config.Raw, cloudProfileConfig); err != nil {
 		return nil, err


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement
/priority normal
/platform openstack

**What this PR does / why we need it**:
Now we only validate the `.spec.provider.{infrastructure,controlPlane}Config` values against the constraints defined in the `CloudProfile` if the values in the shoot were changed during an update. This is to ensure that constraints can be removed from the `CloudProfile` without breaking updates to `Shoot` resources.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
The validator does now only validate the `.spec.provider.{infrastructure,controlPlane}Config` values of a `Shoot` against the constraints in the `CloudProfile` if the values were changed during a `Shoot` update.
```
