### PR TITLE
Use cinder-csi-plugin@v1.20.0 for Kubernetes >= 1.20

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -32,6 +32,12 @@ images:
   sourceRepository: github.com/kubernetes/cloud-provider-openstack
   repository: docker.io/k8scloudprovider/cinder-csi-plugin
   tag: "v1.19.0"
+  targetVersion: "1.19.x"
+- name: csi-driver-cinder
+  sourceRepository: github.com/kubernetes/cloud-provider-openstack
+  repository: docker.io/k8scloudprovider/cinder-csi-plugin
+  tag: "v1.20.0"
+  targetVersion: ">= 1.20"
 - name: csi-provisioner
   sourceRepository: github.com/kubernetes-csi/external-provisioner
   repository: k8s.gcr.io/sig-storage/csi-provisioner


### PR DESCRIPTION
/area storage
/platform openstack

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
provider-openstack is now using cinder-csi-plugin@v1.20 for Kubernetes >= 1.20 clusters.
```
