### PR TITLE
update machineclasses to use cloudprovider secret

### DIFF
--- a/charts/internal/machineclass/templates/machineclass.yaml
+++ b/charts/internal/machineclass/templates/machineclass.yaml
@@ -12,12 +12,6 @@ metadata:
 type: Opaque
 data:
   userData: {{ $machineClass.secret.cloudConfig | b64enc }}
-  authURL: {{ $machineClass.secret.authURL | b64enc }}
-  insecure: dHJ1ZQ== # true
-  domainName: {{ $machineClass.secret.domainName | b64enc }}
-  tenantName: {{ $machineClass.secret.tenantName | b64enc }}
-  username: {{ $machineClass.secret.username | b64enc }}
-  password: {{ $machineClass.secret.password | b64enc }}
 ---
 apiVersion: machine.sapcloud.io/v1alpha1
 kind: OpenStackMachineClass
@@ -47,6 +41,9 @@ spec:
   secretRef:
     name: {{ $machineClass.name }}
     namespace: {{ $.Release.Namespace }}
+  credentialsSecretRef:
+    name: {{ $machineClass.credentialsSecretRef.name }}
+    namespace: {{ $machineClass.credentialsSecretRef.namespace }}
 {{- if $machineClass.tags }}
   tags:
 {{ toYaml $machineClass.tags | indent 4 }}

--- a/charts/internal/machineclass/values.yaml
+++ b/charts/internal/machineclass/values.yaml
@@ -24,3 +24,6 @@ machineClasses:
     username: abc
     password: abc
     cloudConfig: abc
+  credentialsSecretRef:
+    name: cloudprovider
+    namespace: shoot-namespace

--- a/pkg/controller/worker/machine_controller_manager.go
+++ b/pkg/controller/worker/machine_controller_manager.go
@@ -20,8 +20,8 @@ import (
 	"path/filepath"
 
 	"github.com/gardener/gardener-extension-provider-openstack/pkg/openstack"
-	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
 
+	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/utils/chart"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
@@ -76,10 +76,4 @@ func (w *workerDelegate) GetMachineControllerManagerShootChartValues(ctx context
 	return map[string]interface{}{
 		"providerName": openstack.Name,
 	}, nil
-}
-
-// GetMachineControllerManagerCloudCredentials should return the IaaS credentials
-// with the secret keys used by the machine-controller-manager.
-func (w *workerDelegate) GetMachineControllerManagerCloudCredentials(ctx context.Context) (map[string][]byte, error) {
-	return w.generateMachineClassSecretData(ctx)
 }

--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -26,6 +26,7 @@ import (
 	apiv1alpha1 "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack/v1alpha1"
 	. "github.com/gardener/gardener-extension-provider-openstack/pkg/controller/worker"
 	"github.com/gardener/gardener-extension-provider-openstack/pkg/openstack"
+
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
 	"github.com/gardener/gardener/extensions/pkg/controller/common"
 	"github.com/gardener/gardener/extensions/pkg/controller/worker"
@@ -89,13 +90,9 @@ var _ = Describe("Machines", func() {
 				namespace        string
 				cloudProfileName string
 
-				openstackAuthURL    string
-				openstackDomainName string
-				openstackTenantName string
-				openstackUserName   string
-				openstackPassword   string
-				region              string
-				regionWithImages    string
+				openstackAuthURL string
+				region           string
+				regionWithImages string
 
 				machineImageName    string
 				machineImageVersion string
@@ -148,10 +145,6 @@ var _ = Describe("Machines", func() {
 				regionWithImages = "eu-de-2"
 
 				openstackAuthURL = "auth-url"
-				openstackDomainName = "domain-name"
-				openstackTenantName = "tenant-name"
-				openstackUserName = "user-name"
-				openstackPassword = "password"
 
 				machineImageName = "my-os"
 				machineImageVersion = "123"
@@ -383,10 +376,10 @@ var _ = Describe("Machines", func() {
 						machineClassWithHashPool2Zone2 = fmt.Sprintf("%s-%s", machineClassNamePool2Zone2, workerPoolHash2)
 					)
 
-					addNameAndSecretToMachineClass(machineClassPool1Zone1, openstackAuthURL, openstackDomainName, openstackTenantName, openstackUserName, openstackPassword, machineClassWithHashPool1Zone1)
-					addNameAndSecretToMachineClass(machineClassPool1Zone2, openstackAuthURL, openstackDomainName, openstackTenantName, openstackUserName, openstackPassword, machineClassWithHashPool1Zone2)
-					addNameAndSecretToMachineClass(machineClassPool2Zone1, openstackAuthURL, openstackDomainName, openstackTenantName, openstackUserName, openstackPassword, machineClassWithHashPool2Zone1)
-					addNameAndSecretToMachineClass(machineClassPool2Zone2, openstackAuthURL, openstackDomainName, openstackTenantName, openstackUserName, openstackPassword, machineClassWithHashPool2Zone2)
+					addNameAndSecretToMachineClass(machineClassPool1Zone1, machineClassWithHashPool1Zone1, w.Spec.SecretRef)
+					addNameAndSecretToMachineClass(machineClassPool1Zone2, machineClassWithHashPool1Zone2, w.Spec.SecretRef)
+					addNameAndSecretToMachineClass(machineClassPool2Zone1, machineClassWithHashPool2Zone1, w.Spec.SecretRef)
+					addNameAndSecretToMachineClass(machineClassPool2Zone2, machineClassWithHashPool2Zone2, w.Spec.SecretRef)
 
 					machineClasses = map[string]interface{}{"machineClasses": []map[string]interface{}{
 						machineClassPool1Zone1,
@@ -443,8 +436,6 @@ var _ = Describe("Machines", func() {
 					setup(region, machineImage, "")
 					workerDelegate, _ := NewWorkerDelegate(common.NewClientContext(c, scheme, decoder), chartApplier, "", w, cluster, nil)
 
-					expectGetSecretCallToWork(c, openstackDomainName, openstackTenantName, openstackUserName, openstackPassword)
-
 					// Test workerDelegate.DeployMachineClasses()
 
 					chartApplier.
@@ -500,10 +491,7 @@ var _ = Describe("Machines", func() {
 				It("should return the expected machine deployments for profile image types with id", func() {
 					setup(regionWithImages, "", machineImageID)
 					workerDelegate, _ := NewWorkerDelegate(common.NewClientContext(c, scheme, decoder), chartApplier, "", workerWithRegion, clusterWithRegion, nil)
-
 					clusterWithRegion.Shoot.Spec.Hibernation = &gardencorev1beta1.Hibernation{Enabled: pointer.BoolPtr(true)}
-
-					expectGetSecretCallToWork(c, openstackDomainName, openstackTenantName, openstackUserName, openstackPassword)
 
 					// Test workerDelegate.DeployMachineClasses()
 
@@ -568,7 +556,6 @@ var _ = Describe("Machines", func() {
 					)
 
 					setup(region, machineImage, "")
-					expectGetSecretCallToWork(c, openstackDomainName, openstackTenantName, openstackUserName, openstackPassword)
 					workerWithServerGroup := w.DeepCopy()
 					workerWithServerGroup.Status.ProviderStatus = &runtime.RawExtension{
 						Object: &apiv1alpha1.WorkerStatus{
@@ -620,10 +607,10 @@ var _ = Describe("Machines", func() {
 					machineClassWithHashPool1Zone2 := fmt.Sprintf("%s-%s", machineClassNamePool1Zone2, workerPoolHash1)
 					machineClassWithHashPool2Zone1 := fmt.Sprintf("%s-%s", machineClassNamePool2Zone1, workerPoolHash2)
 					machineClassWithHashPool2Zone2 := fmt.Sprintf("%s-%s", machineClassNamePool2Zone2, workerPoolHash2)
-					addNameAndSecretToMachineClass(machineClassPool1Zone1, openstackAuthURL, openstackDomainName, openstackTenantName, openstackUserName, openstackPassword, machineClassWithHashPool1Zone1)
-					addNameAndSecretToMachineClass(machineClassPool1Zone2, openstackAuthURL, openstackDomainName, openstackTenantName, openstackUserName, openstackPassword, machineClassWithHashPool1Zone2)
-					addNameAndSecretToMachineClass(machineClassPool2Zone1, openstackAuthURL, openstackDomainName, openstackTenantName, openstackUserName, openstackPassword, machineClassWithHashPool2Zone1)
-					addNameAndSecretToMachineClass(machineClassPool2Zone2, openstackAuthURL, openstackDomainName, openstackTenantName, openstackUserName, openstackPassword, machineClassWithHashPool2Zone2)
+					addNameAndSecretToMachineClass(machineClassPool1Zone1, machineClassWithHashPool1Zone1, w.Spec.SecretRef)
+					addNameAndSecretToMachineClass(machineClassPool1Zone2, machineClassWithHashPool1Zone2, w.Spec.SecretRef)
+					addNameAndSecretToMachineClass(machineClassPool2Zone1, machineClassWithHashPool2Zone1, w.Spec.SecretRef)
+					addNameAndSecretToMachineClass(machineClassPool2Zone2, machineClassWithHashPool2Zone2, w.Spec.SecretRef)
 					machineClasses := map[string]interface{}{"machineClasses": []map[string]interface{}{
 						machineClassPool1Zone1,
 						machineClassPool1Zone2,
@@ -647,19 +634,7 @@ var _ = Describe("Machines", func() {
 				})
 			})
 
-			It("should fail because the secret cannot be read", func() {
-				c.EXPECT().
-					Get(context.TODO(), gomock.Any(), gomock.AssignableToTypeOf(&corev1.Secret{})).
-					Return(fmt.Errorf("error"))
-
-				result, err := workerDelegate.GenerateMachineDeployments(context.TODO())
-				Expect(err).To(HaveOccurred())
-				Expect(result).To(BeNil())
-			})
-
 			It("should fail because the version is invalid", func() {
-				expectGetSecretCallToWork(c, openstackDomainName, openstackTenantName, openstackUserName, openstackPassword)
-
 				clusterWithoutImages.Shoot.Spec.Kubernetes.Version = "invalid"
 				workerDelegate, _ = NewWorkerDelegate(common.NewClientContext(c, scheme, decoder), chartApplier, "", w, cluster, nil)
 
@@ -669,8 +644,6 @@ var _ = Describe("Machines", func() {
 			})
 
 			It("should fail because the infrastructure status cannot be decoded", func() {
-				expectGetSecretCallToWork(c, openstackDomainName, openstackTenantName, openstackUserName, openstackPassword)
-
 				w.Spec.InfrastructureProviderStatus = &runtime.RawExtension{}
 
 				workerDelegate, _ = NewWorkerDelegate(common.NewClientContext(c, scheme, decoder), chartApplier, "", w, cluster, nil)
@@ -681,8 +654,6 @@ var _ = Describe("Machines", func() {
 			})
 
 			It("should fail because the security group cannot be found", func() {
-				expectGetSecretCallToWork(c, openstackDomainName, openstackTenantName, openstackUserName, openstackPassword)
-
 				w.Spec.InfrastructureProviderStatus = &runtime.RawExtension{
 					Raw: encode(&api.InfrastructureStatus{}),
 				}
@@ -695,8 +666,6 @@ var _ = Describe("Machines", func() {
 			})
 
 			It("should fail because the machine image for this cloud profile cannot be found", func() {
-				expectGetSecretCallToWork(c, openstackDomainName, openstackTenantName, openstackUserName, openstackPassword)
-
 				clusterWithoutImages.CloudProfile.Name = "another-cloud-profile"
 
 				workerDelegate, _ = NewWorkerDelegate(common.NewClientContext(c, scheme, decoder), chartApplier, "", w, clusterWithoutImages, nil)
@@ -707,8 +676,6 @@ var _ = Describe("Machines", func() {
 			})
 
 			It("should set expected machineControllerManager settings on machine deployment", func() {
-				expectGetSecretCallToWork(c, openstackDomainName, openstackTenantName, openstackUserName, openstackPassword)
-
 				testDrainTimeout := metav1.Duration{Duration: 10 * time.Minute}
 				testHealthTimeout := metav1.Duration{Duration: 20 * time.Minute}
 				testCreationTimeout := metav1.Duration{Duration: 30 * time.Minute}
@@ -744,20 +711,6 @@ func encode(obj runtime.Object) []byte {
 	return data
 }
 
-func expectGetSecretCallToWork(c *mockclient.MockClient, openstackDomainName, openstackTenantName, openstackUserName, openstackPassword string) {
-	c.EXPECT().
-		Get(context.TODO(), gomock.Any(), gomock.AssignableToTypeOf(&corev1.Secret{})).
-		DoAndReturn(func(_ context.Context, _ client.ObjectKey, secret *corev1.Secret) error {
-			secret.Data = map[string][]byte{
-				openstack.DomainName: []byte(openstackDomainName),
-				openstack.TenantName: []byte(openstackTenantName),
-				openstack.UserName:   []byte(openstackUserName),
-				openstack.Password:   []byte(openstackPassword),
-			}
-			return nil
-		})
-}
-
 func useDefaultMachineClass(def map[string]interface{}, key string, value interface{}) map[string]interface{} {
 	out := make(map[string]interface{}, len(def)+1)
 
@@ -782,14 +735,13 @@ func useDefaultMachineClassWith(def map[string]interface{}, add map[string]inter
 
 	return out
 }
-func addNameAndSecretToMachineClass(class map[string]interface{}, openstackAuthURL, openstackDomainName, openstackTenantName, openstackUserName, openstackPassword, name string) {
+func addNameAndSecretToMachineClass(class map[string]interface{}, name string, credentialsSecretRef corev1.SecretReference) {
 	class["name"] = name
 	class["labels"] = map[string]string{
 		v1beta1constants.GardenerPurpose: genericworkeractuator.GardenPurposeMachineClass,
 	}
-	class["secret"].(map[string]interface{})[openstack.AuthURL] = openstackAuthURL
-	class["secret"].(map[string]interface{})[openstack.DomainName] = openstackDomainName
-	class["secret"].(map[string]interface{})[openstack.TenantName] = openstackTenantName
-	class["secret"].(map[string]interface{})[openstack.UserName] = openstackUserName
-	class["secret"].(map[string]interface{})[openstack.Password] = openstackPassword
+	class["credentialsSecretRef"] = map[string]interface{}{
+		"name":      credentialsSecretRef.Name,
+		"namespace": credentialsSecretRef.Namespace,
+	}
 }

--- a/pkg/openstack/types.go
+++ b/pkg/openstack/types.go
@@ -57,6 +57,8 @@ const (
 	Password = "password"
 	// Region is a constant for the key in a backup secret that holds the Openstack region.
 	Region = "region"
+	// Insecure is a constant for the key in a cloud provider secret that configures whether the OpenStack client verifies the server's certificate.
+	Insecure = "insecure"
 
 	// CloudProviderConfigName is the name of the secret containing the cloud provider config.
 	CloudProviderConfigName = "cloud-provider-config"

--- a/pkg/webhook/cloudprovider/ensurer.go
+++ b/pkg/webhook/cloudprovider/ensurer.go
@@ -80,5 +80,6 @@ func (e *ensurer) EnsureCloudProviderSecret(
 		new.Data = make(map[string][]byte)
 	}
 	new.Data[types.AuthURL] = []byte(keyStoneURL)
+	new.Data[types.Insecure] = []byte("true")
 	return nil
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement
/priority normal
/platform openstack

**What this PR does / why we need it**:

Uses the machine classes .{spec.}credentialsSecretRef field. It is a reference to a secret containing only the credentials, while today's `.spec.secretRef` still contains the user-data. [See here for more details](https://github.com/gardener/machine-controller-manager/pull/578).

Uses the worker's secret reference as the credentialsSecretRef.
This means all worker pools use the same "cloudprovider" secret containing only the cloud provider credentials.
The existing MachineClass SecretReference then only contains the user data that is different for each pool.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Set to draft, due to the pending discussion in https://github.com/gardener/gardener-extension-provider-aws/pull/238. 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Reducing credential update complexity by all the machine classes using the new .{spec.}credentialsSecretRef field.
This means all worker pools use the same "cloudprovider" secret containing only the cloud provider credentials.
The existing MachineClass SecretReference only contains the user data that is different for each pool.
```
