### PR TITLE
remove server group update validation

### DIFF
--- a/docs/usage-as-end-user.md
+++ b/docs/usage-as-end-user.md
@@ -86,7 +86,7 @@ If you don't want to configure anything for the `cloudControllerManager` simply 
 
 ## `WorkerConfig`
 
-Each worker group in a shoot may contain provider specific configurations and options. These are contained in the `providerConfig` section of a worker group.
+Each worker group in a shoot may contain provider-specific configurations and options. These are contained in the `providerConfig` section of a worker group and can be configured using a `WorkerConfig` object.
 An example of a `WorkerConfig` looks as follows:
 
 ```yaml
@@ -96,15 +96,17 @@ serverGroup:
   policy: soft-anti-affinity
 ```
 
-When you specify the `serverGroup` section in your worker group configuration, a new server group will be created with the configured policy and all machines managed by this worker group will be assigned as members of the created server group.
-For users to have access to this feature, it must be enabled on the `CloudProfile` by your operator.
+When you specify the `serverGroup` section in your worker group configuration, a new server group will be created with the configured policy for each worker group that enabled this setting and all machines managed by this worker group will be assigned as members of the created server group.
 
-Existing shoots that want to use this feature, have to create **new** worker groups with a server group configuration and migrate their workloads on the new nodes. Updating existing worker groups with server group configuration is currently prohibited.
+For users to have access to the server group feature, it must be enabled on the `CloudProfile` by your operator. 
+Existing clusters can take advantage of this feature by updating the server group configuration of their respective worker groups. Worker groups that are already configured with server groups can update their setting to change the policy used, or remove it altogether at any time.
+
+Users must be aware that **any change to the server group settings will result in a rolling deployment of new nodes for the affected worker group**.
+
 
 Please note the following restrictions when deploying workers with server groups:
-+ The `serverGroup` and `serverGroup.policy` fields are immutable upon creation. Users are not allowed to change the policy value and neither add or remove a `serverGroup` section from a worker group after it has been created.
 + The `serverGroup` section is optional, but if it is included in the worker configuration, it must contain a valid policy value.
-+ The available `policy` values that can be used, are defined in the provider specific section of `CloudProfile`, by your operator.
++ The available `policy` values that can be used, are defined in the provider specific section of `CloudProfile` by your operator.
 + Certain policy values may induce further constraints. Using the `affinity` policy is only allowed when the worker group utilizes a single zone.
 
 ## Example `Shoot` manifest (one availability zone)

--- a/pkg/apis/openstack/validation/shoot_test.go
+++ b/pkg/apis/openstack/validation/shoot_test.go
@@ -297,69 +297,6 @@ var _ = Describe("Shoot validation", func() {
 					})),
 				))
 			})
-
-			Context("#ValidateServerGroups", func() {
-				BeforeEach(func() {
-					providerConfig := &openstack.WorkerConfig{
-						ServerGroup: &openstack.ServerGroup{
-							Policy: "foo",
-						},
-					}
-
-					arr, err := json.Marshal(providerConfig)
-					Expect(err).To(BeNil())
-
-					for i := range workers {
-						workers[i].ProviderConfig = &runtime.RawExtension{
-							Raw: arr,
-						}
-					}
-				})
-
-				It("should forbid removing server group policies", func() {
-					newWorkers := copyWorkers(workers)
-
-					newWorkers[0].ProviderConfig = nil
-					errorList := ValidateWorkersUpdate(workers, newWorkers, nilPath)
-					Expect(errorList).To(HaveLen(1))
-					Expect(errorList).To(ConsistOf(
-						PointTo(MatchFields(IgnoreExtras, Fields{
-							"Type":     Equal(field.ErrorTypeInvalid),
-							"Field":    Equal("[0].providerConfig.serverGroup"),
-							"BadValue": BeNil(),
-						})),
-					))
-				})
-
-				It("should forbid modifying server group policies", func() {
-					newWorkers := copyWorkers(workers)
-
-					newWorkers[0].ProviderConfig = &runtime.RawExtension{
-						Object: &openstack.WorkerConfig{
-							ServerGroup: &openstack.ServerGroup{
-								Policy: "bar",
-							},
-						},
-					}
-
-					errorList := ValidateWorkersUpdate(workers, newWorkers, nilPath)
-					Expect(errorList).To(HaveLen(1))
-					Expect(errorList).To(ConsistOf(
-						PointTo(MatchFields(IgnoreExtras, Fields{
-							"Type":     Equal(field.ErrorTypeInvalid),
-							"Field":    Equal("[0].providerConfig.serverGroup.policy"),
-							"BadValue": Equal("bar"),
-						})),
-					))
-				})
-
-				It("should allow updates with no server group changes", func() {
-					newWorkers := copyWorkers(workers)
-
-					errorList := ValidateWorkersUpdate(workers, newWorkers, nilPath)
-					Expect(errorList).To(BeEmpty())
-				})
-			})
 		})
 	})
 })


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement
/priority normal
/platform openstack

**What this PR does / why we need it**:
This PR removes the validation checks that prevented worker groups to change server group settings after their creation. This will trigger a rolling update (by changing the `MachineClass` hash)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc user
Allow updating server group settings on existing worker groups.
```
