### PR TITLE
fix secret key

### DIFF
--- a/pkg/webhook/cloudprovider/ensurer.go
+++ b/pkg/webhook/cloudprovider/ensurer.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack"
 	"github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack/helper"
+	types "github.com/gardener/gardener-extension-provider-openstack/pkg/openstack"
 
 	"github.com/gardener/gardener/extensions/pkg/webhook/cloudprovider"
 	gcontext "github.com/gardener/gardener/extensions/pkg/webhook/context"
@@ -27,10 +28,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
-)
-
-const (
-	authUrlKey = "auth_url"
 )
 
 // NewEnsurer creates cloudprovider ensurer.
@@ -82,6 +79,6 @@ func (e *ensurer) EnsureCloudProviderSecret(
 	if new.Data == nil {
 		new.Data = make(map[string][]byte)
 	}
-	new.Data[authUrlKey] = []byte(keyStoneURL)
+	new.Data[types.AuthURL] = []byte(keyStoneURL)
 	return nil
 }

--- a/pkg/webhook/cloudprovider/ensurer_test.go
+++ b/pkg/webhook/cloudprovider/ensurer_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack/install"
 	openstackv1alpha1 "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack/v1alpha1"
+	types "github.com/gardener/gardener-extension-provider-openstack/pkg/openstack"
 
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
 	"github.com/gardener/gardener/extensions/pkg/webhook/cloudprovider"
@@ -85,7 +86,7 @@ var _ = Describe("Ensurer", func() {
 		)
 		err := ensurer.EnsureCloudProviderSecret(ctx, ectx, new, nil)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(string(new.Data[authUrlKey])).To(Equal(authUrl))
+		Expect(string(new.Data[types.AuthURL])).To(Equal(authUrl))
 	})
 
 	It("Should return an error if no authURL is found", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/priority normal
/platform openstack

**What this PR does / why we need it**:
Fixes a bug where the auth-url webhook was updating the secret using the wrong key for the data.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
