### PR TITLE
Fix ControlPlane reconciliation for K8s < 1.19

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -37,7 +37,7 @@ images:
   sourceRepository: github.com/kubernetes/cloud-provider-openstack
   repository: docker.io/k8scloudprovider/cinder-csi-plugin
   tag: "v1.19.0"
-  targetVersion: "1.19.x"
+  targetVersion: "< 1.20"
 - name: csi-driver-cinder
   sourceRepository: github.com/kubernetes/cloud-provider-openstack
   repository: docker.io/k8scloudprovider/cinder-csi-plugin


### PR DESCRIPTION
/kind bug

After https://github.com/gardener/gardener-extension-provider-openstack/pull/205 the ControlPlane reconciliation for K8s < 1.19 fails with:
```
  lastErrors:
    - description: >-
        task "Waiting until shoot control plane has been reconciled" failed:
        Error while waiting for ControlPlane shoot--foo--bar/bar
        to become ready: extension encountered error during reconciliation:
        Error reconciling controlplane: could not apply control plane chart for
        controlplane 'shoot--foo--bar/bar': could not inject
        chart 'csi-driver-controller' images: could not find image
        "csi-driver-cinder" opts runtime version v1.18.14 target version 1.18.14
      taskID: Waiting until shoot control plane has been reconciled
```

Although the csi-driver is deployed only for K8s > 1.19, the `csi-driver-cinder` image is part of the `controlPlaneChart` - ref https://github.com/gardener/gardener-extension-provider-openstack/blob/v1.15.0/pkg/controller/controlplane/valuesprovider.go#L173. Hence when the `controlPlaneChart` is being applied, it tries to find the corresponding `csi-driver-cinder` image even for K8s < 1.19 even though the corresponding csi chart won't be applied.
This PR contains a straightforward fix.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
