### PR TITLE
Add useragent header for api call issued by ccm and csi driver

### DIFF
--- a/charts/internal/seed-controlplane/charts/cloud-controller-manager/templates/cloud-controller-manager.yaml
+++ b/charts/internal/seed-controlplane/charts/cloud-controller-manager/templates/cloud-controller-manager.yaml
@@ -66,6 +66,9 @@ spec:
         {{- end }}
         - --tls-cipher-suites={{ include "kubernetes.tlsCipherSuites" . | replace "\n" "," | trimPrefix "," }}
         - --use-service-account-credentials
+        {{- if semverCompare ">= 1.15" .Values.kubernetesVersion }}{{- range $userAgentHeader := .Values.userAgentHeaders }}
+        - --user-agent={{ $userAgentHeader }}
+        {{- end }}{{- end }}
         - --v=2
         livenessProbe:
           httpGet:

--- a/charts/internal/seed-controlplane/charts/cloud-controller-manager/values.yaml
+++ b/charts/internal/seed-controlplane/charts/cloud-controller-manager/values.yaml
@@ -9,6 +9,7 @@ featureGates: {}
   # RotateKubeletServerCertificate: false
 images:
   hyperkube: image-repository:image-tag
+userAgentHeaders: []
 resources:
   requests:
     cpu: 100m

--- a/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/deployment-csi-driver-controller.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/deployment-csi-driver-controller.yaml
@@ -43,6 +43,9 @@ spec:
         - --endpoint=$(CSI_ENDPOINT)
         - --cloud-config=/etc/kubernetes/cloudprovider/cloudprovider.conf
         - --cluster={{ .Release.Namespace }}
+        {{- range $userAgentHeader := .Values.userAgentHeaders }}
+        - --user-agent={{ $userAgentHeader }}
+        {{- end }}
         - --v=3
         env:
         - name: CSI_ENDPOINT

--- a/charts/internal/seed-controlplane/charts/csi-driver-controller/values.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-driver-controller/values.yaml
@@ -12,6 +12,7 @@ images:
 
 socketPath: /var/lib/csi/sockets/pluginproxy
 timeout: 3m
+userAgentHeaders: []
 
 resources:
   driver:

--- a/charts/internal/shoot-system-components/charts/csi-driver-node/templates/daemonset.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/templates/daemonset.yaml
@@ -36,6 +36,9 @@ spec:
         - --endpoint=$(CSI_ENDPOINT)
         - --nodeid=$(NODE_ID)
         - --cloud-config=/etc/kubernetes/cloudprovider/cloudprovider.conf
+        {{- range $userAgentHeader := .Values.userAgentHeaders }}
+        - --user-agent={{ $userAgentHeader }}
+        {{- end }}
         - --v=5
         env:
         - name: CSI_ENDPOINT

--- a/charts/internal/shoot-system-components/charts/csi-driver-node/values.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/values.yaml
@@ -8,6 +8,7 @@ images:
 
 socketPath: /csi/csi.sock
 vpaEnabled: false
+userAgentHeaders: []
 
 resources:
   driver:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind enhancement
/priority normal
/platform openstack

**What this PR does / why we need it**:
Add the Openstack domain name, the tenant/project name and the Shoot technical name (Project name + Shoot name) as http headers for the API calls which the the Openstack Cloud Controller Manager and CSI drive run against OpenStack APIs.

This should help to detect log messages which belong to certain Shoot faster on the Openstack provider side.

**Which issue(s) this PR fixes**:
Fixes #214

**Special notes for your reviewer**:
I wanted to play around before I remove the draft state.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The name of the Openstack domain, tenant/project name and the technical name of the respective Shoot will be added as http headers for the API call which the Openstack Cloud Controller Manager and CSI driver run against Openstack APIs.
```

cc @kayrus, @kon-angelo @dguendisch 