### PR TITLE
Add max retries to repeat failed or throttled operations

### DIFF
--- a/charts/internal/openstack-infra/templates/main.tf
+++ b/charts/internal/openstack-infra/templates/main.tf
@@ -6,6 +6,7 @@ provider "openstack" {
   user_name   = var.USER_NAME
   password    = var.PASSWORD
   insecure    = true
+  max_retries = "{{ required "openstack.maxApiCallRetries is required" .Values.openstack.maxApiCallRetries }}"
 }
 
 //=====================================================================

--- a/charts/internal/openstack-infra/values.yaml
+++ b/charts/internal/openstack-infra/values.yaml
@@ -4,6 +4,7 @@ openstack:
   tenantName: kubernetes
   region: eu-de-1
   floatingPoolName: my-pool
+  maxApiCallRetries: 10
 
 create:
   router: true


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind enhancement
/priority normal
/platform openstack

**What this PR does / why we need it**:
Add max retries for api call to retry failed or throttled operations.

**Which issue(s) this PR fixes**:
Fixes partly #220

**Special notes for your reviewer**:
Require `terraformer-openstack` with provider openstack `v.1.37.0` integrated. See https://github.com/gardener/terraformer/pull/68

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```NONE

```

/invite @kon-angelo 
cc @kayrus 