### PR TITLE
adapt to OOT MCM

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -32,6 +32,10 @@ images:
   sourceRepository: github.com/gardener/machine-controller-manager
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager
   tag: "v0.37.0"
+- name: machine-controller-manager-provider-openstack
+  sourceRepository: github.com/gardener/machine-controller-manager-provider-openstack
+  repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager-provider-openstack
+  tag: "v0.0.1"
 
 - name: csi-driver-cinder
   sourceRepository: github.com/kubernetes/cloud-provider-openstack

--- a/charts/internal/machine-controller-manager/seed/templates/deployment.yaml
+++ b/charts/internal/machine-controller-manager/seed/templates/deployment.yaml
@@ -83,7 +83,7 @@ spec:
           readOnly: true
       - name: provider-openstack
         image: {{ index .Values.images "machine-controller-manager-provider-openstack" }}
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         command:
           - ./machine-controller
           - --control-kubeconfig=inClusterConfig

--- a/charts/internal/machine-controller-manager/seed/templates/deployment.yaml
+++ b/charts/internal/machine-controller-manager/seed/templates/deployment.yaml
@@ -39,7 +39,7 @@ spec:
       serviceAccountName: machine-controller-manager
       terminationGracePeriodSeconds: 5
       containers:
-      - name: machine-controller-manager
+      - name: openstack-machine-controller-manager
         image: {{ index .Values.images "machine-controller-manager" }}
         imagePullPolicy: IfNotPresent
         command:
@@ -48,15 +48,13 @@ spec:
         - --target-kubeconfig=/var/lib/machine-controller-manager/kubeconfig
         - --namespace={{ .Release.Namespace }}
         - --port={{ .Values.metricsPort }}
-        - --machine-creation-timeout=20m
-        - --machine-drain-timeout=2h
-        - --machine-health-timeout=10m
         - --machine-safety-apiserver-statuscheck-timeout=30s
         - --machine-safety-apiserver-statuscheck-period=1m
         - --machine-safety-orphan-vms-period=30m
         - --machine-safety-overshooting-period=1m
         - --safety-up=2
         - --safety-down=1
+        - --delete-migrated-machine-class=true
         - --v=3
         livenessProbe:
           failureThreshold: 3
@@ -93,6 +91,9 @@ spec:
           - --port={{ .Values.metricsPortOpenstack}}
           - --target-kubeconfig=/var/lib/machine-controller-manager/kubeconfig
           - --v=3
+          - --machine-creation-timeout=20m
+          - --machine-drain-timeout=2h
+          - --machine-health-timeout=10m
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/charts/internal/machine-controller-manager/seed/templates/deployment.yaml
+++ b/charts/internal/machine-controller-manager/seed/templates/deployment.yaml
@@ -39,7 +39,7 @@ spec:
       serviceAccountName: machine-controller-manager
       terminationGracePeriodSeconds: 5
       containers:
-      - name: openstack-machine-controller-manager
+      - name: machine-controller-manager
         image: {{ index .Values.images "machine-controller-manager" }}
         imagePullPolicy: IfNotPresent
         command:
@@ -83,6 +83,32 @@ spec:
         - mountPath: /var/lib/machine-controller-manager
           name: machine-controller-manager
           readOnly: true
+      - name: provider-openstack
+        image: {{ index .Values.images "machine-controller-manager-provider-openstack" }}
+        imagePullPolicy: Always
+        command:
+          - ./machine-controller
+          - --control-kubeconfig=inClusterConfig
+          - --namespace={{ .Release.Namespace }}
+          - --port={{ .Values.metricsPortOpenstack}}
+          - --target-kubeconfig=/var/lib/machine-controller-manager/kubeconfig
+          - --v=3
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: {{ .Values.metricsPortOpenstack }}
+            scheme: HTTP
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+          - mountPath: /var/lib/machine-controller-manager
+            name: machine-controller-manager
+            readOnly: true
       volumes:
       - name: machine-controller-manager
         secret:

--- a/charts/internal/machine-controller-manager/seed/values.yaml
+++ b/charts/internal/machine-controller-manager/seed/values.yaml
@@ -1,5 +1,6 @@
 images:
   machine-controller-manager: image-repository:image-tag
+  machine-controller-manager-provider-openstack: image-repository:image-tag
 
 replicas: 1
 
@@ -13,6 +14,7 @@ namespace:
   uid: uuid-of-namespace
 
 metricsPort: 10258
+metricsPortOpenstack: 10259
 
 vpa:
   enabled: true

--- a/charts/internal/machine-controller-manager/shoot/templates/clusterrole-machine-controller-manager.yaml
+++ b/charts/internal/machine-controller-manager/shoot/templates/clusterrole-machine-controller-manager.yaml
@@ -60,3 +60,10 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - policy
+  verbs:
+  - list
+  - watch
+  resources:
+  - poddisruptionbudgets

--- a/charts/internal/machineclass/templates/machineclass.yaml
+++ b/charts/internal/machineclass/templates/machineclass.yaml
@@ -14,38 +14,46 @@ data:
   userData: {{ $machineClass.secret.cloudConfig | b64enc }}
 ---
 apiVersion: machine.sapcloud.io/v1alpha1
-kind: OpenStackMachineClass
+kind: MachineClass
 metadata:
   name: {{ $machineClass.name }}
   namespace: {{ $.Release.Namespace }}
-spec:
-  region: {{ $machineClass.region }}
-  availabilityZone: {{ $machineClass.availabilityZone }}
-  flavorName: {{ $machineClass.machineType }}
-  keyName: {{ $machineClass.keyName }}
-{{- if $machineClass.imageID }}
-  imageID: {{ $machineClass.imageID }}
-{{- else }}
-  imageName: {{ $machineClass.imageName }}
+{{- if $machineClass.labels }}
+  labels:
+  {{ toYaml $machineClass.labels | indent 4 }}
 {{- end }}
-  networkID: {{ $machineClass.networkID }}
-  podNetworkCidr: {{ $machineClass.podNetworkCidr }}
+provider: "OpenStack"
+secretRef:
+  name: {{ $machineClass.name }}
+  namespace: {{ $.Release.Namespace }}
+credentialsSecretRef:
+  name: {{ $machineClass.credentialsSecretRef.name }}
+  namespace: {{ $machineClass.credentialsSecretRef.namespace }}
+providerSpec:
+  apiVersion: openstack.machine.gardener.cloud/v1alpha1
+  kind: MachineProviderConfig
+  spec:
+    region: {{ $machineClass.region }}
+    availabilityZone: {{ $machineClass.availabilityZone }}
+    flavorName: {{ $machineClass.machineType }}
+    keyName: {{ $machineClass.keyName }}
+{{- if $machineClass.imageID }}
+    imageID: {{ $machineClass.imageID }}
+{{- else }}
+    imageName: {{ $machineClass.imageName }}
+{{- end }}
+    networkID: {{ $machineClass.networkID }}
+    podNetworkCidr: {{ $machineClass.podNetworkCidr }}
 {{- if $machineClass.rootDiskSize }}
-  rootDiskSize: {{ $machineClass.rootDiskSize }}
+    rootDiskSize: {{ $machineClass.rootDiskSize }}
 {{- end}}
 {{- if $machineClass.serverGroupID }}
-  serverGroupID: {{ $machineClass.serverGroupID }}
+    serverGroupID: {{ $machineClass.serverGroupID }}
 {{- end }}
-  securityGroups:
-{{ toYaml $machineClass.securityGroups | indent 2 }}
-  secretRef:
-    name: {{ $machineClass.name }}
-    namespace: {{ $.Release.Namespace }}
-  credentialsSecretRef:
-    name: {{ $machineClass.credentialsSecretRef.name }}
-    namespace: {{ $machineClass.credentialsSecretRef.namespace }}
+    securityGroups:
+{{ toYaml $machineClass.securityGroups | indent 4 }}
 {{- if $machineClass.tags }}
-  tags:
-{{ toYaml $machineClass.tags | indent 4 }}
+    tags:
+{{ toYaml $machineClass.tags | indent 6 }}
 {{- end }}
 {{- end }}

--- a/pkg/controller/worker/machine_controller_manager.go
+++ b/pkg/controller/worker/machine_controller_manager.go
@@ -34,7 +34,7 @@ var (
 	mcmChart = &chart.Chart{
 		Name:   openstack.MachineControllerManagerName,
 		Path:   filepath.Join(openstack.InternalChartsPath, openstack.MachineControllerManagerName, "seed"),
-		Images: []string{openstack.MachineControllerManagerImageName},
+		Images: []string{openstack.MachineControllerManagerImageName, openstack.MachineControllerManagerProviderOpenStackImageName},
 		Objects: []*chart.Object{
 			{Type: &appsv1.Deployment{}, Name: openstack.MachineControllerManagerName},
 			{Type: &corev1.Service{}, Name: openstack.MachineControllerManagerName},

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -58,6 +58,7 @@ func (w *workerDelegate) DeployMachineClasses(ctx context.Context) error {
 	}
 
 	// Delete any older version machine class CRs.
+	// TODO: This can safely be removed after a few releases. It only facilitates the transition between OpenStackMachineClass -> MachineClass for existing shoots.
 	if err := w.Client().DeleteAllOf(ctx, &machinev1alpha1.OpenStackMachineClass{}, client.InNamespace(w.worker.Namespace)); err != nil {
 		return errors.Wrapf(err, "cleaning up old OpenstackMachineClass resources failed")
 	}

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -34,7 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// MachineClassKind yields the name of the OpenStack machine class.
+// MachineClassKind yields the name of the machine class kind used by OpenStack provider.
 func (w *workerDelegate) MachineClassKind() string {
 	return "MachineClass"
 }
@@ -44,7 +44,7 @@ func (w *workerDelegate) MachineClass() client.Object {
 	return &machinev1alpha1.MachineClass{}
 }
 
-// MachineClassList yields a newly initialized OpenStackMachineClassList object.
+// MachineClassList yields a newly initialized MachineClassList object.
 func (w *workerDelegate) MachineClassList() client.ObjectList {
 	return &machinev1alpha1.MachineClassList{}
 }

--- a/pkg/openstack/types.go
+++ b/pkg/openstack/types.go
@@ -43,7 +43,8 @@ const (
 	// CSISnapshotControllerImageName is the name of the csi-snapshot-controller image.
 	CSISnapshotControllerImageName = "csi-snapshot-controller"
 	// MachineControllerManagerImageName is the name of the MachineControllerManager image.
-	MachineControllerManagerImageName = "machine-controller-manager"
+	MachineControllerManagerImageName                  = "machine-controller-manager"
+	MachineControllerManagerProviderOpenStackImageName = "machine-controller-manager-provider-openstack"
 
 	// AuthURL is a constant for the key in a cloud provider secret that holds the OpenStack auth url.
 	AuthURL = "authURL"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind api-change
/priority normal
/platform openstack

**What this PR does / why we need it**:
Changes the MCM deployment to the OOT repo one. Also adapts the `MachineClass` templates for the new CR.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Drafted until first release of the OOT repo. 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Openstack extension now uses the new Out-Of-Tree MCM implementation.
```
