### PR TITLE
[release-v1.16] Secret data checksum for CSI driver on worker nodes

### DIFF
--- a/charts/internal/shoot-system-components/charts/csi-driver-node/templates/daemonset.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/templates/daemonset.yaml
@@ -14,6 +14,8 @@ spec:
       role: disk-driver
   template:
     metadata:
+      annotations:
+        checksum/secret-cloud-provider-config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
       labels:
         app: csi
         role: disk-driver


### PR DESCRIPTION
/area usability
/kind bug
/priority normal
/platform openstack

Cherry pick of #226 on release-v1.16.

#226: Secret data checksum for CSI driver on worker nodes

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
An issue has been resolved which prevented the CSI driver from properly functioning when the infrastructure credentials were changed.
```
