### PR TITLE
[release-v1.16] [ci:component:github.com/gardener/terraformer:v2.1.0->v2.1.1]

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -2,7 +2,7 @@ images:
 - name: terraformer
   sourceRepository: github.com/gardener/terraformer
   repository: eu.gcr.io/gardener-project/gardener/terraformer-openstack
-  tag: "v2.1.0"
+  tag: "v2.1.1"
 
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes/cloud-provider-openstack


### PR DESCRIPTION
/kind bug

Cherry pick of #227 on release-v1.16.

#227: [ci:component:github.com/gardener/terraformer:v2.1.0->v2.1.1]

**Release Notes*:
``` bugfix operator github.com/gardener/terraformer #72 @timebertt
A bug was fixed that caused terraform to leak its finalizer on ConfigMaps and Secrets in case of an interrupt during `terraform destroy`.
```