### PR TITLE
Update kubernetes-csi/external-snapshotter to v2.1.4

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -54,11 +54,11 @@ images:
 - name: csi-snapshotter
   sourceRepository: github.com/kubernetes-csi/external-snapshotter
   repository: k8s.gcr.io/sig-storage/csi-snapshotter
-  tag: "v2.1.3"
+  tag: "v2.1.4"
 - name: csi-snapshot-controller
   sourceRepository: github.com/kubernetes-csi/external-snapshotter
   repository: k8s.gcr.io/sig-storage/snapshot-controller
-  tag: "v2.1.3"
+  tag: "v2.1.4"
 - name: csi-resizer
   sourceRepository: github.com/kubernetes-csi/external-resizer
   repository: k8s.gcr.io/sig-storage/csi-resizer


### PR DESCRIPTION
/area storage
/kind bug

Ref https://github.com/kubernetes-csi/external-snapshotter/releases/tag/v2.1.4

Part of https://github.com/gardener/gardener/issues/2227

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
The following images are updated (see [CHANGELOG](https://github.com/kubernetes-csi/external-snapshotter/blob/v2.1.4/CHANGELOG-2.1.md) for more details):
- k8s.gcr.io/sig-storage/csi-snapshotter: v2.1.3 -> v2.1.4
- k8s.gcr.io/sig-storage/snapshot-controller: v2.1.3 -> v2.1.4
```