### PR TITLE
Use Terraform variables for credentials

### DIFF
--- a/charts/internal/openstack-infra/templates/main.tf
+++ b/charts/internal/openstack-infra/templates/main.tf
@@ -1,7 +1,7 @@
 provider "openstack" {
   auth_url    = "{{ required "openstack.authURL is required" .Values.openstack.authURL }}"
-  domain_name = "{{ required "openstack.domainName is required" .Values.openstack.domainName }}"
-  tenant_name = "{{ required "openstack.tenantName is required" .Values.openstack.tenantName }}"
+  domain_name = var.DOMAIN_NAME
+  tenant_name = var.TENANT_NAME
   region      = "{{ required "openstack.region is required" .Values.openstack.region }}"
   user_name   = var.USER_NAME
   password    = var.PASSWORD

--- a/charts/internal/openstack-infra/templates/variables.tf
+++ b/charts/internal/openstack-infra/templates/variables.tf
@@ -1,3 +1,13 @@
+variable "DOMAIN_NAME" {
+  description = "OpenStack domain name"
+  type        = string
+}
+
+variable "TENANT_NAME" {
+  description = "OpenStack project name"
+  type        = string
+}
+
 variable "USER_NAME" {
   description = "OpenStack user name"
   type        = string

--- a/charts/internal/openstack-infra/values.yaml
+++ b/charts/internal/openstack-infra/values.yaml
@@ -1,7 +1,5 @@
 openstack:
   authURL: https://keystone/v3/
-  domainName: CP
-  tenantName: kubernetes
   region: eu-de-1
   floatingPoolName: my-pool
   maxApiCallRetries: 10

--- a/pkg/controller/infrastructure/actuator_reconcile.go
+++ b/pkg/controller/infrastructure/actuator_reconcile.go
@@ -40,12 +40,7 @@ func (a *actuator) reconcile(ctx context.Context, logger logr.Logger, infra *ext
 		return err
 	}
 
-	creds, err := infrastructure.GetCredentialsFromInfrastructure(ctx, a.Client(), infra)
-	if err != nil {
-		return err
-	}
-
-	terraformFiles, err := infrastructure.RenderTerraformerChart(a.ChartRenderer(), infra, creds, config, cluster)
+	terraformFiles, err := infrastructure.RenderTerraformerChart(a.ChartRenderer(), infra, config, cluster)
 	if err != nil {
 		return err
 	}

--- a/pkg/internal/infrastructure/terraform.go
+++ b/pkg/internal/infrastructure/terraform.go
@@ -22,11 +22,10 @@ import (
 	api "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack"
 	"github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack/helper"
 	apiv1alpha1 "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack/v1alpha1"
-	"github.com/gardener/gardener-extension-provider-openstack/pkg/openstack"
 	openstacktypes "github.com/gardener/gardener-extension-provider-openstack/pkg/openstack"
+
 	"github.com/gardener/gardener/extensions/pkg/controller"
 	"github.com/gardener/gardener/extensions/pkg/terraformer"
-
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/chartrenderer"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -62,7 +61,6 @@ var StatusTypeMeta = metav1.TypeMeta{
 // ComputeTerraformerChartValues computes the values for the OpenStack Terraformer chart.
 func ComputeTerraformerChartValues(
 	infra *extensionsv1alpha1.Infrastructure,
-	credentials *openstack.Credentials,
 	config *api.InfrastructureConfig,
 	cluster *controller.Cluster,
 ) (map[string]interface{}, error) {
@@ -114,8 +112,6 @@ func ComputeTerraformerChartValues(
 	return map[string]interface{}{
 		"openstack": map[string]interface{}{
 			"authURL":          keyStoneURL,
-			"domainName":       credentials.DomainName,
-			"tenantName":       credentials.TenantName,
 			"region":           infra.Spec.Region,
 			"floatingPoolName": config.FloatingPoolName,
 		},
@@ -155,11 +151,10 @@ func findFloatingSubnet(isRouterRequired bool, config *api.InfrastructureConfig,
 func RenderTerraformerChart(
 	renderer chartrenderer.Interface,
 	infra *extensionsv1alpha1.Infrastructure,
-	credentials *openstack.Credentials,
 	config *api.InfrastructureConfig,
 	cluster *controller.Cluster,
 ) (*TerraformFiles, error) {
-	values, err := ComputeTerraformerChartValues(infra, credentials, config, cluster)
+	values, err := ComputeTerraformerChartValues(infra, config, cluster)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/internal/infrastructure/terraform_test.go
+++ b/pkg/internal/infrastructure/terraform_test.go
@@ -18,13 +18,10 @@ import (
 	"encoding/json"
 	"strconv"
 
-	"k8s.io/utils/pointer"
-
 	api "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack"
 	apiv1alpha1 "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack/v1alpha1"
-	"github.com/gardener/gardener-extension-provider-openstack/pkg/openstack"
-	"github.com/gardener/gardener/extensions/pkg/controller"
 
+	"github.com/gardener/gardener/extensions/pkg/controller"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	. "github.com/onsi/ginkgo"
@@ -32,6 +29,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/pointer"
 )
 
 var _ = Describe("Terraform", func() {
@@ -41,7 +39,6 @@ var _ = Describe("Terraform", func() {
 		cloudProfileConfigJSON []byte
 		config                 *api.InfrastructureConfig
 		cluster                *controller.Cluster
-		credentials            *openstack.Credentials
 
 		keystoneURL = "foo-bar.com"
 		dnsServers  = []string{"a", "b"}
@@ -106,8 +103,6 @@ var _ = Describe("Terraform", func() {
 				},
 			},
 		}
-
-		credentials = &openstack.Credentials{Username: "user", Password: "secret"}
 	})
 
 	Describe("#ComputeTerraformerChartValues", func() {
@@ -122,8 +117,6 @@ var _ = Describe("Terraform", func() {
 		BeforeEach(func() {
 			expectedOpenStackValues = map[string]interface{}{
 				"authURL":          keystoneURL,
-				"domainName":       credentials.DomainName,
-				"tenantName":       credentials.TenantName,
 				"region":           infra.Spec.Region,
 				"floatingPoolName": config.FloatingPoolName,
 			}
@@ -148,7 +141,7 @@ var _ = Describe("Terraform", func() {
 		})
 
 		It("should correctly compute the terraformer chart values", func() {
-			values, err := ComputeTerraformerChartValues(infra, credentials, config, cluster)
+			values, err := ComputeTerraformerChartValues(infra, config, cluster)
 			Expect(err).To(BeNil())
 
 			Expect(values).To(Equal(map[string]interface{}{
@@ -173,7 +166,7 @@ var _ = Describe("Terraform", func() {
 			expectedRouterValues["id"] = DefaultRouterID
 			expectedRouterValues["enableSNAT"] = true
 
-			values, err := ComputeTerraformerChartValues(infra, credentials, config, cluster)
+			values, err := ComputeTerraformerChartValues(infra, config, cluster)
 			Expect(err).To(BeNil())
 			Expect(values).To(Equal(map[string]interface{}{
 				"openstack":    expectedOpenStackValues,
@@ -197,7 +190,7 @@ var _ = Describe("Terraform", func() {
 			expectedRouterValues["id"] = DefaultRouterID
 			expectedRouterValues["floatingPoolSubnet"] = fipSubnetID
 
-			values, err := ComputeTerraformerChartValues(infra, credentials, config, cluster)
+			values, err := ComputeTerraformerChartValues(infra, config, cluster)
 			Expect(err).To(BeNil())
 			Expect(values).To(Equal(map[string]interface{}{
 				"openstack":    expectedOpenStackValues,

--- a/pkg/internal/terraform.go
+++ b/pkg/internal/terraform.go
@@ -29,6 +29,10 @@ import (
 )
 
 const (
+	// TerraformVarNameDomainName maps to terraform internal var representation.
+	TerraformVarNameDomainName = "TF_VAR_DOMAIN_NAME"
+	// TerraformVarNameProjectName maps to terraform internal var representation.
+	TerraformVarNameProjectName = "TF_VAR_TENANT_NAME"
 	// TerraformVarNameUserName maps to terraform internal var representation.
 	TerraformVarNameUserName = "TF_VAR_USER_NAME"
 	// TerraformVarNamePassword maps to terraform internal var representation.
@@ -38,6 +42,22 @@ const (
 // TerraformerEnvVars computes the Terraformer environment variables from the given secret reference.
 func TerraformerEnvVars(secretRef corev1.SecretReference) []corev1.EnvVar {
 	return []corev1.EnvVar{{
+		Name: TerraformVarNameDomainName,
+		ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{
+			LocalObjectReference: corev1.LocalObjectReference{
+				Name: secretRef.Name,
+			},
+			Key: openstack.DomainName,
+		}},
+	}, {
+		Name: TerraformVarNameProjectName,
+		ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{
+			LocalObjectReference: corev1.LocalObjectReference{
+				Name: secretRef.Name,
+			},
+			Key: openstack.TenantName,
+		}},
+	}, {
 		Name: TerraformVarNameUserName,
 		ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{
 			LocalObjectReference: corev1.LocalObjectReference{

--- a/pkg/internal/terraform_test.go
+++ b/pkg/internal/terraform_test.go
@@ -27,6 +27,24 @@ var _ = Describe("Terraform", func() {
 			secretRef := corev1.SecretReference{Name: "cloud"}
 			Expect(TerraformerEnvVars(secretRef)).To(ConsistOf(
 				corev1.EnvVar{
+					Name: "TF_VAR_DOMAIN_NAME",
+					ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: secretRef.Name,
+						},
+						Key: "domainName",
+					}},
+				},
+				corev1.EnvVar{
+					Name: "TF_VAR_TENANT_NAME",
+					ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: secretRef.Name,
+						},
+						Key: "tenantName",
+					}},
+				},
+				corev1.EnvVar{
 					Name: "TF_VAR_USER_NAME",
 					ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{
 						LocalObjectReference: corev1.LocalObjectReference{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement
/priority normal
/platform openstack

**What this PR does / why we need it**:
Instead of templating the credentials (`domainName`, `tenantName`) into the Terraform script we are now using container environment variables with references to the `cloudprovider` secret (similar to how it's done for `username` and `password`).
The Terraform script is only updated on creation/reconciliation, but if an `Infrastructure` is already marked for deletion then it's never updated again. This is a problem if the `domainName` or `tenantName` changes.

**Special notes for your reviewer**:
/cc @dguendisch @timuthy 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
