### PR TITLE
fix failing servergroup creation on Nova 2.64+

### DIFF
--- a/pkg/apis/openstack/validation/shoot.go
+++ b/pkg/apis/openstack/validation/shoot.go
@@ -19,6 +19,8 @@ import (
 
 	api "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack"
 	"github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack/helper"
+	openstackclient "github.com/gardener/gardener-extension-provider-openstack/pkg/openstack/client"
+
 	"github.com/gardener/gardener/pkg/apis/core"
 	"github.com/gardener/gardener/pkg/apis/core/validation"
 	apivalidation "k8s.io/apimachinery/pkg/api/validation"
@@ -112,8 +114,8 @@ func validateWorkerConfig(parent *field.Path, worker *core.Worker, workerConfig 
 		return allErrs
 	}
 
-	if len(worker.Zones) > 1 && workerConfig.ServerGroup.Policy == api.ServerGroupPolicyAffinity {
-		allErrs = append(allErrs, field.Forbidden(parent.Child("serverGroup", "policy"), fmt.Sprintf("using %q policy with multiple availability zones is not allowed", api.ServerGroupPolicyAffinity)))
+	if len(worker.Zones) > 1 && workerConfig.ServerGroup.Policy == openstackclient.ServerGroupPolicyAffinity {
+		allErrs = append(allErrs, field.Forbidden(parent.Child("serverGroup", "policy"), fmt.Sprintf("using %q policy with multiple availability zones is not allowed", openstackclient.ServerGroupPolicyAffinity)))
 	}
 
 	return allErrs

--- a/pkg/apis/openstack/validation/shoot_test.go
+++ b/pkg/apis/openstack/validation/shoot_test.go
@@ -19,6 +19,8 @@ import (
 
 	"github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack"
 	. "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack/validation"
+	openstackclient "github.com/gardener/gardener-extension-provider-openstack/pkg/openstack/client"
+
 	"github.com/gardener/gardener/pkg/apis/core"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -126,7 +128,7 @@ var _ = Describe("Shoot validation", func() {
 
 				BeforeEach(func() {
 					cloudProfileConfig = &openstack.CloudProfileConfig{
-						ServerGroupPolicies: []string{"foo", "bar", openstack.ServerGroupPolicyAffinity},
+						ServerGroupPolicies: []string{"foo", "bar", openstackclient.ServerGroupPolicyAffinity},
 					}
 				})
 
@@ -204,7 +206,7 @@ var _ = Describe("Shoot validation", func() {
 				It("should not allow hard affinity policy with multiple availability zones", func() {
 					providerConfig := &openstack.WorkerConfig{
 						ServerGroup: &openstack.ServerGroup{
-							Policy: openstack.ServerGroupPolicyAffinity,
+							Policy: openstackclient.ServerGroupPolicyAffinity,
 						},
 					}
 

--- a/pkg/openstack/client/client.go
+++ b/pkg/openstack/client/client.go
@@ -98,14 +98,6 @@ func (oc *OpenstackClientFactory) Storage(options ...Option) (Storage, error) {
 	}, nil
 }
 
-type serviceVersion struct {
-	Version struct {
-		Version    string `json:"version"`
-		Status     string `json:"status"`
-		MinVersion string `json:"min_version"`
-	} `json:"version"`
-}
-
 // Compute returns a Compute client. The client uses Nova v2 API for issuing calls.
 func (oc *OpenstackClientFactory) Compute(options ...Option) (Compute, error) {
 	eo := gophercloud.EndpointOpts{}
@@ -117,17 +109,6 @@ func (oc *OpenstackClientFactory) Compute(options ...Option) (Compute, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	// discover the latest microversion of the API and set it on the client.
-	// this is necessary for the creating servergroups with "soft-anti-affinity" policy. Soft variants of affinity policies,
-	// are only supported in >=2.1 version of Compute API.
-	// https://docs.openstack.org/api-guide/compute/microversions.html
-	version := serviceVersion{}
-	_, err = client.Get(client.ResourceBaseURL(), &version, nil)
-	if err != nil {
-		return nil, err
-	}
-	client.Microversion = version.Version.Version
 
 	return &ComputeClient{
 		client: client,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/priority blocker
/platform openstack

**What this PR does / why we need it**:
This PR fixes an issue when to trying to create servergroups with nova API `>= 2.64`. The request no longer accepts the `Policies` field on those versions. The current client picked the highest supported version of the Nova API and if that was greater than `2.64` the creation of servergroups would fail.

Instead, do not set the microversion of the client.  In case `soft-*` servergroup policies are requested, pin the client to `2.15`, since its the minimum version that supports these values.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fix a bug in servergroup creation when the Nova API is `> 2.63`
```
