### PR TITLE
Set the timeout for the webhook to 10 seconds

### DIFF
--- a/charts/gardener-extension-validator-openstack/charts/application/templates/validatingwebhook-validator.yaml
+++ b/charts/gardener-extension-validator-openstack/charts/application/templates/validatingwebhook-validator.yaml
@@ -16,6 +16,7 @@ webhooks:
     resources:
     - shoots
   failurePolicy: Fail
+  timeoutSeconds: 10
   objectSelector: {}
   namespaceSelector: {}
   sideEffects: None

--- a/example/40-validatingwebhookconfiguration.yaml
+++ b/example/40-validatingwebhookconfiguration.yaml
@@ -16,6 +16,7 @@ webhooks:
     resources:
     - shoots
   failurePolicy: Fail
+  timeoutSeconds: 10
   objectSelector: {}
   namespaceSelector: {}
   sideEffects: None


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->

/kind enhancement
/platform openstack

**What this PR does / why we need it**:
Set the timeout for the webhook to 10 seconds

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->

```other operator
The timeout seconds for the validating admission webhook is now set to 10s.
```
