### PR TITLE
Update kubernetes-csi/livenessprobe

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -74,4 +74,4 @@ images:
 - name: csi-liveness-probe
   sourceRepository: github.com/kubernetes-csi/livenessprobe
   repository: k8s.gcr.io/sig-storage/livenessprobe
-  tag: "v2.1.0"
+  tag: "v2.2.0"


### PR DESCRIPTION
/kind bug
/platform openstack

We observe a huge memory leak with the `csi-liveness-probe` sidecar. Its memory usage is increasing across the time.

![Screenshot 2021-04-08 at 14 17 28](https://user-images.githubusercontent.com/9372594/114020554-656be780-9878-11eb-8f5f-337c98f28db5.png)

From the screenshot you can see that the memory for the `csi-liveness-probe` container goes above 1Gi.
There is upstream fix https://github.com/kubernetes-csi/livenessprobe/pull/94 for a memory leak that is available in `k8s.gcr.io/sig-storage/livenessprobe@v2.2.0`.


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
The following image is updated (see [CHANGELOG](https://github.com/kubernetes-csi/livenessprobe/blob/v2.2.0/CHANGELOG/CHANGELOG-2.2.md) for more details):
- k8s.gcr.io/sig-storage/livenessprobe: v2.1.0 -> v2.2.0
```
