### PR TITLE
[release-v1.17] Automated cherry pick of #256: Update kubernetes-csi/livenessprobe

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -74,4 +74,4 @@ images:
 - name: csi-liveness-probe
   sourceRepository: github.com/kubernetes-csi/livenessprobe
   repository: k8s.gcr.io/sig-storage/livenessprobe
-  tag: "v2.1.0"
+  tag: "v2.2.0"


### PR DESCRIPTION
/kind bug
/platform openstack

Cherry pick of #256 on release-v1.17.

#256: Update kubernetes-csi/livenessprobe

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
The following image is updated (see [CHANGELOG](https://github.com/kubernetes-csi/livenessprobe/blob/v2.2.0/CHANGELOG/CHANGELOG-2.2.md) for more details):
- k8s.gcr.io/sig-storage/livenessprobe: v2.1.0 -> v2.2.0
```