### PR TITLE
Specify container resources for CSI sidecars

### DIFF
--- a/charts/internal/seed-controlplane/charts/csi-driver-controller/values.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-driver-controller/values.yaml
@@ -50,6 +50,13 @@ resources:
     limits:
       cpu: 30m
       memory: 50Mi
+  livenessProbe:
+    requests:
+      cpu: 10m
+      memory: 32Mi
+    limits:
+      cpu: 30m
+      memory: 50Mi
 
 csiSnapshotController:
   replicas: 1

--- a/charts/internal/shoot-system-components/charts/csi-driver-node/templates/daemonset.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/templates/daemonset.yaml
@@ -101,6 +101,10 @@ spec:
           value: {{ .Values.socketPath }}
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/{{ include "csi-driver-node.provisioner" . }}/csi.sock
+{{- if .Values.resources.nodeDriverRegistrar }}
+        resources:
+{{ toYaml .Values.resources.nodeDriverRegistrar | indent 10 }}
+{{- end }}
         volumeMounts:
         - name: plugin-dir
           mountPath: /csi

--- a/charts/internal/shoot-system-components/charts/csi-driver-node/values.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/values.yaml
@@ -18,3 +18,17 @@ resources:
     limits:
       cpu: 50m
       memory: 80Mi
+  nodeDriverRegistrar:
+    requests:
+      cpu: 10m
+      memory: 32Mi
+    limits:
+      cpu: 30m
+      memory: 50Mi
+  livenessProbe:
+    requests:
+      cpu: 10m
+      memory: 32Mi
+    limits:
+      cpu: 30m
+      memory: 50Mi


### PR DESCRIPTION
/kind enhancement
/platform openstack

Currently the liveness-probe and csi-node-driver-registrar sidecars on the csi-driver-node Pod, the liveness-probe sidecar on  the csi-driver-controller Pod do not define resource requests and limits.
Without any resource limits, currently we don't prevent any abnormal usage of resources by these sidecars. For example we recently observed a huge memory leak (see more details in #256) in the liveness-probe sidecar - because of the memory leak the sidecar container was using more than 1Gi when the normal (without the memory leak) memory usage of the container is ~20Mi. With specifying resource requests and limits, we can prevent such cases. 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The few CSI sidecar containers that didn't specify any resource requests and limits do now specify appropriate requests and limits. 
```
