### PR TITLE
Clean up the stale target build stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,9 +20,3 @@ FROM base as gardener-extension-admission-openstack
 
 COPY --from=builder /go/bin/gardener-extension-admission-openstack /gardener-extension-admission-openstack
 ENTRYPOINT ["/gardener-extension-admission-openstack"]
-
-############# gardener-extension-validator-openstack
-FROM base AS gardener-extension-validator-openstack
-
-COPY --from=builder /go/bin/gardener-extension-admission-openstack /gardener-extension-admission-openstack
-ENTRYPOINT ["/gardener-extension-admission-openstack"]


### PR DESCRIPTION
/kind cleanup

No longer needed after the merge of https://github.com/gardener/gardener-extension-provider-openstack/pull/265

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
