### PR TITLE
Do not print secret content in error message

### DIFF
--- a/pkg/openstack/credentials.go
+++ b/pkg/openstack/credentials.go
@@ -57,19 +57,19 @@ func ExtractCredentials(secret *corev1.Secret) (*Credentials, error) {
 	if secret.Data == nil {
 		return nil, fmt.Errorf("secret does not contain any data")
 	}
-	domainName, err := getRequired(secret.Data, DomainName)
+	domainName, err := getRequired(secret, DomainName)
 	if err != nil {
 		return nil, err
 	}
-	tenantName, err := getRequired(secret.Data, TenantName)
+	tenantName, err := getRequired(secret, TenantName)
 	if err != nil {
 		return nil, err
 	}
-	userName, err := getRequired(secret.Data, UserName)
+	userName, err := getRequired(secret, UserName)
 	if err != nil {
 		return nil, err
 	}
-	password, err := getRequired(secret.Data, Password)
+	password, err := getRequired(secret, Password)
 	if err != nil {
 		return nil, err
 	}
@@ -85,13 +85,13 @@ func ExtractCredentials(secret *corev1.Secret) (*Credentials, error) {
 }
 
 // getRequired checks if the provided map has a valid value for a corresponding key.
-func getRequired(data map[string][]byte, key string) (string, error) {
-	value, ok := data[key]
+func getRequired(secret *corev1.Secret, key string) (string, error) {
+	value, ok := secret.Data[key]
 	if !ok {
-		return "", fmt.Errorf("map %v does not contain key %s", data, key)
+		return "", fmt.Errorf("missing %q data key in secret %s/%s", key, secret.Namespace, secret.Name)
 	}
 	if len(value) == 0 {
-		return "", fmt.Errorf("key %s may not be empty", key)
+		return "", fmt.Errorf("key %q in secret %s/%s cannot be empty", key, secret.Namespace, secret.Name)
 	}
 	return string(value), nil
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind bug
/platform openstack

**What this PR does / why we need it**:
Do not print secret content in error message

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
No longer print secret data into error messages.
```
