### PR TITLE
Update kubernetes-csi/livenessprobe

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -86,4 +86,4 @@ images:
 - name: csi-liveness-probe
   sourceRepository: github.com/kubernetes-csi/livenessprobe
   repository: k8s.gcr.io/sig-storage/livenessprobe
-  tag: "v2.2.0"
+  tag: "v2.3.0"


### PR DESCRIPTION
/kind bug
/platform openstack

@nickytd recently reported that the csi-driver Pod in the kube-system Namespace is quite noisy and 

> produces around 2.6 millions of logs in the last 24h in one of our clusters

I believe part of the noisy logs are coming from the livenessProbe container which has noisy logging in `< v2.3.0` - the corresponding upstream issue itself is https://github.com/kubernetes-csi/livenessprobe/issues/110.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
The following image is updated (see [CHANGELOG](https://github.com/kubernetes-csi/livenessprobe/blob/v2.3.0/CHANGELOG/CHANGELOG-2.3.md) for more details):
- k8s.gcr.io/sig-storage/livenessprobe: v2.2.0 -> v2.3.0
```

