### PR TITLE
Reduce the log level of cinder-csi-driver

### DIFF
--- a/charts/internal/shoot-system-components/charts/csi-driver-node/templates/daemonset.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/templates/daemonset.yaml
@@ -41,7 +41,7 @@ spec:
         {{- range $userAgentHeader := .Values.userAgentHeaders }}
         - --user-agent={{ $userAgentHeader }}
         {{- end }}
-        - --v=5
+        - --v=4
         env:
         - name: CSI_ENDPOINT
           value: unix://{{ .Values.socketPath }}


### PR DESCRIPTION
/kind enhancement
/platform openstack

As described in https://github.com/gardener/gardener-extension-provider-openstack/pull/287, the csi-driver-node logging is verbose and noisy.

Except the livenessprobe container, the csi-driver container is noisy as well. It generates a lot of logs such as:

```
I0524 20:01:44.879641       1 utils.go:81] GRPC request:
I0524 20:01:44.879674       1 identityserver.go:50] Probe() called with req
I0524 20:01:44.885084       1 utils.go:86] GRPC response:
I0524 20:01:54.879767       1 utils.go:80] GRPC call: /csi.v1.Identity/Probe
I0524 20:01:54.879837       1 utils.go:81] GRPC request:
I0524 20:01:54.879872       1 identityserver.go:50] Probe() called with req
I0524 20:01:54.883811       1 utils.go:86] GRPC response:
I0524 20:02:04.879962       1 utils.go:80] GRPC call: /csi.v1.Identity/Probe
I0524 20:02:04.879978       1 utils.go:81] GRPC request:
I0524 20:02:04.880007       1 identityserver.go:50] Probe() called with req
I0524 20:02:04.884123       1 utils.go:86] GRPC response:
``` 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
