### PR TITLE
Remove version constraints for lb config

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.16
 
 require (
 	github.com/Masterminds/goutils v1.1.1 // indirect
-	github.com/Masterminds/semver v1.5.0
 	github.com/Masterminds/sprig v2.22.0+incompatible
 	github.com/ahmetb/gen-crd-api-reference-docs v0.2.0
 	github.com/coreos/go-systemd/v22 v22.1.0

--- a/pkg/admission/validator/shoot.go
+++ b/pkg/admission/validator/shoot.go
@@ -23,7 +23,6 @@ import (
 	"github.com/gardener/gardener-extension-provider-openstack/pkg/openstack"
 	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
 
-	"github.com/Masterminds/semver"
 	"github.com/gardener/gardener/pkg/apis/core"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
@@ -53,7 +52,6 @@ type validationContext struct {
 	cpConfig           *api.ControlPlaneConfig
 	cloudProfile       *gardencorev1beta1.CloudProfile
 	cloudProfileConfig *api.CloudProfileConfig
-	shootVersion       *semver.Version
 }
 
 var (
@@ -121,7 +119,7 @@ func (s *shoot) validateShootCreation(ctx context.Context, shoot *core.Shoot, do
 	allErrs := field.ErrorList{}
 
 	allErrs = append(allErrs, openstackvalidation.ValidateInfrastructureConfigAgainstCloudProfile(nil, valContext.infraConfig, domain, valContext.shoot.Spec.Region, valContext.cloudProfileConfig, infraConfigPath)...)
-	allErrs = append(allErrs, openstackvalidation.ValidateControlPlaneConfigAgainstCloudProfile(nil, valContext.cpConfig, domain, valContext.shoot.Spec.Region, valContext.infraConfig.FloatingPoolName, valContext.shootVersion, valContext.cloudProfileConfig, cpConfigPath)...)
+	allErrs = append(allErrs, openstackvalidation.ValidateControlPlaneConfigAgainstCloudProfile(nil, valContext.cpConfig, domain, valContext.shoot.Spec.Region, valContext.infraConfig.FloatingPoolName, valContext.cloudProfileConfig, cpConfigPath)...)
 	allErrs = append(allErrs, s.validateShoot(valContext)...)
 	return allErrs.ToAggregate()
 }
@@ -156,7 +154,7 @@ func (s *shoot) validateShootUpdate(ctx context.Context, oldShoot, shoot *core.S
 		oldCpConfig.Zone != cpConfig.Zone ||
 		!equality.Semantic.DeepEqual(oldCpConfig.LoadBalancerClasses, cpConfig.LoadBalancerClasses) ||
 		oldValContext.infraConfig.FloatingPoolName != valContext.infraConfig.FloatingPoolName {
-		allErrs = append(allErrs, openstackvalidation.ValidateControlPlaneConfigAgainstCloudProfile(oldCpConfig, cpConfig, domain, valContext.shoot.Spec.Region, valContext.infraConfig.FloatingPoolName, valContext.shootVersion, valContext.cloudProfileConfig, cpConfigPath)...)
+		allErrs = append(allErrs, openstackvalidation.ValidateControlPlaneConfigAgainstCloudProfile(oldCpConfig, cpConfig, domain, valContext.shoot.Spec.Region, valContext.infraConfig.FloatingPoolName, valContext.cloudProfileConfig, cpConfigPath)...)
 	}
 
 	if errList := openstackvalidation.ValidateWorkersUpdate(oldValContext.shoot.Spec.Provider.Workers, valContext.shoot.Spec.Provider.Workers, workersPath); len(errList) > 0 {
@@ -171,7 +169,7 @@ func (s *shoot) validateShoot(context *validationContext) field.ErrorList {
 	allErrs := field.ErrorList{}
 	allErrs = append(allErrs, openstackvalidation.ValidateNetworking(context.shoot.Spec.Networking, nwPath)...)
 	allErrs = append(allErrs, openstackvalidation.ValidateInfrastructureConfig(context.infraConfig, context.shoot.Spec.Networking.Nodes, infraConfigPath)...)
-	allErrs = append(allErrs, openstackvalidation.ValidateControlPlaneConfig(context.cpConfig, context.shootVersion, cpConfigPath)...)
+	allErrs = append(allErrs, openstackvalidation.ValidateControlPlaneConfig(context.cpConfig, cpConfigPath)...)
 	allErrs = append(allErrs, openstackvalidation.ValidateWorkers(context.shoot.Spec.Provider.Workers, context.cloudProfileConfig, workersPath)...)
 	return allErrs
 }
@@ -206,18 +204,12 @@ func newValidationContext(ctx context.Context, decoder runtime.Decoder, c client
 		return nil, fmt.Errorf("an error occurred while reading the cloud profile %q: %v", cloudProfile.Name, err)
 	}
 
-	k8sVersion, err := semver.NewVersion(shoot.Spec.Kubernetes.Version)
-	if err != nil {
-		return nil, err
-	}
-
 	return &validationContext{
 		shoot:              shoot,
 		infraConfig:        infraConfig,
 		cpConfig:           cpConfig,
 		cloudProfile:       cloudProfile,
 		cloudProfileConfig: cloudProfileConfig,
-		shootVersion:       k8sVersion,
 	}, nil
 }
 

--- a/pkg/apis/openstack/helper/helper.go
+++ b/pkg/apis/openstack/helper/helper.go
@@ -19,13 +19,7 @@ import (
 
 	api "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack"
 	"github.com/gardener/gardener-extension-provider-openstack/pkg/utils"
-	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
-
-	"github.com/Masterminds/semver"
 )
-
-// K8sVersionV121 represents the Kubernetes v1.21.0 version.
-var K8sVersionV121 = semver.MustParse("v1.21.0")
 
 // FindSubnetByPurpose takes a list of subnets and tries to find the first entry
 // whose purpose matches with the given purpose. If no such entry is found then an error will be
@@ -181,37 +175,4 @@ func checkFloatingPoolCandidate(floatingPool *api.FloatingPool, floatingPoolName
 	}
 
 	return nil, 0
-}
-
-// FilterLoadBalancerClassByVersionContraints filters a given list of load balancer classes
-// to consider the only usable load balancer classes with version compatible features
-// based on a given kubernetes version.
-func FilterLoadBalancerClassByVersionContraints(lbClasses []api.LoadBalancerClass, version *semver.Version) []api.LoadBalancerClass {
-	var (
-		usableLoadBalancerClasses = []api.LoadBalancerClass{}
-		lessThenK8sV121           = version.LessThan(K8sVersionV121)
-	)
-
-	for _, lbClass := range lbClasses {
-		if lessThenK8sV121 && (lbClass.FloatingSubnetName != nil || lbClass.FloatingSubnetTags != nil) {
-			continue
-		}
-		lbClassRef := lbClass
-		usableLoadBalancerClasses = append(usableLoadBalancerClasses, lbClassRef)
-	}
-
-	return usableLoadBalancerClasses
-}
-
-// DetermineShootVersionFromCluster receives a cluster resource and determine the
-// Shoot version out of it. If it can't be determined an error will be returned.
-func DetermineShootVersionFromCluster(cluster *extensionscontroller.Cluster) (*semver.Version, error) {
-	if cluster == nil || cluster.Shoot == nil {
-		return nil, fmt.Errorf("cluster or shoot object in cluster is empty")
-	}
-	version, err := semver.NewVersion(cluster.Shoot.Spec.Kubernetes.Version)
-	if err != nil {
-		return nil, err
-	}
-	return version, nil
 }

--- a/pkg/apis/openstack/helper/helper_test.go
+++ b/pkg/apis/openstack/helper/helper_test.go
@@ -15,11 +15,8 @@
 package helper_test
 
 import (
-	"github.com/Masterminds/semver"
 	api "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack"
 	. "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack/helper"
-	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
-	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
@@ -141,50 +138,6 @@ var _ = Describe("Helper", func() {
 		Entry("return fip even if there is a non-constraing fip with better score", []api.FloatingPool{{Name: "fip-*", Region: &regionName}, {Name: "fip-1", Region: &regionName, NonConstraining: pointer.BoolPtr(true)}}, "fip-1", regionName, nil, pointer.StringPtr("fip-*")),
 		Entry("return non-constraing fip as there is no other matching fip", []api.FloatingPool{{Name: "nofip-1", Region: &regionName}, {Name: "fip-1", Region: &regionName, NonConstraining: pointer.BoolPtr(true)}}, "fip-1", regionName, nil, pointer.StringPtr("fip-1")),
 	)
-
-	DescribeTable("#FilterLoadBalancerClassByVersionContraints",
-		func(k8sVersion string, lbClasses, expectedLbClasses []api.LoadBalancerClass) {
-			version, err := semver.NewVersion(k8sVersion)
-			Expect(err).NotTo(HaveOccurred())
-
-			filterLbClassList := FilterLoadBalancerClassByVersionContraints(lbClasses, version)
-
-			Expect(filterLbClassList).To(Equal(expectedLbClasses))
-		},
-		Entry("should return input list for k8s version >= v1.21", "v1.21.0",
-			[]api.LoadBalancerClass{{Name: "default", FloatingSubnetTags: pointer.StringPtr("test1,test2"), FloatingSubnetName: pointer.StringPtr("*pattern*")}},
-			[]api.LoadBalancerClass{{Name: "default", FloatingSubnetTags: pointer.StringPtr("test1,test2"), FloatingSubnetName: pointer.StringPtr("*pattern*")}},
-		),
-		Entry("should return input list for k8s version < v1.21 as there are no entries with unsupporeted fields", "v1.20.0",
-			[]api.LoadBalancerClass{{Name: "default", FloatingNetworkID: pointer.StringPtr("fip-1")}},
-			[]api.LoadBalancerClass{{Name: "default", FloatingNetworkID: pointer.StringPtr("fip-1")}},
-		),
-		Entry("should return empty list for k8s version < v1.21 as entries with not supported field floatingSubnetName are filtered", "v1.20.0",
-			[]api.LoadBalancerClass{
-				{Name: "default", FloatingSubnetName: pointer.StringPtr("*pattern*")}},
-			[]api.LoadBalancerClass{},
-		),
-		Entry("should return empty list for k8s version < v1.21 as entries with not supported field floatingSubnetTags are filtered", "v1.20.0",
-			[]api.LoadBalancerClass{{Name: "default", FloatingSubnetTags: pointer.StringPtr("test1,test2")}},
-			[]api.LoadBalancerClass{},
-		),
-	)
-
-	DescribeTable("DetermineShootVersionFromCluster",
-		func(cluster *extensionscontroller.Cluster, expectError bool, expectedVersion string) {
-			version, err := DetermineShootVersionFromCluster(cluster)
-			if expectError {
-				Expect(err).To(HaveOccurred())
-				return
-			}
-			Expect(err).NotTo(HaveOccurred())
-			Expect(version.String()).To(Equal(expectedVersion))
-		},
-		Entry("should return shoot version", makeCluster("v1.20.0"), false, "1.20.0"),
-		Entry("should return error as shoot verison is invalid", makeCluster("x.x.x"), true, ""),
-		Entry("should return error as cluster resource is empty", nil, true, ""),
-		Entry("should return error as cluster shoot resource is empty", &extensionscontroller.Cluster{}, true, ""),
-	)
 })
 
 func makeProfileMachineImages(name, version, image string) []api.MachineImages {
@@ -222,18 +175,6 @@ func makeProfileRegionMachineImages(name, version, image, region string) []api.M
 		{
 			Name:     name,
 			Versions: versions,
-		},
-	}
-}
-
-func makeCluster(version string) *extensionscontroller.Cluster {
-	return &extensionscontroller.Cluster{
-		Shoot: &gardencorev1beta1.Shoot{
-			Spec: gardencorev1beta1.ShootSpec{
-				Kubernetes: gardencorev1beta1.Kubernetes{
-					Version: version,
-				},
-			},
 		},
 	}
 }

--- a/pkg/apis/openstack/validation/controlplane_test.go
+++ b/pkg/apis/openstack/validation/controlplane_test.go
@@ -15,7 +15,6 @@
 package validation_test
 
 import (
-	"github.com/Masterminds/semver"
 	api "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack"
 	. "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack/validation"
 
@@ -32,26 +31,24 @@ var _ = Describe("ControlPlaneConfig validation", func() {
 		lbProvider1  = "foo"
 		nilPath      *field.Path
 		controlPlane *api.ControlPlaneConfig
-		k8sVersion   *semver.Version
 	)
 
 	BeforeEach(func() {
 		controlPlane = &api.ControlPlaneConfig{
 			LoadBalancerProvider: lbProvider1,
 		}
-		k8sVersion = semver.MustParse("v1.20")
 	})
 
 	Describe("#ValidateControlPlaneConfig", func() {
 
 		It("should return no errors for a valid configuration", func() {
-			Expect(ValidateControlPlaneConfig(controlPlane, k8sVersion, nilPath)).To(BeEmpty())
+			Expect(ValidateControlPlaneConfig(controlPlane, nilPath)).To(BeEmpty())
 		})
 
 		It("should require the name of a load balancer provider", func() {
 			controlPlane.LoadBalancerProvider = ""
 
-			errorList := ValidateControlPlaneConfig(controlPlane, k8sVersion, nilPath)
+			errorList := ValidateControlPlaneConfig(controlPlane, nilPath)
 
 			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":  Equal(field.ErrorTypeRequired),
@@ -118,7 +115,7 @@ var _ = Describe("ControlPlaneConfig validation", func() {
 		It("should require a name of a load balancer provider that is part of the constraints", func() {
 			controlPlane.LoadBalancerProvider = "bar"
 
-			errorList := ValidateControlPlaneConfigAgainstCloudProfile(nil, controlPlane, domain, region, floatingPool, k8sVersion, cloudProfileConfig, nilPath)
+			errorList := ValidateControlPlaneConfigAgainstCloudProfile(nil, controlPlane, domain, region, floatingPool, cloudProfileConfig, nilPath)
 
 			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":  Equal(field.ErrorTypeNotSupported),
@@ -150,7 +147,7 @@ var _ = Describe("ControlPlaneConfig validation", func() {
 			}
 			controlPlane.LoadBalancerProvider = lbProvider1
 
-			errorList := ValidateControlPlaneConfigAgainstCloudProfile(nil, controlPlane, domain, differentRegion, "", k8sVersion, cloudProfileConfig, nilPath)
+			errorList := ValidateControlPlaneConfigAgainstCloudProfile(nil, controlPlane, domain, differentRegion, "", cloudProfileConfig, nilPath)
 
 			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":  Equal(field.ErrorTypeNotSupported),
@@ -183,7 +180,7 @@ var _ = Describe("ControlPlaneConfig validation", func() {
 			}
 			controlPlane.LoadBalancerProvider = lbProvider1
 
-			errorList := ValidateControlPlaneConfigAgainstCloudProfile(nil, controlPlane, domain, region, floatingPool, k8sVersion, cloudProfileConfig, nilPath)
+			errorList := ValidateControlPlaneConfigAgainstCloudProfile(nil, controlPlane, domain, region, floatingPool, cloudProfileConfig, nilPath)
 
 			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":  Equal(field.ErrorTypeNotSupported),
@@ -216,7 +213,7 @@ var _ = Describe("ControlPlaneConfig validation", func() {
 			}
 			controlPlane.LoadBalancerProvider = lbProvider2
 
-			errorList := ValidateControlPlaneConfigAgainstCloudProfile(nil, controlPlane, domain, differentRegion, "", k8sVersion, cloudProfileConfig, nilPath)
+			errorList := ValidateControlPlaneConfigAgainstCloudProfile(nil, controlPlane, domain, differentRegion, "", cloudProfileConfig, nilPath)
 
 			Expect(errorList).To(BeEmpty())
 		})
@@ -224,7 +221,7 @@ var _ = Describe("ControlPlaneConfig validation", func() {
 		It("should pass because no load balancer class is configured in cloud profile", func() {
 			cloudProfileConfig.Constraints.FloatingPools[0].LoadBalancerClasses = nil
 
-			errorList := ValidateControlPlaneConfigAgainstCloudProfile(nil, controlPlane, domain, region, floatingPool, k8sVersion, cloudProfileConfig, nilPath)
+			errorList := ValidateControlPlaneConfigAgainstCloudProfile(nil, controlPlane, domain, region, floatingPool, cloudProfileConfig, nilPath)
 
 			Expect(errorList).To(BeEmpty())
 		})
@@ -232,7 +229,7 @@ var _ = Describe("ControlPlaneConfig validation", func() {
 		It("should pass because load balancer class is configured correctly in control plane", func() {
 			controlPlane.LoadBalancerClasses = []api.LoadBalancerClass{loadBalancerClass}
 
-			errorList := ValidateControlPlaneConfigAgainstCloudProfile(nil, controlPlane, domain, region, floatingPool, k8sVersion, cloudProfileConfig, nilPath)
+			errorList := ValidateControlPlaneConfigAgainstCloudProfile(nil, controlPlane, domain, region, floatingPool, cloudProfileConfig, nilPath)
 
 			Expect(errorList).To(BeEmpty())
 		})
@@ -251,7 +248,7 @@ var _ = Describe("ControlPlaneConfig validation", func() {
 
 			controlPlane.LoadBalancerClasses = []api.LoadBalancerClass{lbClasses[1], lbClasses[0]}
 
-			errorList := ValidateControlPlaneConfigAgainstCloudProfile(nil, controlPlane, domain, region, floatingPool, k8sVersion, cloudProfileConfig, nilPath)
+			errorList := ValidateControlPlaneConfigAgainstCloudProfile(nil, controlPlane, domain, region, floatingPool, cloudProfileConfig, nilPath)
 
 			Expect(errorList).To(ConsistOf(
 				PointTo(MatchFields(IgnoreExtras, Fields{
@@ -290,7 +287,7 @@ var _ = Describe("ControlPlaneConfig validation", func() {
 
 			controlPlane.LoadBalancerClasses = []api.LoadBalancerClass{lbClasses[1]}
 
-			errorList := ValidateControlPlaneConfigAgainstCloudProfile(nil, controlPlane, domain, differentRegion, fpName, k8sVersion, cloudProfileConfig, nilPath)
+			errorList := ValidateControlPlaneConfigAgainstCloudProfile(nil, controlPlane, domain, differentRegion, fpName, cloudProfileConfig, nilPath)
 
 			Expect(errorList).To(BeEmpty())
 		})
@@ -311,7 +308,7 @@ var _ = Describe("ControlPlaneConfig validation", func() {
 
 			controlPlane.LoadBalancerClasses = []api.LoadBalancerClass{lbClasses[1]}
 
-			errorList := ValidateControlPlaneConfigAgainstCloudProfile(nil, controlPlane, domain, region, fpName, k8sVersion, cloudProfileConfig, nilPath)
+			errorList := ValidateControlPlaneConfigAgainstCloudProfile(nil, controlPlane, domain, region, fpName, cloudProfileConfig, nilPath)
 
 			Expect(errorList).To(BeEmpty())
 		})
@@ -329,7 +326,7 @@ var _ = Describe("ControlPlaneConfig validation", func() {
 
 			controlPlane.LoadBalancerClasses = []api.LoadBalancerClass{lbClasses[0]}
 
-			errorList := ValidateControlPlaneConfigAgainstCloudProfile(nil, controlPlane, domain, region, floatingPool, k8sVersion, cloudProfileConfig, nilPath)
+			errorList := ValidateControlPlaneConfigAgainstCloudProfile(nil, controlPlane, domain, region, floatingPool, cloudProfileConfig, nilPath)
 
 			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":  Equal(field.ErrorTypeNotSupported),
@@ -351,7 +348,7 @@ var _ = Describe("ControlPlaneConfig validation", func() {
 
 			controlPlane.LoadBalancerClasses = append(controlPlane.LoadBalancerClasses, lbClasses[0])
 
-			errorList := ValidateControlPlaneConfigAgainstCloudProfile(nil, controlPlane, domain, region, floatingPool, k8sVersion, cloudProfileConfig, nilPath)
+			errorList := ValidateControlPlaneConfigAgainstCloudProfile(nil, controlPlane, domain, region, floatingPool, cloudProfileConfig, nilPath)
 
 			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":  Equal(field.ErrorTypeNotSupported),
@@ -380,9 +377,9 @@ var _ = Describe("ControlPlaneConfig validation", func() {
 
 			controlPlane.LoadBalancerClasses = append(controlPlane.LoadBalancerClasses, lbClasses[0])
 
-			errorList := ValidateControlPlaneConfigAgainstCloudProfile(nil, controlPlane, domain, region, floatingPool, k8sVersion, cloudProfileConfig, nilPath)
+			errorList := ValidateControlPlaneConfigAgainstCloudProfile(nil, controlPlane, domain, region, floatingPool, cloudProfileConfig, nilPath)
 			Expect(errorList).To(BeEmpty())
-			errorList = ValidateControlPlaneConfigAgainstCloudProfile(nil, controlPlane, differentDomain, region, floatingPool, k8sVersion, cloudProfileConfig, nilPath)
+			errorList = ValidateControlPlaneConfigAgainstCloudProfile(nil, controlPlane, differentDomain, region, floatingPool, cloudProfileConfig, nilPath)
 			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":  Equal(field.ErrorTypeNotSupported),
 				"Field": Equal("loadBalancerClasses[0]"),
@@ -393,7 +390,7 @@ var _ = Describe("ControlPlaneConfig validation", func() {
 			controlPlane.LoadBalancerClasses = []api.LoadBalancerClass{loadBalancerClass}
 			cloudProfileConfig.Constraints.FloatingPools = nil
 
-			errorList := ValidateControlPlaneConfigAgainstCloudProfile(nil, controlPlane, domain, region, floatingPool, k8sVersion, cloudProfileConfig, nilPath)
+			errorList := ValidateControlPlaneConfigAgainstCloudProfile(nil, controlPlane, domain, region, floatingPool, cloudProfileConfig, nilPath)
 
 			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":  Equal(field.ErrorTypeInvalid),
@@ -406,7 +403,7 @@ var _ = Describe("ControlPlaneConfig validation", func() {
 			lbClass.FloatingNetworkID = nil
 			controlPlane.LoadBalancerClasses = []api.LoadBalancerClass{lbClass}
 
-			errorList := ValidateControlPlaneConfigAgainstCloudProfile(nil, controlPlane, domain, region, floatingPool, k8sVersion, cloudProfileConfig, nilPath)
+			errorList := ValidateControlPlaneConfigAgainstCloudProfile(nil, controlPlane, domain, region, floatingPool, cloudProfileConfig, nilPath)
 
 			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":  Equal(field.ErrorTypeNotSupported),
@@ -418,7 +415,7 @@ var _ = Describe("ControlPlaneConfig validation", func() {
 			controlPlane.LoadBalancerProvider = "does-for-sure-not-exist-in-cloudprofile"
 			oldControlPlane := controlPlane.DeepCopy()
 
-			errorList := ValidateControlPlaneConfigAgainstCloudProfile(oldControlPlane, controlPlane, domain, region, floatingPool, k8sVersion, cloudProfileConfig, nilPath)
+			errorList := ValidateControlPlaneConfigAgainstCloudProfile(oldControlPlane, controlPlane, domain, region, floatingPool, cloudProfileConfig, nilPath)
 			Expect(errorList).To(BeEmpty())
 		})
 
@@ -429,7 +426,7 @@ var _ = Describe("ControlPlaneConfig validation", func() {
 			controlPlane.LoadBalancerClasses = []api.LoadBalancerClass{*loadBalancerClassNotInCloudProfile}
 			oldControlPlane := controlPlane.DeepCopy()
 
-			errorList := ValidateControlPlaneConfigAgainstCloudProfile(oldControlPlane, controlPlane, domain, region, floatingPool, k8sVersion, cloudProfileConfig, nilPath)
+			errorList := ValidateControlPlaneConfigAgainstCloudProfile(oldControlPlane, controlPlane, domain, region, floatingPool, cloudProfileConfig, nilPath)
 			Expect(errorList).To(BeEmpty())
 		})
 	})

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -480,11 +480,7 @@ func getConfigChartValues(
 
 	var loadBalancerClassesFromCloudProfile = []api.LoadBalancerClass{}
 	if floatingPool, err := helper.FindFloatingPool(cloudProfileConfig.Constraints.FloatingPools, infraStatus.Networks.FloatingPool.Name, cp.Spec.Region, nil); err == nil {
-		shootVersion, err := helper.DetermineShootVersionFromCluster(cluster)
-		if err != nil {
-			return nil, err
-		}
-		loadBalancerClassesFromCloudProfile = helper.FilterLoadBalancerClassByVersionContraints(floatingPool.LoadBalancerClasses, shootVersion)
+		loadBalancerClassesFromCloudProfile = floatingPool.LoadBalancerClasses
 	}
 
 	// The LoadBalancerClasses from the CloudProfile will be configured by default.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -4,7 +4,6 @@ github.com/BurntSushi/toml
 ## explicit
 github.com/Masterminds/goutils
 # github.com/Masterminds/semver v1.5.0
-## explicit
 github.com/Masterminds/semver
 # github.com/Masterminds/sprig v2.22.0+incompatible
 ## explicit


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind cleanup
/platform openstack

**What this PR does / why we need it**:
The version constraints for `floating-subnet` and `floating-subnet-tags` field in the cloud-provider-config to select a floating subnet to pick the floating ip for a load balancer has been removed.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The version constraints for `floating-subnet` and `floating-subnet-tags` field in the cloud-provider-config to select a floating subnet to pick the floating ip for a load balancer has been removed.
```

/invite @kon-angelo 
