### PR TITLE
Update the admission-openstack RBAC after cloud provider Secrets validation feature

### DIFF
--- a/charts/gardener-extension-admission-openstack/charts/application/templates/rbac.yaml
+++ b/charts/gardener-extension-admission-openstack/charts/application/templates/rbac.yaml
@@ -9,6 +9,7 @@ rules:
 - apiGroups:
   - core.gardener.cloud
   resources:
+  - shoots
   - cloudprofiles
   - secretbindings
   verbs:
@@ -21,8 +22,6 @@ rules:
   - secrets
   verbs:
   - get
-  - list
-  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
/kind bug

Similar to https://github.com/gardener/gardener-extension-provider-aws/pull/346
Follow-up after https://github.com/gardener/gardener-extension-provider-openstack/pull/280 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
