### PR TITLE
Enhance validation of cloud provider secrets

### DIFF
--- a/pkg/apis/openstack/validation/secrets.go
+++ b/pkg/apis/openstack/validation/secrets.go
@@ -63,7 +63,7 @@ func ValidateCloudProviderSecret(secret *corev1.Secret) error {
 	// authURL must be a valid URL if present
 	if credentials.AuthURL != "" {
 		if _, err := url.Parse(credentials.AuthURL); err != nil {
-			return fmt.Errorf("field %q in secret %s must be a valid URL if present", openstack.AuthURL, secretKey)
+			return fmt.Errorf("field %q in secret %s must be a valid URL when present: %v", openstack.AuthURL, secretKey, err)
 		}
 	}
 

--- a/pkg/apis/openstack/validation/secrets.go
+++ b/pkg/apis/openstack/validation/secrets.go
@@ -15,12 +15,57 @@
 package validation
 
 import (
+	"fmt"
+	"net/url"
+	"strings"
+
 	"github.com/gardener/gardener-extension-provider-openstack/pkg/openstack"
+
 	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	tenantNameMaxLen = 64
 )
 
 // ValidateCloudProviderSecret checks whether the given secret contains a valid OpenStack credentials.
 func ValidateCloudProviderSecret(secret *corev1.Secret) error {
-	_, err := openstack.ExtractCredentials(secret)
-	return err
+	credentials, err := openstack.ExtractCredentials(secret)
+	if err != nil {
+		return err
+	}
+
+	secretKey := fmt.Sprintf("%s/%s", secret.Namespace, secret.Name)
+
+	// domainName, tenantName, and userName must not contain leading or trailing whitespace
+	for key, value := range map[string]string{
+		openstack.DomainName: credentials.DomainName,
+		openstack.TenantName: credentials.TenantName,
+		openstack.UserName:   credentials.Username,
+	} {
+		if strings.TrimSpace(value) != value {
+			return fmt.Errorf("field %q in secret %s must not contain leading or traling whitespace", key, secretKey)
+		}
+	}
+
+	// tenantName must not be longer than 64 characters, see https://docs.openstack.org/api-ref/identity/v3/?expanded=show-project-details-detail
+	if len(credentials.TenantName) > tenantNameMaxLen {
+		return fmt.Errorf("field %q in secret %s cannot be longer than %d characters", openstack.TenantName, secretKey, tenantNameMaxLen)
+	}
+
+	// password must not contain leading or trailing new lines, as they are known to cause issues
+	// Other whitespace characters such as spaces are intentionally not checked for,
+	// since there is no documentation indicating that they would not be valid
+	if strings.Trim(credentials.Password, "\n\r") != credentials.Password {
+		return fmt.Errorf("field %q in secret %s must not contain leading or traling new lines", openstack.Password, secretKey)
+	}
+
+	// authURL must be a valid URL if present
+	if credentials.AuthURL != "" {
+		if _, err := url.Parse(credentials.AuthURL); err != nil {
+			return fmt.Errorf("field %q in secret %s must be a valid URL if present", openstack.AuthURL, secretKey)
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
**How to categorize this PR?**

/area usability
/area ops-productivity
/kind enhancement
/platform openstack

**What this PR does / why we need it**:
Enhances the validation of Openstack cloud provider secrets:
* `domainName`, `tenantName`, and `userName` must not contain leading or trailing whitespace.
* `tenantName` must not be longer than 64 characters, see https://docs.openstack.org/api-ref/identity/v3/?expanded=show-project-details-detail.
* `password` must not contain leading or trailing new lines, as they are known to cause issues. Other whitespace characters such as spaces are intentionally not checked for, since there I couldn't find any documentation indicating that they would not be valid.
* `authURL` must be a valid URL if present. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
`authURL` is validated with `url.Parse` which is fairly lenient. I believe this is appropriate since there are no documented restrictions for this field besides being a "URL".

**Release note**:

```other operator
Validation of Openstack cloud provider secrets is enhanced to reject `domainName`, `tenantName`, and `userName` that contain leading or trailing whitespace, `tenantName` that is longer than 64 characters, `password` that contain leading or trailing new lines, and `authURL` that is not a valid URL.
```
