### PR TITLE
add support for application credentials

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 ############# builder
-FROM golang:1.16.3 AS builder
+FROM golang:1.16.5 AS builder
 
 WORKDIR /go/src/github.com/gardener/gardener-extension-provider-openstack
 COPY . .
 RUN make install
 
 ############# base
-FROM alpine:3.13.4 AS base
+FROM alpine:3.13.5 AS base
 
 ############# gardener-extension-provider-openstack
 FROM base AS gardener-extension-provider-openstack

--- a/charts/internal/cloud-provider-config/templates/_cloud-provider-config-global.tpl
+++ b/charts/internal/cloud-provider-config/templates/_cloud-provider-config-global.tpl
@@ -2,12 +2,13 @@
 auth-url="{{ .Values.authUrl }}"
 domain-name="{{ .Values.domainName }}"
 tenant-name="{{ .Values.tenantName }}"
-{{- if .Values.username }}
 username="{{ .Values.username }}"
+{{- if .Values.password }}
 password="{{ .Values.password }}"
 {{- end }}
-{{- if .Values.applicationCredentialID }}
+{{- if .Values.applicationCredentialSecret }}
 application-credential-id="{{ .Values.applicationCredentialID }}"
+application-credential-name="{{ .Values.applicationCredentialName }}"
 application-credential-secret="{{ .Values.applicationCredentialSecret }}"
 {{- end }}
 region="{{ .Values.region }}"

--- a/charts/internal/cloud-provider-config/templates/_cloud-provider-config-global.tpl
+++ b/charts/internal/cloud-provider-config/templates/_cloud-provider-config-global.tpl
@@ -2,7 +2,13 @@
 auth-url="{{ .Values.authUrl }}"
 domain-name="{{ .Values.domainName }}"
 tenant-name="{{ .Values.tenantName }}"
+{{- if .Values.username }}
 username="{{ .Values.username }}"
 password="{{ .Values.password }}"
+{{- end }}
+{{- if .Values.applicationCredentialID }}
+application-credential-id="{{ .Values.applicationCredentialID }}"
+application-credential-secret="{{ .Values.applicationCredentialSecret }}"
+{{- end }}
 region="{{ .Values.region }}"
 {{- end -}}

--- a/charts/internal/cloud-provider-config/values.yaml
+++ b/charts/internal/cloud-provider-config/values.yaml
@@ -5,6 +5,9 @@ domainName: fooDomain
 tenantName: fooTenant
 username: barUser
 password: barPass
+# applicationCredentialID: barID
+# applicationCredentialName: barName
+# applicationCredentialSecret: barSecret
 region: eu
 # [LoadBalancer]
 lbProvider: foobar

--- a/docs/usage-as-end-user.md
+++ b/docs/usage-as-end-user.md
@@ -26,6 +26,7 @@ data:
 
   # or application credentials
   #applicationCredentialID: base64(app-credential-id)
+  #applicationCredentialName: base64(app-credential-name) # optional
   #applicationCredentialSecret: base64(app-credential-secret)
 ```
 

--- a/docs/usage-as-end-user.md
+++ b/docs/usage-as-end-user.md
@@ -19,11 +19,22 @@ type: Opaque
 data:
   domainName: base64(domain-name)
   tenantName: base64(tenant-name)
+  
+  # either use username/password
   username: base64(user-name)
   password: base64(password)
+
+  # or application credentials
+  #applicationCredentialID: base64(app-credential-id)
+  #applicationCredentialSecret: base64(app-credential-secret)
 ```
 
 Please look up https://docs.openstack.org/keystone/pike/admin/identity-concepts.html as well.
+
+For authentication with username/password see [Keystone username/password](https://docs.openstack.org/keystone/latest/user/supported_clients.html)
+
+Alternatively, for authentication with application credentials see [Keystone Application Credentials](https://docs.openstack.org/keystone/latest/user/application_credentials.html)
+
 
 ⚠️ Depending on your API usage it can be problematic to reuse the same provider credentials for different Shoot clusters due to rate limits.
 Please consider spreading your Shoots over multiple credentials from different tenants if you are hitting those limits.

--- a/pkg/apis/openstack/validation/secrets.go
+++ b/pkg/apis/openstack/validation/secrets.go
@@ -39,9 +39,11 @@ func ValidateCloudProviderSecret(secret *corev1.Secret) error {
 
 	// domainName, tenantName, and userName must not contain leading or trailing whitespace
 	for key, value := range map[string]string{
-		openstack.DomainName: credentials.DomainName,
-		openstack.TenantName: credentials.TenantName,
-		openstack.UserName:   credentials.Username,
+		openstack.DomainName:                  credentials.DomainName,
+		openstack.TenantName:                  credentials.TenantName,
+		openstack.UserName:                    credentials.Username,
+		openstack.ApplicationCredentialID:     credentials.ApplicationCredentialID,
+		openstack.ApplicationCredentialSecret: credentials.ApplicationCredentialSecret,
 	} {
 		if strings.TrimSpace(value) != value {
 			return fmt.Errorf("field %q in secret %s must not contain leading or traling whitespace", key, secretKey)

--- a/pkg/apis/openstack/validation/secrets.go
+++ b/pkg/apis/openstack/validation/secrets.go
@@ -43,6 +43,7 @@ func ValidateCloudProviderSecret(secret *corev1.Secret) error {
 		openstack.TenantName:                  credentials.TenantName,
 		openstack.UserName:                    credentials.Username,
 		openstack.ApplicationCredentialID:     credentials.ApplicationCredentialID,
+		openstack.ApplicationCredentialName:   credentials.ApplicationCredentialName,
 		openstack.ApplicationCredentialSecret: credentials.ApplicationCredentialSecret,
 	} {
 		if strings.TrimSpace(value) != value {

--- a/pkg/apis/openstack/validation/secrets_test.go
+++ b/pkg/apis/openstack/validation/secrets_test.go
@@ -196,5 +196,63 @@ var _ = Describe("Secret validation", func() {
 			},
 			BeNil(),
 		),
+
+		Entry("should return error when the application credential id contains a trailing new line",
+			map[string][]byte{
+				openstack.DomainName:                  []byte("domain"),
+				openstack.TenantName:                  []byte("tenant"),
+				openstack.ApplicationCredentialID:     []byte("app-id\n"),
+				openstack.ApplicationCredentialSecret: []byte("app-secret"),
+			},
+			HaveOccurred(),
+		),
+
+		Entry("should return error when the application credential secret contains a trailing new line",
+			map[string][]byte{
+				openstack.DomainName:                  []byte("domain"),
+				openstack.TenantName:                  []byte("tenant"),
+				openstack.ApplicationCredentialID:     []byte("app-id"),
+				openstack.ApplicationCredentialSecret: []byte("app-secret\n"),
+			},
+			HaveOccurred(),
+		),
+
+		Entry("should return error when neither username nor application credential id is given",
+			map[string][]byte{
+				openstack.DomainName: []byte("domain"),
+				openstack.TenantName: []byte("tenant"),
+			},
+			HaveOccurred(),
+		),
+
+		Entry("should return error when both username and application credential id is given",
+			map[string][]byte{
+				openstack.DomainName:              []byte("domain"),
+				openstack.TenantName:              []byte("tenant"),
+				openstack.UserName:                []byte("user"),
+				openstack.ApplicationCredentialID: []byte("app-id"),
+			},
+			HaveOccurred(),
+		),
+
+		Entry("should return error when application credential secret is missing",
+			map[string][]byte{
+				openstack.DomainName:              []byte("domain"),
+				openstack.TenantName:              []byte("tenant"),
+				openstack.ApplicationCredentialID: []byte("app-id"),
+			},
+			HaveOccurred(),
+		),
+
+		Entry("should succeed when the client application credentials are valid (with AuthURL)",
+			map[string][]byte{
+				openstack.DomainName:                  []byte("domain"),
+				openstack.TenantName:                  []byte("tenant"),
+				openstack.ApplicationCredentialID:     []byte("app-id"),
+				openstack.ApplicationCredentialSecret: []byte("app-secret"),
+				openstack.AuthURL:                     []byte("https://foo.bar"),
+			},
+			BeNil(),
+		),
 	)
 })

--- a/pkg/apis/openstack/validation/secrets_test.go
+++ b/pkg/apis/openstack/validation/secrets_test.go
@@ -217,6 +217,18 @@ var _ = Describe("Secret validation", func() {
 			HaveOccurred(),
 		),
 
+		Entry("should return error when the application credential name contains a trailing new line",
+			map[string][]byte{
+				openstack.DomainName:                  []byte("domain"),
+				openstack.TenantName:                  []byte("tenant"),
+				openstack.UserName:                    []byte("user"),
+				openstack.ApplicationCredentialID:     []byte("app-id"),
+				openstack.ApplicationCredentialName:   []byte("app-name\n"),
+				openstack.ApplicationCredentialSecret: []byte("app-secret"),
+			},
+			HaveOccurred(),
+		),
+
 		Entry("should return error when neither username nor application credential id is given",
 			map[string][]byte{
 				openstack.DomainName: []byte("domain"),
@@ -225,12 +237,12 @@ var _ = Describe("Secret validation", func() {
 			HaveOccurred(),
 		),
 
-		Entry("should return error when both username and application credential id is given",
+		Entry("should return error when both password and application credential secret is given",
 			map[string][]byte{
-				openstack.DomainName:              []byte("domain"),
-				openstack.TenantName:              []byte("tenant"),
-				openstack.UserName:                []byte("user"),
-				openstack.ApplicationCredentialID: []byte("app-id"),
+				openstack.DomainName:                  []byte("domain"),
+				openstack.TenantName:                  []byte("tenant"),
+				openstack.Password:                    []byte("password"),
+				openstack.ApplicationCredentialSecret: []byte("app-secret"),
 			},
 			HaveOccurred(),
 		),
@@ -244,11 +256,45 @@ var _ = Describe("Secret validation", func() {
 			HaveOccurred(),
 		),
 
-		Entry("should succeed when the client application credentials are valid (with AuthURL)",
+		Entry("should return error when application credential name is given, but without user name",
+			map[string][]byte{
+				openstack.DomainName:                  []byte("domain"),
+				openstack.TenantName:                  []byte("tenant"),
+				openstack.ApplicationCredentialName:   []byte("app-name"),
+				openstack.ApplicationCredentialSecret: []byte("app-secret"),
+			},
+			HaveOccurred(),
+		),
+
+		Entry("should succeed when the client application credentials are valid (id + secret)",
 			map[string][]byte{
 				openstack.DomainName:                  []byte("domain"),
 				openstack.TenantName:                  []byte("tenant"),
 				openstack.ApplicationCredentialID:     []byte("app-id"),
+				openstack.ApplicationCredentialSecret: []byte("app-secret"),
+				openstack.AuthURL:                     []byte("https://foo.bar"),
+			},
+			BeNil(),
+		),
+
+		Entry("should succeed when the client application credentials are valid (id + name + secret)",
+			map[string][]byte{
+				openstack.DomainName:                  []byte("domain"),
+				openstack.TenantName:                  []byte("tenant"),
+				openstack.ApplicationCredentialID:     []byte("app-id"),
+				openstack.ApplicationCredentialName:   []byte("app-name"),
+				openstack.ApplicationCredentialSecret: []byte("app-secret"),
+				openstack.AuthURL:                     []byte("https://foo.bar"),
+			},
+			BeNil(),
+		),
+
+		Entry("should succeed when the client application credentials are valid (username + name + secret)",
+			map[string][]byte{
+				openstack.DomainName:                  []byte("domain"),
+				openstack.TenantName:                  []byte("tenant"),
+				openstack.UserName:                    []byte("user"),
+				openstack.ApplicationCredentialName:   []byte("app-name"),
 				openstack.ApplicationCredentialSecret: []byte("app-secret"),
 				openstack.AuthURL:                     []byte("https://foo.bar"),
 			},

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -488,6 +488,7 @@ func getConfigChartValues(
 		"username":                    c.Username,
 		"password":                    c.Password,
 		"applicationCredentialID":     c.ApplicationCredentialID,
+		"applicationCredentialName":   c.ApplicationCredentialName,
 		"applicationCredentialSecret": c.ApplicationCredentialSecret,
 		"region":                      cp.Spec.Region,
 		"lbProvider":                  cpConfig.LoadBalancerProvider,

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -482,21 +482,23 @@ func getConfigChartValues(
 	}
 
 	values := map[string]interface{}{
-		"kubernetesVersion":          cluster.Shoot.Spec.Kubernetes.Version,
-		"domainName":                 c.DomainName,
-		"tenantName":                 c.TenantName,
-		"username":                   c.Username,
-		"password":                   c.Password,
-		"region":                     cp.Spec.Region,
-		"lbProvider":                 cpConfig.LoadBalancerProvider,
-		"floatingNetworkID":          infraStatus.Networks.FloatingPool.ID,
-		"subnetID":                   subnet.ID,
-		"authUrl":                    keyStoneURL,
-		"dhcpDomain":                 cloudProfileConfig.DHCPDomain,
-		"requestTimeout":             cloudProfileConfig.RequestTimeout,
-		"useOctavia":                 cloudProfileConfig.UseOctavia != nil && *cloudProfileConfig.UseOctavia,
-		"rescanBlockStorageOnResize": cloudProfileConfig.RescanBlockStorageOnResize != nil && *cloudProfileConfig.RescanBlockStorageOnResize,
-		"nodeVolumeAttachLimit":      cloudProfileConfig.NodeVolumeAttachLimit,
+		"kubernetesVersion":           cluster.Shoot.Spec.Kubernetes.Version,
+		"domainName":                  c.DomainName,
+		"tenantName":                  c.TenantName,
+		"username":                    c.Username,
+		"password":                    c.Password,
+		"applicationCredentialID":     c.ApplicationCredentialID,
+		"applicationCredentialSecret": c.ApplicationCredentialSecret,
+		"region":                      cp.Spec.Region,
+		"lbProvider":                  cpConfig.LoadBalancerProvider,
+		"floatingNetworkID":           infraStatus.Networks.FloatingPool.ID,
+		"subnetID":                    subnet.ID,
+		"authUrl":                     keyStoneURL,
+		"dhcpDomain":                  cloudProfileConfig.DHCPDomain,
+		"requestTimeout":              cloudProfileConfig.RequestTimeout,
+		"useOctavia":                  cloudProfileConfig.UseOctavia != nil && *cloudProfileConfig.UseOctavia,
+		"rescanBlockStorageOnResize":  cloudProfileConfig.RescanBlockStorageOnResize != nil && *cloudProfileConfig.RescanBlockStorageOnResize,
+		"nodeVolumeAttachLimit":       cloudProfileConfig.NodeVolumeAttachLimit,
 	}
 
 	var loadBalancerClassesFromCloudProfile = []api.LoadBalancerClass{}

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -256,21 +256,23 @@ var _ = Describe("ValuesProvider", func() {
 
 	Describe("#GetConfigChartValues", func() {
 		configChartValues := map[string]interface{}{
-			"kubernetesVersion":          "1.13.4",
-			"domainName":                 "domain-name",
-			"tenantName":                 "tenant-name",
-			"username":                   "username",
-			"password":                   "password",
-			"region":                     region,
-			"subnetID":                   "subnet-acbd1234",
-			"lbProvider":                 "load-balancer-provider",
-			"floatingNetworkID":          "floating-network-id",
-			"authUrl":                    authURL,
-			"dhcpDomain":                 dhcpDomain,
-			"requestTimeout":             requestTimeout,
-			"useOctavia":                 useOctavia,
-			"rescanBlockStorageOnResize": rescanBlockStorageOnResize,
-			"nodeVolumeAttachLimit":      pointer.Int32Ptr(nodeVoluemAttachLimit),
+			"kubernetesVersion":           "1.13.4",
+			"domainName":                  "domain-name",
+			"tenantName":                  "tenant-name",
+			"username":                    "username",
+			"password":                    "password",
+			"region":                      region,
+			"subnetID":                    "subnet-acbd1234",
+			"lbProvider":                  "load-balancer-provider",
+			"floatingNetworkID":           "floating-network-id",
+			"authUrl":                     authURL,
+			"dhcpDomain":                  dhcpDomain,
+			"requestTimeout":              requestTimeout,
+			"useOctavia":                  useOctavia,
+			"rescanBlockStorageOnResize":  rescanBlockStorageOnResize,
+			"nodeVolumeAttachLimit":       pointer.Int32Ptr(nodeVoluemAttachLimit),
+			"applicationCredentialID":     "",
+			"applicationCredentialSecret": "",
 		}
 
 		It("should return correct config chart values", func() {
@@ -420,6 +422,29 @@ var _ = Describe("ValuesProvider", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(values).To(Equal(expectedValues))
 		})
+
+		It("should return correct config chart values with application credentials", func() {
+			secret2 := *cpSecret
+			secret2.Data = map[string][]byte{
+				"domainName":                  []byte(domainName),
+				"tenantName":                  []byte(tenantName),
+				"applicationCredentialID":     []byte(`app-id`),
+				"applicationCredentialSecret": []byte(`app-secret`),
+			}
+
+			c.EXPECT().Get(ctx, cpSecretKey, &corev1.Secret{}).DoAndReturn(clientGet(&secret2))
+
+			expectedValues := utils.MergeMaps(configChartValues, map[string]interface{}{
+				"username":                    "",
+				"password":                    "",
+				"applicationCredentialID":     "app-id",
+				"applicationCredentialSecret": "app-secret",
+			})
+			values, err := vp.GetConfigChartValues(ctx, cp, clusterK8sLessThan119)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(values).To(Equal(expectedValues))
+		})
+
 	})
 
 	Describe("#GetControlPlaneChartValues", func() {

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -273,6 +273,7 @@ var _ = Describe("ValuesProvider", func() {
 			"nodeVolumeAttachLimit":       pointer.Int32Ptr(nodeVoluemAttachLimit),
 			"applicationCredentialID":     "",
 			"applicationCredentialSecret": "",
+			"applicationCredentialName":   "",
 		}
 
 		It("should return correct config chart values", func() {

--- a/pkg/controller/infrastructure/actuator_delete.go
+++ b/pkg/controller/infrastructure/actuator_delete.go
@@ -52,9 +52,8 @@ func (a *actuator) Delete(ctx context.Context, infra *extensionsv1alpha1.Infrast
 	if err != nil {
 		return err
 	}
-	useApplicationCredentials := credentials.ApplicationCredentialID != ""
 
 	return tf.
-		SetEnvVars(internal.TerraformerEnvVars(infra.Spec.SecretRef, useApplicationCredentials)...).
+		SetEnvVars(internal.TerraformerEnvVars(infra.Spec.SecretRef, credentials)...).
 		Destroy(ctx)
 }

--- a/pkg/controller/infrastructure/actuator_delete.go
+++ b/pkg/controller/infrastructure/actuator_delete.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/gardener/gardener-extension-provider-openstack/pkg/internal"
 	"github.com/gardener/gardener-extension-provider-openstack/pkg/internal/infrastructure"
+	"github.com/gardener/gardener-extension-provider-openstack/pkg/openstack"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
@@ -46,7 +47,14 @@ func (a *actuator) Delete(ctx context.Context, infra *extensionsv1alpha1.Infrast
 		return tf.CleanupConfiguration(ctx)
 	}
 
+	// need to known if application credentials are used
+	credentials, err := openstack.GetCredentials(ctx, a.Client(), infra.Spec.SecretRef)
+	if err != nil {
+		return err
+	}
+	useApplicationCredentials := credentials.ApplicationCredentialID != ""
+
 	return tf.
-		SetEnvVars(internal.TerraformerEnvVars(infra.Spec.SecretRef)...).
+		SetEnvVars(internal.TerraformerEnvVars(infra.Spec.SecretRef, useApplicationCredentials)...).
 		Destroy(ctx)
 }

--- a/pkg/controller/infrastructure/actuator_reconcile.go
+++ b/pkg/controller/infrastructure/actuator_reconcile.go
@@ -51,9 +51,8 @@ func (a *actuator) reconcile(ctx context.Context, logger logr.Logger, infra *ext
 	if err != nil {
 		return err
 	}
-	useApplicationCredentials := credentials.ApplicationCredentialID != ""
 
-	tf, err := internal.NewTerraformerWithAuth(logger, a.RESTConfig(), infrastructure.TerraformerPurpose, infra, useApplicationCredentials)
+	tf, err := internal.NewTerraformerWithAuth(logger, a.RESTConfig(), infrastructure.TerraformerPurpose, infra, credentials)
 	if err != nil {
 		return err
 	}

--- a/pkg/internal/infrastructure/templates/main.tpl.tf
+++ b/pkg/internal/infrastructure/templates/main.tpl.tf
@@ -5,6 +5,8 @@ provider "openstack" {
   region      = "{{ .openstack.region }}"
   user_name   = var.USER_NAME
   password    = var.PASSWORD
+  application_credential_id     = var.APPLICATION_CREDENTIAL_ID
+  application_credential_secret = var.APPLICATION_CREDENTIAL_SECRET
   insecure    = true
   max_retries = "{{ .openstack.maxApiCallRetries }}"
 }

--- a/pkg/internal/infrastructure/templates/main.tpl.tf
+++ b/pkg/internal/infrastructure/templates/main.tpl.tf
@@ -6,6 +6,7 @@ provider "openstack" {
   user_name   = var.USER_NAME
   password    = var.PASSWORD
   application_credential_id     = var.APPLICATION_CREDENTIAL_ID
+  application_credential_name   = var.APPLICATION_CREDENTIAL_NAME
   application_credential_secret = var.APPLICATION_CREDENTIAL_SECRET
   insecure    = true
   max_retries = "{{ .openstack.maxApiCallRetries }}"

--- a/pkg/internal/infrastructure/templates/variables.tf
+++ b/pkg/internal/infrastructure/templates/variables.tf
@@ -11,9 +11,23 @@ variable "TENANT_NAME" {
 variable "USER_NAME" {
   description = "OpenStack user name"
   type        = string
+  default     = "" # not needed if application credentials are used
 }
 
 variable "PASSWORD" {
   description = "OpenStack password"
   type        = string
+  default     = "" # not needed if application credentials are used
+}
+
+variable "APPLICATION_CREDENTIAL_ID" {
+  description = "OpenStack application credential id"
+  type        = string
+  default     = "" # not needed if username/password are used
+}
+
+variable "APPLICATION_CREDENTIAL_SECRET" {
+  description = "OpenStack application credential secret"
+  type        = string
+  default     = "" # not needed if username/password are used
 }

--- a/pkg/internal/infrastructure/templates/variables.tf
+++ b/pkg/internal/infrastructure/templates/variables.tf
@@ -11,7 +11,7 @@ variable "TENANT_NAME" {
 variable "USER_NAME" {
   description = "OpenStack user name"
   type        = string
-  default     = "" # not needed if application credentials are used
+  default     = "" # not needed if application credentials are used with APPLICATION_CREDENTIAL_ID
 }
 
 variable "PASSWORD" {
@@ -24,6 +24,12 @@ variable "APPLICATION_CREDENTIAL_ID" {
   description = "OpenStack application credential id"
   type        = string
   default     = "" # not needed if username/password are used
+}
+
+variable "APPLICATION_CREDENTIAL_NAME" {
+  description = "OpenStack application credential name"
+  type        = string
+  default     = "" # not needed if username/password are used or APPLICATION_CREDENTIAL_ID is given
 }
 
 variable "APPLICATION_CREDENTIAL_SECRET" {

--- a/pkg/internal/terraform_test.go
+++ b/pkg/internal/terraform_test.go
@@ -15,6 +15,7 @@
 package internal
 
 import (
+	"github.com/gardener/gardener-extension-provider-openstack/pkg/openstack"
 	corev1 "k8s.io/api/core/v1"
 
 	. "github.com/onsi/ginkgo"
@@ -25,7 +26,8 @@ var _ = Describe("Terraform", func() {
 	Describe("#TerraformerEnvVars", func() {
 		It("should correctly create the environment variables for username/password", func() {
 			secretRef := corev1.SecretReference{Name: "cloud"}
-			Expect(TerraformerEnvVars(secretRef, false)).To(ConsistOf(
+			credentials := &openstack.Credentials{}
+			Expect(TerraformerEnvVars(secretRef, credentials)).To(ConsistOf(
 				corev1.EnvVar{
 					Name: "TF_VAR_DOMAIN_NAME",
 					ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{
@@ -63,9 +65,13 @@ var _ = Describe("Terraform", func() {
 					}},
 				}))
 		})
-		It("should correctly create the environment variables for application credentials", func() {
+		It("should correctly create the environment variables for application credentials (id + secret)", func() {
 			secretRef := corev1.SecretReference{Name: "cloud"}
-			Expect(TerraformerEnvVars(secretRef, true)).To(ConsistOf(
+			credentials := &openstack.Credentials{
+				ApplicationCredentialSecret: "secret",
+				ApplicationCredentialID:     "appid",
+			}
+			Expect(TerraformerEnvVars(secretRef, credentials)).To(ConsistOf(
 				corev1.EnvVar{
 					Name: "TF_VAR_DOMAIN_NAME",
 					ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{
@@ -100,6 +106,60 @@ var _ = Describe("Terraform", func() {
 							Name: secretRef.Name,
 						},
 						Key: "applicationCredentialSecret",
+					}},
+				}))
+		})
+		It("should correctly create the environment variables for application credentials (username + name + secret)", func() {
+			secretRef := corev1.SecretReference{Name: "cloud"}
+			credentials := &openstack.Credentials{
+				Username:                    "fred",
+				ApplicationCredentialName:   "appname",
+				ApplicationCredentialSecret: "secret",
+			}
+			Expect(TerraformerEnvVars(secretRef, credentials)).To(ConsistOf(
+				corev1.EnvVar{
+					Name: "TF_VAR_DOMAIN_NAME",
+					ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: secretRef.Name,
+						},
+						Key: "domainName",
+					}},
+				},
+				corev1.EnvVar{
+					Name: "TF_VAR_TENANT_NAME",
+					ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: secretRef.Name,
+						},
+						Key: "tenantName",
+					}},
+				},
+				corev1.EnvVar{
+					Name: "TF_VAR_APPLICATION_CREDENTIAL_NAME",
+					ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: secretRef.Name,
+						},
+						Key: "applicationCredentialName",
+					}},
+				},
+				corev1.EnvVar{
+					Name: "TF_VAR_APPLICATION_CREDENTIAL_SECRET",
+					ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: secretRef.Name,
+						},
+						Key: "applicationCredentialSecret",
+					}},
+				},
+				corev1.EnvVar{
+					Name: "TF_VAR_USER_NAME",
+					ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: secretRef.Name,
+						},
+						Key: "username",
 					}},
 				}))
 		})

--- a/pkg/internal/terraform_test.go
+++ b/pkg/internal/terraform_test.go
@@ -23,9 +23,9 @@ import (
 
 var _ = Describe("Terraform", func() {
 	Describe("#TerraformerEnvVars", func() {
-		It("should correctly create the environment variables", func() {
+		It("should correctly create the environment variables for username/password", func() {
 			secretRef := corev1.SecretReference{Name: "cloud"}
-			Expect(TerraformerEnvVars(secretRef)).To(ConsistOf(
+			Expect(TerraformerEnvVars(secretRef, false)).To(ConsistOf(
 				corev1.EnvVar{
 					Name: "TF_VAR_DOMAIN_NAME",
 					ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{
@@ -60,6 +60,46 @@ var _ = Describe("Terraform", func() {
 							Name: secretRef.Name,
 						},
 						Key: "password",
+					}},
+				}))
+		})
+		It("should correctly create the environment variables for application credentials", func() {
+			secretRef := corev1.SecretReference{Name: "cloud"}
+			Expect(TerraformerEnvVars(secretRef, true)).To(ConsistOf(
+				corev1.EnvVar{
+					Name: "TF_VAR_DOMAIN_NAME",
+					ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: secretRef.Name,
+						},
+						Key: "domainName",
+					}},
+				},
+				corev1.EnvVar{
+					Name: "TF_VAR_TENANT_NAME",
+					ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: secretRef.Name,
+						},
+						Key: "tenantName",
+					}},
+				},
+				corev1.EnvVar{
+					Name: "TF_VAR_APPLICATION_CREDENTIAL_ID",
+					ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: secretRef.Name,
+						},
+						Key: "applicationCredentialID",
+					}},
+				},
+				corev1.EnvVar{
+					Name: "TF_VAR_APPLICATION_CREDENTIAL_SECRET",
+					ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: secretRef.Name,
+						},
+						Key: "applicationCredentialSecret",
 					}},
 				}))
 		})

--- a/pkg/openstack/client/client.go
+++ b/pkg/openstack/client/client.go
@@ -38,11 +38,12 @@ func NewOpenstackClientFromCredentials(credentials *os.Credentials) (Factory, er
 			ProjectName:                 credentials.TenantName,
 			DomainName:                  credentials.DomainName,
 			ApplicationCredentialID:     credentials.ApplicationCredentialID,
+			ApplicationCredentialName:   credentials.ApplicationCredentialName,
 			ApplicationCredentialSecret: credentials.ApplicationCredentialSecret,
 		},
 	}
 
-	if opts.AuthInfo.ApplicationCredentialID != "" {
+	if opts.AuthInfo.ApplicationCredentialSecret != "" {
 		opts.AuthType = clientconfig.AuthV3ApplicationCredential
 	}
 

--- a/pkg/openstack/client/client.go
+++ b/pkg/openstack/client/client.go
@@ -32,12 +32,18 @@ import (
 func NewOpenstackClientFromCredentials(credentials *os.Credentials) (Factory, error) {
 	opts := &clientconfig.ClientOpts{
 		AuthInfo: &clientconfig.AuthInfo{
-			AuthURL:     credentials.AuthURL,
-			Username:    credentials.Username,
-			Password:    credentials.Password,
-			ProjectName: credentials.TenantName,
-			DomainName:  credentials.DomainName,
+			AuthURL:                     credentials.AuthURL,
+			Username:                    credentials.Username,
+			Password:                    credentials.Password,
+			ProjectName:                 credentials.TenantName,
+			DomainName:                  credentials.DomainName,
+			ApplicationCredentialID:     credentials.ApplicationCredentialID,
+			ApplicationCredentialSecret: credentials.ApplicationCredentialSecret,
 		},
+	}
+
+	if opts.AuthInfo.ApplicationCredentialID != "" {
+		opts.AuthType = clientconfig.AuthV3ApplicationCredential
 	}
 
 	authOpts, err := clientconfig.AuthOptions(opts)

--- a/pkg/openstack/types.go
+++ b/pkg/openstack/types.go
@@ -58,6 +58,8 @@ const (
 	Password = "password"
 	// ApplicationCredentialID is a constant for the key in a cloud provider secret and backup secret that holds the OpenStack application credential id.
 	ApplicationCredentialID = "applicationCredentialID"
+	// ApplicationCredentialName is a constant for the key in a cloud provider secret and backup secret that holds the OpenStack application credential name.
+	ApplicationCredentialName = "applicationCredentialName"
 	// ApplicationCredentialSecret is a constant for the key in a cloud provider secret and backup secret that holds the OpenStack application credential secret.
 	ApplicationCredentialSecret = "applicationCredentialSecret"
 	// Region is a constant for the key in a backup secret that holds the Openstack region.

--- a/pkg/openstack/types.go
+++ b/pkg/openstack/types.go
@@ -56,6 +56,10 @@ const (
 	UserName = "username"
 	// Password is a constant for the key in a cloud provider secret and backup secret that holds the OpenStack password.
 	Password = "password"
+	// ApplicationCredentialID is a constant for the key in a cloud provider secret and backup secret that holds the OpenStack application credential id.
+	ApplicationCredentialID = "applicationCredentialID"
+	// ApplicationCredentialSecret is a constant for the key in a cloud provider secret and backup secret that holds the OpenStack application credential secret.
+	ApplicationCredentialSecret = "applicationCredentialSecret"
 	// Region is a constant for the key in a backup secret that holds the Openstack region.
 	Region = "region"
 	// Insecure is a constant for the key in a cloud provider secret that configures whether the OpenStack client verifies the server's certificate.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/area security
/kind enhancement
/platform openstack

**What this PR does / why we need it**:
The provider secret for Openstack can contain the keys `applicationCredentialID` and `applicationCredentialSecret` as alternative to authentication with username/password 

**Which issue(s) this PR fixes**:
Fixes #4 

**Special notes for your reviewer**:
This PR is depending on a new release of the **machine-controller-manager-provider-openstack** which includes PR https://github.com/gardener/machine-controller-manager-provider-openstack/pull/26

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
add support for application credentials
```
