### PR TITLE
fix server group removal from worker pool

### DIFF
--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -117,7 +117,19 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 			}
 		}
 
-		serverGroupDep := serverGroupDepSet.getByPoolName(pool.Name)
+		poolProviderConfig, err := helper.WorkerConfigFromRawExtension(pool.ProviderConfig)
+		if err != nil {
+			return err
+		}
+
+		var serverGroupDep *api.ServerGroupDependency
+		if isServerGroupRequired(poolProviderConfig) {
+			serverGroupDep = serverGroupDepSet.getByPoolName(pool.Name)
+			if serverGroupDep == nil {
+				return fmt.Errorf("server group is required for pool %q, but no server group dependency found", pool.Name)
+			}
+		}
+
 		workerPoolHash, err := w.generateWorkerPoolHash(pool, serverGroupDep)
 		if err != nil {
 			return err

--- a/pkg/controller/worker/server_groups.go
+++ b/pkg/controller/worker/server_groups.go
@@ -26,17 +26,17 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/servergroups"
 )
 
+func isServerGroupRequired(config *api.WorkerConfig) bool {
+	return config != nil && config.ServerGroup != nil && config.ServerGroup.Policy != ""
+}
+
 func generateServerGroupName(clusterName, poolName string) (string, error) {
 	suffix, err := utils.GenerateRandomString(10)
 	if err != nil {
 		return "", err
 	}
 
-	return fmt.Sprintf("%s-%s", getServerGroupNamePrefixForPool(clusterName, poolName), suffix), nil
-}
-
-func getServerGroupNamePrefixForPool(clusterName, poolName string) string {
-	return fmt.Sprintf("%s-%s", clusterName, poolName)
+	return fmt.Sprintf("%s-%s-%s", clusterName, poolName, suffix), nil
 }
 
 func filterServerGroupsByPrefix(sgs []servergroups.ServerGroup, prefix string) []servergroups.ServerGroup {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/platform openstack

**What this PR does / why we need it**:

+ Fixes an issue with servergroups. Prior to the fix, when the servergroups are deleted from a workerpool it would require 2 reconcilliation loops for the change in the shoot's spec to create proper machineclasses.

Minor:
+ change a `map[string]struct{}` used for string lookup to `sets.String`
+ improve the servergroup reverse name lookup by taking into account a trailing `-`.  For example shoots like `shoot_name` and `shoot_name_2` will no longer collide during the reverse lookup. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fixes an issue where removing server groups from a worker pool would not produce correct `machineclasses`. Prior to the fix, two shoot reconciliations would be necessary to reach the desired state.
```
