### PR TITLE
Improve LoadBalancerClass validation

### DIFF
--- a/pkg/apis/openstack/cloudprofile_test.go
+++ b/pkg/apis/openstack/cloudprofile_test.go
@@ -1,0 +1,86 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openstack_test
+
+import (
+	. "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack"
+	"k8s.io/utils/pointer"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("LoadBalancerClass", func() {
+	Context("#IsSemanticallyEqual", func() {
+		var (
+			loadBalancerClassA LoadBalancerClass
+			loadBalancerClassB LoadBalancerClass
+		)
+
+		BeforeEach(func() {
+			loadBalancerClassA = LoadBalancerClass{
+				Name:               "lbclass-A",
+				FloatingNetworkID:  pointer.StringPtr("floating-network-id"),
+				FloatingSubnetID:   pointer.StringPtr("floating-subnet-id"),
+				FloatingSubnetName: pointer.StringPtr("floating-subnet-name"),
+				FloatingSubnetTags: pointer.StringPtr("floating-subnet-tags"),
+				SubnetID:           pointer.StringPtr("subnet-id"),
+			}
+			loadBalancerClassB = LoadBalancerClass{
+				Name:               "lbclass-B",
+				FloatingNetworkID:  pointer.StringPtr("floating-network-id"),
+				FloatingSubnetID:   pointer.StringPtr("floating-subnet-id"),
+				FloatingSubnetName: pointer.StringPtr("floating-subnet-name"),
+				FloatingSubnetTags: pointer.StringPtr("floating-subnet-tags"),
+				SubnetID:           pointer.StringPtr("subnet-id"),
+			}
+		})
+
+		It("should return true as LoadBalancerClass are semantically equal with different names", func() {
+			Expect(loadBalancerClassA.IsSemanticallyEqual(loadBalancerClassB)).To(BeTrue())
+		})
+
+		It("should return true as LoadBalancerClass are semantically equal with different purposes", func() {
+			loadBalancerClassA.Purpose = pointer.StringPtr("purpose-a")
+			loadBalancerClassB.Purpose = pointer.StringPtr("purpose-b")
+			Expect(loadBalancerClassA.IsSemanticallyEqual(loadBalancerClassB)).To(BeTrue())
+		})
+
+		It("should return false as LoadBalancerClass are not semantically due to different floating network ids", func() {
+			loadBalancerClassB.FloatingNetworkID = pointer.StringPtr("floating-network-id-2")
+			Expect(loadBalancerClassA.IsSemanticallyEqual(loadBalancerClassB)).To(BeFalse())
+		})
+
+		It("should return false as LoadBalancerClass are not semantically due to different floating subnet ids", func() {
+			loadBalancerClassB.FloatingSubnetID = pointer.StringPtr("floating-subnet-id-2")
+			Expect(loadBalancerClassA.IsSemanticallyEqual(loadBalancerClassB)).To(BeFalse())
+		})
+
+		It("should return false as LoadBalancerClass are not semantically due to different floating subnet names", func() {
+			loadBalancerClassB.FloatingSubnetName = pointer.StringPtr("floating-subnet-name-2")
+			Expect(loadBalancerClassA.IsSemanticallyEqual(loadBalancerClassB)).To(BeFalse())
+		})
+
+		It("should return false as LoadBalancerClass are not semantically due to different floating subnet tags", func() {
+			loadBalancerClassB.FloatingSubnetTags = pointer.StringPtr("floating-subnet-tags-2")
+			Expect(loadBalancerClassA.IsSemanticallyEqual(loadBalancerClassB)).To(BeFalse())
+		})
+
+		It("should return false as LoadBalancerClass are not semantically due to different subnet ids", func() {
+			loadBalancerClassB.SubnetID = pointer.StringPtr("subnet-ids-2")
+			Expect(loadBalancerClassA.IsSemanticallyEqual(loadBalancerClassB)).To(BeFalse())
+		})
+	})
+})

--- a/pkg/apis/openstack/openstack_suite_test.go
+++ b/pkg/apis/openstack/openstack_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openstack_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestV1alpha1(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "API Openstack Suite")
+}

--- a/pkg/apis/openstack/types_cloudprofile.go
+++ b/pkg/apis/openstack/types_cloudprofile.go
@@ -17,6 +17,8 @@ package openstack
 import (
 	"fmt"
 
+	"github.com/gardener/gardener-extension-provider-openstack/pkg/utils"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -104,6 +106,27 @@ type LoadBalancerClass struct {
 	// SubnetID is the ID of a local subnet used for LoadBalancer provisioning. Only usable if no FloatingPool
 	// configuration is done.
 	SubnetID *string
+}
+
+// IsSemanticallyEqual checks if the load balancer class is semantically equal to
+// another given load balancer class. Name and Purpose fields are allowed to be different.
+func (l LoadBalancerClass) IsSemanticallyEqual(e LoadBalancerClass) bool {
+	if !utils.StringEqual(l.FloatingNetworkID, e.FloatingNetworkID) {
+		return false
+	}
+	if !utils.StringEqual(l.FloatingSubnetID, e.FloatingSubnetID) {
+		return false
+	}
+	if !utils.StringEqual(l.FloatingSubnetName, e.FloatingSubnetName) {
+		return false
+	}
+	if !utils.StringEqual(l.FloatingSubnetTags, e.FloatingSubnetTags) {
+		return false
+	}
+	if !utils.StringEqual(l.SubnetID, e.SubnetID) {
+		return false
+	}
+	return true
 }
 
 func (in LoadBalancerClass) String() string {

--- a/pkg/apis/openstack/validation/cloudprofile.go
+++ b/pkg/apis/openstack/validation/cloudprofile.go
@@ -190,6 +190,7 @@ func validateLoadBalancerClass(lbClass api.LoadBalancerClass, fldPath *field.Pat
 	return allErrs
 }
 
+// ValidateLoadBalancerClasses validates a given list of LoadBalancerClass objects.
 func ValidateLoadBalancerClasses(loadBalancerClasses []api.LoadBalancerClass, fldPath *field.Path) field.ErrorList {
 	var (
 		defaultClassExists bool


### PR DESCRIPTION
**How to categorize this PR?**
/kind enhancement
/platform openstack

**What this PR does / why we need it**:
Allow to change the name and purpose of load balancer classes in `.controlPlaneConfig.loadBalancerClasses[]`. The load balancer classes configuration need still to be semantically equal with the load balancer classes from the CloudProfile.

Add validation to check if there are no load balancer classes with same name and if there are multiple default or private load balancer classes.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
It is now allowed to change the name and purpose of load balancer classes in `.controlPlaneConfig.loadBalancerClasses[]`. The load balancer classes configuration need still to be semantically equal with the load balancer classes from the CloudProfile.
```

/invite @kon-angelo @MartinWeindel 
cc @RaphaelVogel 
