### PR TITLE
Set minAllowed memory for csi-driver-node containers

### DIFF
--- a/charts/internal/shoot-system-components/charts/csi-driver-node/templates/vpa.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/templates/vpa.yaml
@@ -5,6 +5,11 @@ metadata:
   name: csi-driver-node
   namespace: {{ .Release.Namespace }}
 spec:
+  resourcePolicy:
+    containerPolicies:
+    - containerName: '*'
+      minAllowed:
+        memory: 25Mi
   targetRef:
     apiVersion: apps/v1
     kind: DaemonSet


### PR DESCRIPTION
/area storage
/kind bug
/platform openstack

Similar to https://github.com/gardener/gardener-extension-provider-aws/pull/369

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
