### PR TITLE
Deploy shoots in existing Neutron networks

### DIFF
--- a/charts/internal/machineclass/templates/machineclass.yaml
+++ b/charts/internal/machineclass/templates/machineclass.yaml
@@ -37,15 +37,13 @@ providerSpec:
     availabilityZone: {{ $machineClass.availabilityZone }}
     flavorName: {{ $machineClass.machineType }}
     keyName: {{ $machineClass.keyName }}
-{{- if $machineClass.subnetID }}
-    subnetID: {{ $machineClass.subnetID }}
-{{- end }}
 {{- if $machineClass.imageID }}
     imageID: {{ $machineClass.imageID }}
 {{- else }}
     imageName: {{ $machineClass.imageName }}
 {{- end }}
     networkID: {{ $machineClass.networkID }}
+    subnetID: {{ $machineClass.subnetID }}
     podNetworkCidr: {{ $machineClass.podNetworkCidr }}
 {{- if $machineClass.rootDiskSize }}
     rootDiskSize: {{ $machineClass.rootDiskSize }}

--- a/charts/internal/machineclass/templates/machineclass.yaml
+++ b/charts/internal/machineclass/templates/machineclass.yaml
@@ -37,6 +37,9 @@ providerSpec:
     availabilityZone: {{ $machineClass.availabilityZone }}
     flavorName: {{ $machineClass.machineType }}
     keyName: {{ $machineClass.keyName }}
+{{- if $machineClass.subnetID }}
+    subnetID: {{ $machineClass.subnetID }}
+{{- end }}
 {{- if $machineClass.imageID }}
     imageID: {{ $machineClass.imageID }}
 {{- else }}

--- a/docs/usage-as-end-user.md
+++ b/docs/usage-as-end-user.md
@@ -52,6 +52,7 @@ kind: InfrastructureConfig
 floatingPoolName: MY-FLOATING-POOL
 # floatingPoolSubnetName: my-floating-pool-subnet-name
 networks:
+# id: 12345678-abcd-efef-08af-0123456789ab
 # router:
 #   id: 1234
   workers: 10.250.0.0/19
@@ -61,6 +62,8 @@ The `floatingPoolName` is the name of the floating pool you want to use for your
 If you don't know which floating pools are available look it up in the respective `CloudProfile`.
 
 With `floatingPoolSubnetName` you can explicitly define to which subnet in the floating pool network (defined via `floatingPoolName`) the router should be attached to.
+
+If `networks.id` is an optional field. If it is given, you can specify the uuid of an existing private Neutron network (created manually, by other tooling, ...) that should be reused. A new subnet for the Shoot will be created in it.
 
 The `networks.router` section describes whether you want to create the shoot cluster in an already existing router or whether to create a new one:
 

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/go-logr/logr v0.4.0
 	github.com/golang/mock v1.6.0
 	github.com/golang/snappy v0.0.2 // indirect
+	github.com/google/uuid v1.1.2
 	github.com/gophercloud/gophercloud v0.7.0
 	github.com/gophercloud/utils v0.0.0-20200204043447-9864b6f1f12f
 	github.com/mitchellh/copystructure v1.1.1 // indirect

--- a/hack/api-reference/api.md
+++ b/hack/api-reference/api.md
@@ -1059,17 +1059,6 @@ string
 </tr>
 <tr>
 <td>
-<code>managed</code></br>
-<em>
-bool
-</em>
-</td>
-<td>
-<p>ManagedPrivateNetwork indicates whether the network is managed by Gardener.</p>
-</td>
-</tr>
-<tr>
-<td>
 <code>floatingPool</code></br>
 <em>
 <a href="#openstack.provider.extensions.gardener.cloud/v1alpha1.FloatingPoolStatus">

--- a/hack/api-reference/api.md
+++ b/hack/api-reference/api.md
@@ -1059,6 +1059,17 @@ string
 </tr>
 <tr>
 <td>
+<code>managed</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+<p>ManagedPrivateNetwork indicates whether the network is managed by Gardener.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>floatingPool</code></br>
 <em>
 <a href="#openstack.provider.extensions.gardener.cloud/v1alpha1.FloatingPoolStatus">
@@ -1150,6 +1161,18 @@ string
 </td>
 <td>
 <p>Workers is a CIDRs of a worker subnet (private) to create (used for the VMs).</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>id</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ID is the ID of an existing private network.</p>
 </td>
 </tr>
 </tbody>

--- a/pkg/apis/openstack/types_infrastructure.go
+++ b/pkg/apis/openstack/types_infrastructure.go
@@ -74,8 +74,6 @@ type NodeStatus struct {
 type NetworkStatus struct {
 	// ID is the Network id.
 	ID string
-	// ManagedPrivateNetwork indicates whether the network is managed by Gardener.
-	ManagedPrivateNetwork bool
 	// FloatingPool contains information about the floating pool.
 	FloatingPool FloatingPoolStatus
 	// Router contains information about the Router and related resources.

--- a/pkg/apis/openstack/types_infrastructure.go
+++ b/pkg/apis/openstack/types_infrastructure.go
@@ -41,6 +41,8 @@ type Networks struct {
 	Worker string
 	// Workers is a CIDRs of a worker subnet (private) to create (used for the VMs).
 	Workers string
+	// ID is the ID of an existing private network.
+	ID *string
 }
 
 // Router indicates whether to use an existing router or create a new one.
@@ -72,6 +74,8 @@ type NodeStatus struct {
 type NetworkStatus struct {
 	// ID is the Network id.
 	ID string
+	// ManagedPrivateNetwork indicates whether the network is managed by Gardener.
+	ManagedPrivateNetwork bool
 	// FloatingPool contains information about the floating pool.
 	FloatingPool FloatingPoolStatus
 	// Router contains information about the Router and related resources.

--- a/pkg/apis/openstack/v1alpha1/types_infrastructure.go
+++ b/pkg/apis/openstack/v1alpha1/types_infrastructure.go
@@ -44,6 +44,9 @@ type Networks struct {
 	Worker string `json:"worker"`
 	// Workers is a CIDRs of a worker subnet (private) to create (used for the VMs).
 	Workers string `json:"workers"`
+	// ID is the ID of an existing private network.
+	// +optional
+	ID *string `json:"id,omitempty"`
 }
 
 // Router indicates whether to use an existing router or create a new one.
@@ -75,6 +78,8 @@ type NodeStatus struct {
 type NetworkStatus struct {
 	// ID is the Network id.
 	ID string `json:"id"`
+	// ManagedPrivateNetwork indicates whether the network is managed by Gardener.
+	ManagedPrivateNetwork bool `json:"managed"`
 	// FloatingPool contains information about the floating pool.
 	FloatingPool FloatingPoolStatus `json:"floatingPool"`
 	// Router contains information about the Router and related resources.

--- a/pkg/apis/openstack/v1alpha1/types_infrastructure.go
+++ b/pkg/apis/openstack/v1alpha1/types_infrastructure.go
@@ -78,8 +78,6 @@ type NodeStatus struct {
 type NetworkStatus struct {
 	// ID is the Network id.
 	ID string `json:"id"`
-	// ManagedPrivateNetwork indicates whether the network is managed by Gardener.
-	ManagedPrivateNetwork bool `json:"managed"`
 	// FloatingPool contains information about the floating pool.
 	FloatingPool FloatingPoolStatus `json:"floatingPool"`
 	// Router contains information about the Router and related resources.

--- a/pkg/apis/openstack/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/openstack/v1alpha1/zz_generated.conversion.go
@@ -674,7 +674,6 @@ func Convert_openstack_MachineImages_To_v1alpha1_MachineImages(in *openstack.Mac
 
 func autoConvert_v1alpha1_NetworkStatus_To_openstack_NetworkStatus(in *NetworkStatus, out *openstack.NetworkStatus, s conversion.Scope) error {
 	out.ID = in.ID
-	out.ManagedPrivateNetwork = in.ManagedPrivateNetwork
 	if err := Convert_v1alpha1_FloatingPoolStatus_To_openstack_FloatingPoolStatus(&in.FloatingPool, &out.FloatingPool, s); err != nil {
 		return err
 	}
@@ -692,7 +691,6 @@ func Convert_v1alpha1_NetworkStatus_To_openstack_NetworkStatus(in *NetworkStatus
 
 func autoConvert_openstack_NetworkStatus_To_v1alpha1_NetworkStatus(in *openstack.NetworkStatus, out *NetworkStatus, s conversion.Scope) error {
 	out.ID = in.ID
-	out.ManagedPrivateNetwork = in.ManagedPrivateNetwork
 	if err := Convert_openstack_FloatingPoolStatus_To_v1alpha1_FloatingPoolStatus(&in.FloatingPool, &out.FloatingPool, s); err != nil {
 		return err
 	}

--- a/pkg/apis/openstack/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/openstack/v1alpha1/zz_generated.conversion.go
@@ -674,6 +674,7 @@ func Convert_openstack_MachineImages_To_v1alpha1_MachineImages(in *openstack.Mac
 
 func autoConvert_v1alpha1_NetworkStatus_To_openstack_NetworkStatus(in *NetworkStatus, out *openstack.NetworkStatus, s conversion.Scope) error {
 	out.ID = in.ID
+	out.ManagedPrivateNetwork = in.ManagedPrivateNetwork
 	if err := Convert_v1alpha1_FloatingPoolStatus_To_openstack_FloatingPoolStatus(&in.FloatingPool, &out.FloatingPool, s); err != nil {
 		return err
 	}
@@ -691,6 +692,7 @@ func Convert_v1alpha1_NetworkStatus_To_openstack_NetworkStatus(in *NetworkStatus
 
 func autoConvert_openstack_NetworkStatus_To_v1alpha1_NetworkStatus(in *openstack.NetworkStatus, out *NetworkStatus, s conversion.Scope) error {
 	out.ID = in.ID
+	out.ManagedPrivateNetwork = in.ManagedPrivateNetwork
 	if err := Convert_openstack_FloatingPoolStatus_To_v1alpha1_FloatingPoolStatus(&in.FloatingPool, &out.FloatingPool, s); err != nil {
 		return err
 	}
@@ -710,6 +712,7 @@ func autoConvert_v1alpha1_Networks_To_openstack_Networks(in *Networks, out *open
 	out.Router = (*openstack.Router)(unsafe.Pointer(in.Router))
 	out.Worker = in.Worker
 	out.Workers = in.Workers
+	out.ID = (*string)(unsafe.Pointer(in.ID))
 	return nil
 }
 
@@ -722,6 +725,7 @@ func autoConvert_openstack_Networks_To_v1alpha1_Networks(in *openstack.Networks,
 	out.Router = (*Router)(unsafe.Pointer(in.Router))
 	out.Worker = in.Worker
 	out.Workers = in.Workers
+	out.ID = (*string)(unsafe.Pointer(in.ID))
 	return nil
 }
 

--- a/pkg/apis/openstack/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/openstack/v1alpha1/zz_generated.deepcopy.go
@@ -493,6 +493,11 @@ func (in *Networks) DeepCopyInto(out *Networks) {
 		*out = new(Router)
 		**out = **in
 	}
+	if in.ID != nil {
+		in, out := &in.ID, &out.ID
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/openstack/validation/infrastructure.go
+++ b/pkg/apis/openstack/validation/infrastructure.go
@@ -22,6 +22,7 @@ import (
 	"github.com/gardener/gardener-extension-provider-openstack/pkg/utils"
 
 	cidrvalidation "github.com/gardener/gardener/pkg/utils/validation/cidr"
+	"github.com/google/uuid"
 	apivalidation "k8s.io/apimachinery/pkg/api/validation"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -59,6 +60,12 @@ func ValidateInfrastructureConfig(infra *api.InfrastructureConfig, nodesCIDR *st
 
 	if nodes != nil {
 		allErrs = append(allErrs, nodes.ValidateSubset(workerCIDR)...)
+	}
+
+	if infra.Networks.ID != nil {
+		if _, err := uuid.Parse(*infra.Networks.ID); err != nil {
+			allErrs = append(allErrs, field.Invalid(networksPath.Child("id"), infra.Networks.ID, "if network ID is provided it must be a valid OpenStack UUID"))
+		}
 	}
 
 	if infra.Networks.Router != nil && len(infra.Networks.Router.ID) == 0 {

--- a/pkg/apis/openstack/validation/infrastructure_test.go
+++ b/pkg/apis/openstack/validation/infrastructure_test.go
@@ -19,7 +19,9 @@ import (
 
 	api "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack"
 	. "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack/validation"
+
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
@@ -138,6 +140,28 @@ var _ = Describe("InfrastructureConfig validation", func() {
 				"Field":  Equal("networks.workers"),
 				"Detail": Equal("must be valid canonical CIDR"),
 			}))
+		})
+
+		It("should forbid an invalid network id configuration", func() {
+			invalidID := "thisiswrong"
+			infrastructureConfig.Networks.ID = &invalidID
+
+			errorList := ValidateInfrastructureConfig(infrastructureConfig, &nodes, nilPath)
+
+			Expect(errorList).To(ConsistOfFields(Fields{
+				"Type":  Equal(field.ErrorTypeInvalid),
+				"Field": Equal("networks.id"),
+			}))
+		})
+
+		It("should allow an valid OpenStack UUID as network ID", func() {
+			id, err := uuid.NewUUID()
+			Expect(err).NotTo(HaveOccurred())
+			infrastructureConfig.Networks.ID = pointer.StringPtr(id.String())
+
+			errorList := ValidateInfrastructureConfig(infrastructureConfig, &nodes, nilPath)
+
+			Expect(errorList).To(BeEmpty())
 		})
 	})
 

--- a/pkg/apis/openstack/zz_generated.deepcopy.go
+++ b/pkg/apis/openstack/zz_generated.deepcopy.go
@@ -493,6 +493,11 @@ func (in *Networks) DeepCopyInto(out *Networks) {
 		*out = new(Router)
 		**out = **in
 	}
+	if in.ID != nil {
+		in, out := &in.ID, &out.ID
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -163,9 +163,7 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 				},
 			}
 
-			if !infrastructureStatus.Networks.ManagedPrivateNetwork {
-				machineClassSpec["subnetID"] = subnet.ID
-			}
+			machineClassSpec["subnetID"] = subnet.ID
 
 			if volumeSize > 0 {
 				machineClassSpec["rootDiskSize"] = volumeSize

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -100,6 +100,11 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 		return err
 	}
 
+	subnet, err := helper.FindSubnetByPurpose(infrastructureStatus.Networks.Subnets, api.PurposeNodes)
+	if err != nil {
+		return err
+	}
+
 	for _, pool := range w.worker.Spec.Pools {
 		zoneLen := int32(len(pool.Zones))
 
@@ -156,6 +161,10 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 				"secret": map[string]interface{}{
 					"cloudConfig": string(pool.UserData),
 				},
+			}
+
+			if !infrastructureStatus.Networks.ManagedPrivateNetwork {
+				machineClassSpec["subnetID"] = subnet.ID
 			}
 
 			if volumeSize > 0 {

--- a/pkg/internal/infrastructure/terraform.go
+++ b/pkg/internal/infrastructure/terraform.go
@@ -20,13 +20,14 @@ import (
 	"fmt"
 	"strconv"
 
-	api "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack"
-	"github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack/helper"
-	apiv1alpha1 "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack/v1alpha1"
 	"github.com/gardener/gardener/extensions/pkg/controller"
 	"github.com/gardener/gardener/extensions/pkg/terraformer"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	api "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack"
+	"github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack/helper"
+	apiv1alpha1 "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack/v1alpha1"
 )
 
 const (
@@ -277,6 +278,5 @@ func ComputeStatus(ctx context.Context, tf terraformer.Terraformer, config *api.
 
 	status := StatusFromTerraformState(state)
 	status.Networks.FloatingPool.Name = config.FloatingPoolName
-	status.Networks.ManagedPrivateNetwork = config.Networks.ID == nil
 	return status, nil
 }

--- a/pkg/internal/infrastructure/terraform_test.go
+++ b/pkg/internal/infrastructure/terraform_test.go
@@ -122,7 +122,8 @@ var _ = Describe("Terraform", func() {
 				"maxApiCallRetries": MaxApiCallRetries,
 			}
 			expectedCreateValues = map[string]interface{}{
-				"router": false,
+				"router":  false,
+				"network": true,
 			}
 			expectedRouterValues = map[string]interface{}{
 				"id": strconv.Quote("1"),
@@ -166,6 +167,27 @@ var _ = Describe("Terraform", func() {
 			expectedCreateValues["router"] = true
 			expectedRouterValues["id"] = DefaultRouterID
 			expectedRouterValues["enableSNAT"] = true
+
+			values, err := ComputeTerraformerTemplateValues(infra, config, cluster)
+			Expect(err).To(BeNil())
+			Expect(values).To(Equal(map[string]interface{}{
+				"openstack":    expectedOpenStackValues,
+				"create":       expectedCreateValues,
+				"dnsServers":   dnsServers,
+				"sshPublicKey": string(infra.Spec.SSHPublicKey),
+				"router":       expectedRouterValues,
+				"clusterName":  infra.Namespace,
+				"networks":     expectedNetworkValues,
+				"outputKeys":   expectedOutputKeysValues,
+			}))
+		})
+
+		It("should correctly compute the terraformer chart values when reusing vpc", func() {
+			networkID := "networkID"
+
+			config.Networks.ID = &networkID
+			expectedCreateValues["network"] = false
+			expectedNetworkValues["id"] = networkID
 
 			values, err := ComputeTerraformerTemplateValues(infra, config, cluster)
 			Expect(err).To(BeNil())

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -312,6 +312,7 @@ github.com/google/go-cmp/cmp/internal/value
 # github.com/google/gofuzz v1.1.0
 github.com/google/gofuzz
 # github.com/google/uuid v1.1.2
+## explicit
 github.com/google/uuid
 # github.com/googleapis/gnostic v0.5.5
 github.com/googleapis/gnostic/compiler


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement
/platform openstack

**What this PR does / why we need it**:
Allows the creation of shoots into existing user-managed networks.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Shoots can now be deployed in existing Neutron networks. The network can be specified by its ID in the respective shoot's infrastructure configuration.
```
