### PR TITLE
Make the linter fail on missing or wrong doc comments

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -5,3 +5,15 @@ run:
 linters:
   disable:
   - unused
+  enable:
+  - revive
+
+issues:
+  exclude-use-default: false
+  exclude:
+  # revive
+  - var-naming # ((var|const|struct field|func) .* should be .*
+  - dot-imports # should not use dot imports
+  - package-comments # package comment should be of the form
+  - indent-error-flow # if block ends with a return statement, so drop this else and outdent its block
+  - "exported: (type|func) name will be used as .* by other packages, and that stutters;"

--- a/pkg/admission/validator/webhook.go
+++ b/pkg/admission/validator/webhook.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
+// SecretsValidatorName is the name of the secrets validator.
 const SecretsValidatorName = "secrets." + extensionswebhook.ValidatorName
 
 var logger = log.Log.WithName("openstack-validator-webhook")

--- a/pkg/apis/openstack/types_cloudprofile.go
+++ b/pkg/apis/openstack/types_cloudprofile.go
@@ -132,25 +132,25 @@ func (l LoadBalancerClass) IsSemanticallyEqual(e LoadBalancerClass) bool {
 	return true
 }
 
-func (in LoadBalancerClass) String() string {
-	result := fmt.Sprintf("Name: %q", in.Name)
-	if in.Purpose != nil {
-		result += fmt.Sprintf(", Purpose: %q", *in.Purpose)
+func (l LoadBalancerClass) String() string {
+	result := fmt.Sprintf("Name: %q", l.Name)
+	if l.Purpose != nil {
+		result += fmt.Sprintf(", Purpose: %q", *l.Purpose)
 	}
-	if in.FloatingSubnetID != nil {
-		result += fmt.Sprintf(", FloatingSubnetID: %q", *in.FloatingSubnetID)
+	if l.FloatingSubnetID != nil {
+		result += fmt.Sprintf(", FloatingSubnetID: %q", *l.FloatingSubnetID)
 	}
-	if in.FloatingSubnetTags != nil {
-		result += fmt.Sprintf(", FloatingSubnetTags: %q", *in.FloatingSubnetTags)
+	if l.FloatingSubnetTags != nil {
+		result += fmt.Sprintf(", FloatingSubnetTags: %q", *l.FloatingSubnetTags)
 	}
-	if in.FloatingSubnetName != nil {
-		result += fmt.Sprintf(", FloatingSubnetName: %q", *in.FloatingSubnetName)
+	if l.FloatingSubnetName != nil {
+		result += fmt.Sprintf(", FloatingSubnetName: %q", *l.FloatingSubnetName)
 	}
-	if in.FloatingNetworkID != nil {
-		result += fmt.Sprintf(", FloatingNetworkID: %q", *in.FloatingNetworkID)
+	if l.FloatingNetworkID != nil {
+		result += fmt.Sprintf(", FloatingNetworkID: %q", *l.FloatingNetworkID)
 	}
-	if in.SubnetID != nil {
-		result += fmt.Sprintf(", SubnetID: %q", *in.SubnetID)
+	if l.SubnetID != nil {
+		result += fmt.Sprintf(", SubnetID: %q", *l.SubnetID)
 	}
 	return result
 }

--- a/pkg/apis/openstack/types_worker.go
+++ b/pkg/apis/openstack/types_worker.go
@@ -58,6 +58,7 @@ type ServerGroupDependency struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
 // WorkerConfig contains configuration data for a worker pool.
 type WorkerConfig struct {
 	metav1.TypeMeta

--- a/pkg/apis/openstack/v1alpha1/types_worker.go
+++ b/pkg/apis/openstack/v1alpha1/types_worker.go
@@ -61,6 +61,7 @@ type ServerGroupDependency struct {
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
 // WorkerConfig contains configuration data for a worker pool.
 type WorkerConfig struct {
 	metav1.TypeMeta `json:",inline"`

--- a/pkg/controller/dnsrecord/actuator.go
+++ b/pkg/controller/dnsrecord/actuator.go
@@ -46,6 +46,7 @@ type actuator struct {
 	logger                 logr.Logger
 }
 
+// NewActuator creates a new dnsrecord.Actuator.
 func NewActuator(openstackClientFactory openstackclient.FactoryFactory, logger logr.Logger) dnsrecord.Actuator {
 	return &actuator{
 		openstackClientFactory: openstackClientFactory,

--- a/pkg/controller/worker/machine_dependencies_test.go
+++ b/pkg/controller/worker/machine_dependencies_test.go
@@ -106,7 +106,7 @@ var _ = Describe("#MachineDependencies", func() {
 			)
 
 			ctx := context.Background()
-			expectStatusUpdateToSucceed(cl, statusCl, ctx)
+			expectStatusUpdateToSucceed(ctx, cl, statusCl)
 
 			err := workerDelegate.DeployMachineDependencies(ctx)
 			Expect(err).NotTo(HaveOccurred())
@@ -145,7 +145,7 @@ var _ = Describe("#MachineDependencies", func() {
 			computeClient.EXPECT().CreateServerGroup(prefixMatch(serverGroupPrefix(clusterName, pool2)), policy).Return(&servergroups.ServerGroup{
 				ID: serverGroupID2,
 			}, nil)
-			expectStatusUpdateToSucceed(cl, statusCl, ctx)
+			expectStatusUpdateToSucceed(ctx, cl, statusCl)
 
 			err := workerDelegate.DeployMachineDependencies(ctx)
 			Expect(err).NotTo(HaveOccurred())
@@ -187,7 +187,7 @@ var _ = Describe("#MachineDependencies", func() {
 			computeClient.EXPECT().CreateServerGroup(prefixMatch(serverGroupPrefix(clusterName, poolName)), policy).Return(&servergroups.ServerGroup{
 				ID: "id",
 			}, nil)
-			expectStatusUpdateToSucceed(cl, statusCl, ctx)
+			expectStatusUpdateToSucceed(ctx, cl, statusCl)
 
 			err := workerDelegate.DeployMachineDependencies(ctx)
 			Expect(err).NotTo(HaveOccurred())
@@ -208,7 +208,7 @@ var _ = Describe("#MachineDependencies", func() {
 			computeClient.EXPECT().CreateServerGroup(prefixMatch(serverGroupPrefix(clusterName, poolName)), newPolicy).Return(&servergroups.ServerGroup{
 				ID: "new-id",
 			}, nil)
-			expectStatusUpdateToSucceed(cl, statusCl, ctx)
+			expectStatusUpdateToSucceed(ctx, cl, statusCl)
 
 			err = workerDelegate.DeployMachineDependencies(ctx)
 			Expect(err).NotTo(HaveOccurred())
@@ -260,7 +260,7 @@ var _ = Describe("#MachineDependencies", func() {
 				},
 			}, nil)
 			computeClient.EXPECT().DeleteServerGroup(serverGroupID).Return(nil)
-			expectStatusUpdateToSucceed(cl, statusCl, ctx)
+			expectStatusUpdateToSucceed(ctx, cl, statusCl)
 
 			err := workerDelegate.CleanupMachineDependencies(ctx)
 			Expect(err).NotTo(HaveOccurred())
@@ -318,7 +318,7 @@ var _ = Describe("#MachineDependencies", func() {
 				},
 			}, nil)
 			computeClient.EXPECT().DeleteServerGroup(oldServerGroupID).Return(nil)
-			expectStatusUpdateToNotContainChanges(cl, statusCl, ctx)
+			expectStatusUpdateToNotContainChanges(ctx, cl, statusCl)
 
 			err := workerDelegate.CleanupMachineDependencies(ctx)
 			Expect(err).NotTo(HaveOccurred())
@@ -381,7 +381,7 @@ var _ = Describe("#MachineDependencies", func() {
 			}, nil)
 			computeClient.EXPECT().DeleteServerGroup(serverGroupID1).Return(nil)
 			computeClient.EXPECT().DeleteServerGroup(serverGroupID2).Return(nil)
-			expectStatusUpdateToSucceed(cl, statusCl, ctx)
+			expectStatusUpdateToSucceed(ctx, cl, statusCl)
 
 			err := workerDelegate.CleanupMachineDependencies(ctx)
 			Expect(err).NotTo(HaveOccurred())
@@ -442,7 +442,7 @@ func newClusterWithDefaultCloudProfileConfig(name string) *controller.Cluster {
 	}
 }
 
-func expectStatusUpdateToSucceed(c *k8smocks.MockClient, statusWriter *k8smocks.MockStatusWriter, ctx context.Context) {
+func expectStatusUpdateToSucceed(ctx context.Context, c *k8smocks.MockClient, statusWriter *k8smocks.MockStatusWriter) {
 	c.EXPECT().Get(ctx, gomock.Any(), gomock.AssignableToTypeOf(&extensionsv1alpha1.Worker{})).
 		DoAndReturn(func(_ context.Context, _ client.ObjectKey, worker *extensionsv1alpha1.Worker) error {
 			return nil
@@ -450,7 +450,7 @@ func expectStatusUpdateToSucceed(c *k8smocks.MockClient, statusWriter *k8smocks.
 	statusWriter.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&extensionsv1alpha1.Worker{})).Return(nil)
 }
 
-func expectStatusUpdateToNotContainChanges(c *k8smocks.MockClient, statusWriter *k8smocks.MockStatusWriter, ctx context.Context) {
+func expectStatusUpdateToNotContainChanges(ctx context.Context, c *k8smocks.MockClient, statusWriter *k8smocks.MockStatusWriter) {
 	c.EXPECT().Get(ctx, gomock.Any(), gomock.AssignableToTypeOf(&extensionsv1alpha1.Worker{})).
 		DoAndReturn(func(_ context.Context, _ client.ObjectKey, worker *extensionsv1alpha1.Worker) error {
 			return nil

--- a/pkg/internal/terraform.go
+++ b/pkg/internal/terraform.go
@@ -45,12 +45,6 @@ const (
 	TerraformVarNameApplicationCredentialSecret = "TF_VAR_APPLICATION_CREDENTIAL_SECRET"
 )
 
-const (
-	TerraformAuthUsernamePassword = 0
-	TerraformAuthApplicationCredentialID
-	TerraformAuthApplicationCredentialName
-)
-
 // TerraformerEnvVars computes the Terraformer environment variables from the given secret reference.
 func TerraformerEnvVars(secretRef corev1.SecretReference, credentials *openstack.Credentials) []corev1.EnvVar {
 

--- a/pkg/openstack/client/compute.go
+++ b/pkg/openstack/client/compute.go
@@ -21,8 +21,10 @@ import (
 )
 
 const (
+	// ServerGroupPolicyAntiAffinity is a constant for the anti-affinity server group policy.
 	ServerGroupPolicyAntiAffinity = "anti-affinity"
-	ServerGroupPolicyAffinity     = "affinity"
+	// ServerGroupPolicyAffinity is a constant for the affinity server group policy.
+	ServerGroupPolicyAffinity = "affinity"
 
 	// softPolicyMicroversion defines the minimum API microversion for Nova that can support soft-* policy variants for server groups.
 	// We set the minimum supported microversion, since later versions (>=2.64) have non-backwards-compatible changes forcing the use of

--- a/pkg/openstack/types.go
+++ b/pkg/openstack/types.go
@@ -43,7 +43,8 @@ const (
 	// CSISnapshotControllerImageName is the name of the csi-snapshot-controller image.
 	CSISnapshotControllerImageName = "csi-snapshot-controller"
 	// MachineControllerManagerImageName is the name of the MachineControllerManager image.
-	MachineControllerManagerImageName                  = "machine-controller-manager"
+	MachineControllerManagerImageName = "machine-controller-manager"
+	// MachineControllerManagerProviderOpenStackImageName is the name of the MachineControllerManager OpenStack image.
 	MachineControllerManagerProviderOpenStackImageName = "machine-controller-manager-provider-openstack"
 
 	// AuthURL is a constant for the key in a cloud provider secret that holds the OpenStack auth url.

--- a/test/tm/generator.go
+++ b/test/tm/generator.go
@@ -35,11 +35,11 @@ const (
 )
 
 var (
-	cfg    *GeneratorConfig
+	cfg    *generatorConfig
 	logger logr.Logger
 )
 
-type GeneratorConfig struct {
+type generatorConfig struct {
 	floatingPoolName                 string
 	loadBalancerProvider             string
 	networkWorkerCidr                string
@@ -48,7 +48,7 @@ type GeneratorConfig struct {
 }
 
 func addFlags() {
-	cfg = &GeneratorConfig{}
+	cfg = &generatorConfig{}
 	flag.StringVar(&cfg.infrastructureProviderConfigPath, "infrastructure-provider-config-filepath", "", "filepath to the provider specific infrastructure config")
 	flag.StringVar(&cfg.controlplaneProviderConfigPath, "controlplane-provider-config-filepath", "", "filepath to the provider specific controlplane config")
 


### PR DESCRIPTION
**How to categorize this PR?**

/area quality, dev-productivity
/kind enhancement
/platform openstack

**What this PR does / why we need it**:
Makes the linter fail on missing or wrong doc comments and a few other common style errors, and fixes all such issues that already exist.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Making the linter fail on missing or wrong doc comments and a few other common style errors consists of enabling `revive` in the `golangci-lint` configuration and excluding certain `revive` errors that we are perhaps not interested in.

I have fixed the following `revive` errors (as regexes that could be included in the `golangci-lint` configuration if desired):

```
- "exported: comment on exported (var|const|type|method|function) .* should be of the form "
- "exported: exported (var|const|type|method|function) .* should have comment or be unexported"
- if-return # redundant if \.\.\.; err != nil check, just return error instead
```

I have disabled the following `revive` errors via the `golangci-lint` configuration:

```
- var-naming # ((var|const|struct field|func) .* should be .*
- dot-imports # should not use dot imports
- package-comments # package comment should be of the form
- indent-error-flow # if block ends with a return statement, so drop this else and outdent its block
- "exported: (type|func) name will be used as .* by other packages, and that stutters;"
```

See also https://github.com/gardener/gardener/pull/4627 and https://github.com/gardener/gardener-extension-provider-aws/pull/410.

**Release note**:

```other developer
Missing or wrong doc comments and a few other common style errors will now be reported by the linter.
```
