### PR TITLE
Remove port ranges from security group rules

### DIFF
--- a/pkg/internal/infrastructure/templates/main.tpl.tf
+++ b/pkg/internal/infrastructure/templates/main.tpl.tf
@@ -92,8 +92,6 @@ resource "openstack_networking_secgroup_rule_v2" "cluster_tcp_all" {
   direction         = "ingress"
   ethertype         = "IPv4"
   protocol          = "tcp"
-  port_range_min    = 1
-  port_range_max    = 65535
   remote_ip_prefix  = "0.0.0.0/0"
   security_group_id = openstack_networking_secgroup_v2.cluster.id
 }
@@ -102,8 +100,6 @@ resource "openstack_networking_secgroup_rule_v2" "cluster_udp_all" {
   direction         = "ingress"
   ethertype         = "IPv4"
   protocol          = "udp"
-  port_range_min    = 1
-  port_range_max    = 65535
   remote_ip_prefix  = "0.0.0.0/0"
   security_group_id = openstack_networking_secgroup_v2.cluster.id
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind regression
/platform openstack

**What this PR does / why we need it**:
When creating security group rules in newer versions of Openstack, Neutron will modify the request mid-flight when using the max port  range (1-65535) to **None**. In the end the SG rule entries will not specify any port range. As a consequence terraform using in the infrastructure reconciliation will detect that as a change and force the deletion and recreation of the SG rules. 

This PR changes the terraform specification for the affected rules to use nil range values and stop the constant TF reconciliation. 

source: https://bugs.launchpad.net/neutron/+bug/1848213 

**Which issue(s) this PR fixes**:
Fixes #335

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Change the security group rules `cluster_tcp_all` and `cluster_udp_all` to use nil port ranges.
```
