### PR TITLE
re-introduce request-timeouts for ccm

### DIFF
--- a/charts/internal/cloud-provider-config/templates/_cloud-provider-config-loadbalancer.tpl
+++ b/charts/internal/cloud-provider-config/templates/_cloud-provider-config-loadbalancer.tpl
@@ -20,7 +20,6 @@ floating-subnet-tags="{{ .Values.floatingSubnetTags }}"
 {{- if .Values.subnetID }}
 subnet-id="{{ .Values.subnetID }}"
 {{- end }}
-{{- include "cloud-provider-config-meta" . | indent 4 }}
 {{- range $i, $class := .Values.floatingClasses }}
 [LoadBalancerClass {{ $class.name | quote }}]
 {{- if $class.floatingNetworkID }}

--- a/charts/internal/cloud-provider-config/templates/_cloud-provider-config-meta.tpl
+++ b/charts/internal/cloud-provider-config/templates/_cloud-provider-config-meta.tpl
@@ -1,10 +1,7 @@
 {{- define "cloud-provider-config-meta" -}}
-{{- if and (semverCompare ">= 1.10.1" .Values.kubernetesVersion) (semverCompare "< 1.10.3" .Values.kubernetesVersion) }}
 [Metadata]
-{{- if (ne .Values.dhcpDomain "") }}
-dhcp-domain="{{ .Values.dhcpDomain }}"
-{{- end }}
-{{- if (ne .Values.requestTimeout "") }}
+{{- if hasKey .Values "requestTimeout" }}
+{{- if .Values.requestTimeout }}
 request-timeout={{ .Values.requestTimeout }}
 {{- end }}
 {{- end }}

--- a/charts/internal/cloud-provider-config/templates/cloud-provider-config.yaml
+++ b/charts/internal/cloud-provider-config/templates/cloud-provider-config.yaml
@@ -1,6 +1,7 @@
 {{- define "cloud-provider-config" -}}
 [Global]
 {{ include "cloud-provider-config-credentials" . }}
+{{ include "cloud-provider-config-meta" . }}
 {{ include "cloud-provider-config-loadbalancer" . }}
 {{- end -}}
 ---

--- a/charts/internal/cloud-provider-config/values.yaml
+++ b/charts/internal/cloud-provider-config/values.yaml
@@ -1,5 +1,5 @@
 kubernetesVersion: 0.0.1
-#[Global]
+# [Global]
 authUrl: fooURL
 domainName: fooDomain
 tenantName: fooTenant
@@ -16,13 +16,7 @@ lbProvider: foobar
 # floatingSubnetName: "*abc*"
 # floatingSubnetTags: tag1,tag2
 # subnetID: foo-bar-123
-# [Metadata]
-dhcpDomain: foobar
-requestTimeout: 2s
 useOctavia: false
-rescanBlockStorageOnResize: false
-ignoreVolumeAZ: false
-# nodeVolumeAttachLimit: 25
 # floatingClasses:
 # - name: A
 #   floatingNetworkID: "1234"
@@ -37,3 +31,9 @@ ignoreVolumeAZ: false
 # - name: D
 #   floatingNetworkID: "1234"
 #   floatingSubnetTags: tag1,tag2
+# [BlockStorage]
+rescanBlockStorageOnResize: false
+ignoreVolumeAZ: false
+# nodeVolumeAttachLimit: 25
+# [Metadata]
+# requestTimeout: 1m

--- a/hack/api-reference/api.md
+++ b/hack/api-reference/api.md
@@ -131,7 +131,9 @@ logical names and versions to provider-specific identifiers.</p>
 <td>
 <code>requestTimeout</code></br>
 <em>
-string
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#duration-v1-meta">
+Kubernetes meta/v1.Duration
+</a>
 </em>
 </td>
 <td>

--- a/pkg/apis/openstack/types_cloudprofile.go
+++ b/pkg/apis/openstack/types_cloudprofile.go
@@ -43,7 +43,6 @@ type CloudProfileConfig struct {
 	// logical names and versions to provider-specific identifiers.
 	MachineImages []MachineImages
 	// RequestTimeout specifies the HTTP timeout against the OpenStack API.
-	// TODO: propagate timeout settings to all components (CCM,CSI,MCM,provider-extension)
 	RequestTimeout *metav1.Duration
 	// RescanBlockStorageOnResize specifies whether the storage plugin scans and checks new block device size before it resizes
 	// the filesystem.

--- a/pkg/apis/openstack/types_cloudprofile.go
+++ b/pkg/apis/openstack/types_cloudprofile.go
@@ -43,7 +43,8 @@ type CloudProfileConfig struct {
 	// logical names and versions to provider-specific identifiers.
 	MachineImages []MachineImages
 	// RequestTimeout specifies the HTTP timeout against the OpenStack API.
-	RequestTimeout *string
+	// TODO: propagate timeout settings to all components (CCM,CSI,MCM,provider-extension)
+	RequestTimeout *metav1.Duration
 	// RescanBlockStorageOnResize specifies whether the storage plugin scans and checks new block device size before it resizes
 	// the filesystem.
 	RescanBlockStorageOnResize *bool

--- a/pkg/apis/openstack/v1alpha1/types_cloudprofile.go
+++ b/pkg/apis/openstack/v1alpha1/types_cloudprofile.go
@@ -45,7 +45,7 @@ type CloudProfileConfig struct {
 	MachineImages []MachineImages `json:"machineImages"`
 	// RequestTimeout specifies the HTTP timeout against the OpenStack API.
 	// +optional
-	RequestTimeout *string `json:"requestTimeout,omitempty"`
+	RequestTimeout *metav1.Duration `json:"requestTimeout,omitempty"`
 	// RescanBlockStorageOnResize specifies whether the storage plugin scans and checks new block device size before it resizes
 	// the filesystem.
 	// +optional

--- a/pkg/apis/openstack/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/openstack/v1alpha1/zz_generated.conversion.go
@@ -24,6 +24,7 @@ import (
 	unsafe "unsafe"
 
 	openstack "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
@@ -327,7 +328,7 @@ func autoConvert_v1alpha1_CloudProfileConfig_To_openstack_CloudProfileConfig(in 
 	out.KeyStoneURL = in.KeyStoneURL
 	out.KeyStoneURLs = *(*[]openstack.KeyStoneURL)(unsafe.Pointer(&in.KeyStoneURLs))
 	out.MachineImages = *(*[]openstack.MachineImages)(unsafe.Pointer(&in.MachineImages))
-	out.RequestTimeout = (*string)(unsafe.Pointer(in.RequestTimeout))
+	out.RequestTimeout = (*v1.Duration)(unsafe.Pointer(in.RequestTimeout))
 	out.RescanBlockStorageOnResize = (*bool)(unsafe.Pointer(in.RescanBlockStorageOnResize))
 	out.IgnoreVolumeAZ = (*bool)(unsafe.Pointer(in.IgnoreVolumeAZ))
 	out.NodeVolumeAttachLimit = (*int32)(unsafe.Pointer(in.NodeVolumeAttachLimit))
@@ -351,7 +352,7 @@ func autoConvert_openstack_CloudProfileConfig_To_v1alpha1_CloudProfileConfig(in 
 	out.KeyStoneURL = in.KeyStoneURL
 	out.KeyStoneURLs = *(*[]KeyStoneURL)(unsafe.Pointer(&in.KeyStoneURLs))
 	out.MachineImages = *(*[]MachineImages)(unsafe.Pointer(&in.MachineImages))
-	out.RequestTimeout = (*string)(unsafe.Pointer(in.RequestTimeout))
+	out.RequestTimeout = (*v1.Duration)(unsafe.Pointer(in.RequestTimeout))
 	out.RescanBlockStorageOnResize = (*bool)(unsafe.Pointer(in.RescanBlockStorageOnResize))
 	out.IgnoreVolumeAZ = (*bool)(unsafe.Pointer(in.IgnoreVolumeAZ))
 	out.NodeVolumeAttachLimit = (*int32)(unsafe.Pointer(in.NodeVolumeAttachLimit))

--- a/pkg/apis/openstack/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/openstack/v1alpha1/zz_generated.deepcopy.go
@@ -21,6 +21,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -76,7 +77,7 @@ func (in *CloudProfileConfig) DeepCopyInto(out *CloudProfileConfig) {
 	}
 	if in.RequestTimeout != nil {
 		in, out := &in.RequestTimeout, &out.RequestTimeout
-		*out = new(string)
+		*out = new(v1.Duration)
 		**out = **in
 	}
 	if in.RescanBlockStorageOnResize != nil {

--- a/pkg/apis/openstack/validation/cloudprofile.go
+++ b/pkg/apis/openstack/validation/cloudprofile.go
@@ -17,7 +17,6 @@ package validation
 import (
 	"fmt"
 	"net"
-	"time"
 
 	api "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack"
 
@@ -146,12 +145,6 @@ func ValidateCloudProfileConfig(cloudProfile *api.CloudProfileConfig, fldPath *f
 
 	if cloudProfile.DHCPDomain != nil && len(*cloudProfile.DHCPDomain) == 0 {
 		allErrs = append(allErrs, field.Required(fldPath.Child("dhcpDomain"), "must provide a dhcp domain when the key is specified"))
-	}
-
-	if cloudProfile.RequestTimeout != nil {
-		if _, err := time.ParseDuration(*cloudProfile.RequestTimeout); err != nil {
-			allErrs = append(allErrs, field.Invalid(fldPath.Child("requestTimeout"), *cloudProfile.RequestTimeout, fmt.Sprintf("invalid duration: %v", err)))
-		}
 	}
 
 	serverGroupPath := fldPath.Child("serverGroupPolicies")

--- a/pkg/apis/openstack/validation/cloudprofile_test.go
+++ b/pkg/apis/openstack/validation/cloudprofile_test.go
@@ -276,19 +276,6 @@ var _ = Describe("CloudProfileConfig validation", func() {
 			})
 		})
 
-		Context("requestTimeout validation", func() {
-			It("should reject invalid durations", func() {
-				cloudProfileConfig.RequestTimeout = pointer.StringPtr("1GiB")
-
-				errorList := ValidateCloudProfileConfig(cloudProfileConfig, fldPath)
-
-				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeInvalid),
-					"Field": Equal("root.requestTimeout"),
-				}))))
-			})
-		})
-
 		Context("machine image validation", func() {
 			It("should enforce that at least one machine image has been defined", func() {
 				cloudProfileConfig.MachineImages = []api.MachineImages{}

--- a/pkg/apis/openstack/zz_generated.deepcopy.go
+++ b/pkg/apis/openstack/zz_generated.deepcopy.go
@@ -21,6 +21,7 @@ limitations under the License.
 package openstack
 
 import (
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -76,7 +77,7 @@ func (in *CloudProfileConfig) DeepCopyInto(out *CloudProfileConfig) {
 	}
 	if in.RequestTimeout != nil {
 		in, out := &in.RequestTimeout, &out.RequestTimeout
-		*out = new(string)
+		*out = new(v1.Duration)
 		**out = **in
 	}
 	if in.RescanBlockStorageOnResize != nil {

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -24,6 +24,8 @@ import (
 	"github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack/helper"
 	"github.com/gardener/gardener-extension-provider-openstack/pkg/openstack"
 	"github.com/gardener/gardener-extension-provider-openstack/pkg/utils"
+
+	"github.com/Masterminds/semver"
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
 	"github.com/gardener/gardener/extensions/pkg/controller/controlplane/genericactuator"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
@@ -34,8 +36,6 @@ import (
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/secrets"
 	"github.com/gardener/gardener/pkg/utils/version"
-
-	"github.com/Masterminds/semver"
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -17,9 +17,11 @@ package controlplane
 import (
 	"context"
 	"encoding/json"
+	"time"
 
 	api "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack"
 	"github.com/gardener/gardener-extension-provider-openstack/pkg/openstack"
+
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
 	"github.com/gardener/gardener/extensions/pkg/controller/controlplane/genericactuator"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
@@ -27,7 +29,6 @@ import (
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
 	"github.com/gardener/gardener/pkg/utils"
-
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -47,8 +48,11 @@ const (
 )
 
 var (
-	dhcpDomain     = pointer.StringPtr("dhcp-domain")
-	requestTimeout = pointer.StringPtr("2s")
+	dhcpDomain           = pointer.StringPtr("dhcp-domain")
+	requestTimeoutString = "2s"
+	requestTimeout       = &metav1.Duration{
+		Duration: func() time.Duration { d, _ := time.ParseDuration(requestTimeoutString); return d }(),
+	}
 )
 
 func defaultControlPlane() *extensionsv1alpha1.ControlPlane {

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -48,10 +48,9 @@ const (
 )
 
 var (
-	dhcpDomain           = pointer.StringPtr("dhcp-domain")
-	requestTimeoutString = "2s"
-	requestTimeout       = &metav1.Duration{
-		Duration: func() time.Duration { d, _ := time.ParseDuration(requestTimeoutString); return d }(),
+	dhcpDomain     = pointer.StringPtr("dhcp-domain")
+	requestTimeout = &metav1.Duration{
+		Duration: func() time.Duration { d, _ := time.ParseDuration("5m"); return d }(),
 	}
 )
 

--- a/pkg/openstack/client/client.go
+++ b/pkg/openstack/client/client.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	os "github.com/gardener/gardener-extension-provider-openstack/pkg/openstack"
+
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack"
 	"github.com/gophercloud/utils/openstack/clientconfig"
@@ -29,6 +30,8 @@ import (
 )
 
 // NewOpenstackClientFromCredentials returns a Factory implementation that can be used to create clients for OpenStack services.
+// TODO: respect CloudProfile's requestTimeout for the OpenStack client.
+// see https://github.com/kubernetes/cloud-provider-openstack/blob/c44d941cdb5c7fe651f5cb9191d0af23e266c7cb/pkg/openstack/openstack.go#L257
 func NewOpenstackClientFromCredentials(credentials *os.Credentials) (Factory, error) {
 	opts := &clientconfig.ClientOpts{
 		AuthInfo: &clientconfig.AuthInfo{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement
/platform openstack

**What this PR does / why we need it**:

Allow the configuration of request-timeout for OpenStack clients used by control plane components (cloud-controller-manager and csi-driver). The configuration is done based on the respective cloudprofile value.
 
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Allow configuration of request timeout  for control plane components (CCM, CSI) via cloudprofile
```
