### PR TITLE
Allow to add options to `/etc/resolv.conf` on worker nodes

### DIFF
--- a/docs/usage-as-operator.md
+++ b/docs/usage-as-operator.md
@@ -65,6 +65,7 @@ machineImages:
 # serverGroupPolicies:
 # - soft-anti-affinity
 # - anti-affinity
+# resolvConfOptions: "rotate timeout:1"
 constraints:
   floatingPools:
   - name: fp-pool-1
@@ -120,6 +121,10 @@ If your OpenStack environment only has regional values and it doesn't make sense
 omit `keystoneURL` and always specify `region`.
 
 If Gardener creates and manages the router of a shoot cluster, it is additionally possible to specify that the [enable_snat](https://registry.terraform.io/providers/terraform-provider-openstack/openstack/latest/docs/resources/networking_router_v2#enable_snat) field is set to `true` via `useSNAT: true` in the `CloudProfileConfig`.
+
+On some OpenStack enviroments, there may be the need to set options in the file `/etc/resolv.conf` on worker nodes.
+If the field `resolvConfOptions` is set, a systemd service will be installed which copies `/run/systemd/resolve/resolv.conf`
+on every change to `/etc/resolv.conf` and appends the given options.
 
 ## Example `CloudProfile` manifest
 

--- a/docs/usage-as-operator.md
+++ b/docs/usage-as-operator.md
@@ -65,7 +65,9 @@ machineImages:
 # serverGroupPolicies:
 # - soft-anti-affinity
 # - anti-affinity
-# resolvConfOptions: "rotate timeout:1"
+# resolvConfOptions:
+# - rotate
+# - timeout:1
 constraints:
   floatingPools:
   - name: fp-pool-1

--- a/hack/api-reference/api.md
+++ b/hack/api-reference/api.md
@@ -216,6 +216,18 @@ bool
 <p>ServerGroupPolicies specify the allowed server group policies for worker groups.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>resolvConfOptions</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ResolvConfOptions specifies options to be added to /etc/resolv.conf on workers</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="openstack.provider.extensions.gardener.cloud/v1alpha1.ControlPlaneConfig">ControlPlaneConfig

--- a/hack/api-reference/api.md
+++ b/hack/api-reference/api.md
@@ -220,7 +220,7 @@ bool
 <td>
 <code>resolvConfOptions</code></br>
 <em>
-string
+[]string
 </em>
 </td>
 <td>

--- a/pkg/apis/openstack/types_cloudprofile.go
+++ b/pkg/apis/openstack/types_cloudprofile.go
@@ -59,7 +59,7 @@ type CloudProfileConfig struct {
 	// ServerGroupPolicies specify the allowed server group policies for worker groups.
 	ServerGroupPolicies []string
 	// ResolvConfOptions specifies options to be added to /etc/resolv.conf on workers
-	ResolvConfOptions *string
+	ResolvConfOptions []string
 }
 
 // Constraints is an object containing constraints for the shoots.

--- a/pkg/apis/openstack/types_cloudprofile.go
+++ b/pkg/apis/openstack/types_cloudprofile.go
@@ -58,6 +58,8 @@ type CloudProfileConfig struct {
 	UseSNAT *bool
 	// ServerGroupPolicies specify the allowed server group policies for worker groups.
 	ServerGroupPolicies []string
+	// ResolvConfOptions specifies options to be added to /etc/resolv.conf on workers
+	ResolvConfOptions *string
 }
 
 // Constraints is an object containing constraints for the shoots.

--- a/pkg/apis/openstack/v1alpha1/types_cloudprofile.go
+++ b/pkg/apis/openstack/v1alpha1/types_cloudprofile.go
@@ -67,6 +67,9 @@ type CloudProfileConfig struct {
 	// ServerGroupPolicies specify the allowed server group policies for worker groups.
 	// +optional
 	ServerGroupPolicies []string `json:"serverGroupPolicies,omitempty"`
+	// ResolvConfOptions specifies options to be added to /etc/resolv.conf on workers
+	// +optional
+	ResolvConfOptions *string `json:"resolvConfOptions,omitempty"`
 }
 
 // Constraints is an object containing constraints for the shoots.

--- a/pkg/apis/openstack/v1alpha1/types_cloudprofile.go
+++ b/pkg/apis/openstack/v1alpha1/types_cloudprofile.go
@@ -69,7 +69,7 @@ type CloudProfileConfig struct {
 	ServerGroupPolicies []string `json:"serverGroupPolicies,omitempty"`
 	// ResolvConfOptions specifies options to be added to /etc/resolv.conf on workers
 	// +optional
-	ResolvConfOptions *string `json:"resolvConfOptions,omitempty"`
+	ResolvConfOptions []string `json:"resolvConfOptions,omitempty"`
 }
 
 // Constraints is an object containing constraints for the shoots.

--- a/pkg/apis/openstack/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/openstack/v1alpha1/zz_generated.conversion.go
@@ -335,6 +335,7 @@ func autoConvert_v1alpha1_CloudProfileConfig_To_openstack_CloudProfileConfig(in 
 	out.UseOctavia = (*bool)(unsafe.Pointer(in.UseOctavia))
 	out.UseSNAT = (*bool)(unsafe.Pointer(in.UseSNAT))
 	out.ServerGroupPolicies = *(*[]string)(unsafe.Pointer(&in.ServerGroupPolicies))
+	out.ResolvConfOptions = (*string)(unsafe.Pointer(in.ResolvConfOptions))
 	return nil
 }
 
@@ -359,6 +360,7 @@ func autoConvert_openstack_CloudProfileConfig_To_v1alpha1_CloudProfileConfig(in 
 	out.UseOctavia = (*bool)(unsafe.Pointer(in.UseOctavia))
 	out.UseSNAT = (*bool)(unsafe.Pointer(in.UseSNAT))
 	out.ServerGroupPolicies = *(*[]string)(unsafe.Pointer(&in.ServerGroupPolicies))
+	out.ResolvConfOptions = (*string)(unsafe.Pointer(in.ResolvConfOptions))
 	return nil
 }
 

--- a/pkg/apis/openstack/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/openstack/v1alpha1/zz_generated.conversion.go
@@ -335,7 +335,7 @@ func autoConvert_v1alpha1_CloudProfileConfig_To_openstack_CloudProfileConfig(in 
 	out.UseOctavia = (*bool)(unsafe.Pointer(in.UseOctavia))
 	out.UseSNAT = (*bool)(unsafe.Pointer(in.UseSNAT))
 	out.ServerGroupPolicies = *(*[]string)(unsafe.Pointer(&in.ServerGroupPolicies))
-	out.ResolvConfOptions = (*string)(unsafe.Pointer(in.ResolvConfOptions))
+	out.ResolvConfOptions = *(*[]string)(unsafe.Pointer(&in.ResolvConfOptions))
 	return nil
 }
 
@@ -360,7 +360,7 @@ func autoConvert_openstack_CloudProfileConfig_To_v1alpha1_CloudProfileConfig(in 
 	out.UseOctavia = (*bool)(unsafe.Pointer(in.UseOctavia))
 	out.UseSNAT = (*bool)(unsafe.Pointer(in.UseSNAT))
 	out.ServerGroupPolicies = *(*[]string)(unsafe.Pointer(&in.ServerGroupPolicies))
-	out.ResolvConfOptions = (*string)(unsafe.Pointer(in.ResolvConfOptions))
+	out.ResolvConfOptions = *(*[]string)(unsafe.Pointer(&in.ResolvConfOptions))
 	return nil
 }
 

--- a/pkg/apis/openstack/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/openstack/v1alpha1/zz_generated.deepcopy.go
@@ -110,6 +110,11 @@ func (in *CloudProfileConfig) DeepCopyInto(out *CloudProfileConfig) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.ResolvConfOptions != nil {
+		in, out := &in.ResolvConfOptions, &out.ResolvConfOptions
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/openstack/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/openstack/v1alpha1/zz_generated.deepcopy.go
@@ -112,8 +112,8 @@ func (in *CloudProfileConfig) DeepCopyInto(out *CloudProfileConfig) {
 	}
 	if in.ResolvConfOptions != nil {
 		in, out := &in.ResolvConfOptions, &out.ResolvConfOptions
-		*out = new(string)
-		**out = **in
+		*out = make([]string, len(*in))
+		copy(*out, *in)
 	}
 	return
 }

--- a/pkg/apis/openstack/zz_generated.deepcopy.go
+++ b/pkg/apis/openstack/zz_generated.deepcopy.go
@@ -110,6 +110,11 @@ func (in *CloudProfileConfig) DeepCopyInto(out *CloudProfileConfig) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.ResolvConfOptions != nil {
+		in, out := &in.ResolvConfOptions, &out.ResolvConfOptions
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/openstack/zz_generated.deepcopy.go
+++ b/pkg/apis/openstack/zz_generated.deepcopy.go
@@ -112,8 +112,8 @@ func (in *CloudProfileConfig) DeepCopyInto(out *CloudProfileConfig) {
 	}
 	if in.ResolvConfOptions != nil {
 		in, out := &in.ResolvConfOptions, &out.ResolvConfOptions
-		*out = new(string)
-		**out = **in
+		*out = make([]string, len(*in))
+		copy(*out, *in)
 	}
 	return
 }

--- a/pkg/webhook/controlplane/ensurer.go
+++ b/pkg/webhook/controlplane/ensurer.go
@@ -17,6 +17,7 @@ package controlplane
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	apisopenstack "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack"
 	"github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack/helper"
@@ -461,7 +462,7 @@ func (e *ensurer) EnsureAdditionalUnits(ctx context.Context, gctx gcontext.Garde
 	if err != nil {
 		return err
 	}
-	if getResolveConfOptions(cloudProfileConfig) != "" {
+	if len(getResolveConfOptions(cloudProfileConfig)) > 0 {
 		e.addAdditionalUnitsForResolvConfOptions(new)
 	}
 	return nil
@@ -507,7 +508,7 @@ func (e *ensurer) EnsureAdditionalFiles(ctx context.Context, gctx gcontext.Garde
 	if err != nil {
 		return err
 	}
-	if options := getResolveConfOptions(cloudProfileConfig); options != "" {
+	if options := getResolveConfOptions(cloudProfileConfig); len(options) > 0 {
 		e.addAdditionalFilesForResolvConfOptions(options, new)
 	}
 	return nil
@@ -515,7 +516,7 @@ func (e *ensurer) EnsureAdditionalFiles(ctx context.Context, gctx gcontext.Garde
 
 // addAdditionalFilesForResolvConfOptions writes the script to update `/etc/resolv.conf` from
 // `/run/systemd/resolve/resolv.conf` and adds a options line to it.
-func (e *ensurer) addAdditionalFilesForResolvConfOptions(options string, new *[]extensionsv1alpha1.File) {
+func (e *ensurer) addAdditionalFilesForResolvConfOptions(options []string, new *[]extensionsv1alpha1.File) {
 	var (
 		permissions int32 = 0755
 		template          = `#!/bin/sh
@@ -527,13 +528,14 @@ line=%q
 
 if [ -f "$file" ]; then
   cp "$file" "$tmp"
-  echo "\n# updated by update-resolv-conf.service (installed by gardener-extension-provider-openstack)" >> "$tmp"
+  echo "" >> "$tmp"
+  echo "# updated by update-resolv-conf.service (installed by gardener-extension-provider-openstack)" >> "$tmp"
   echo "$line" >> "$tmp"
   mv "$tmp" "$dest"
 fi`
 	)
 
-	content := fmt.Sprintf(template, fmt.Sprintf("options %s", options))
+	content := fmt.Sprintf(template, fmt.Sprintf("options %s", strings.Join(options, " ")))
 	file := extensionsv1alpha1.File{
 		Path:        "/opt/bin/update-resolv-conf.sh",
 		Permissions: &permissions,
@@ -559,11 +561,11 @@ func getCloudProfileConfig(ctx context.Context, gctx gcontext.GardenContext) (*a
 	return cloudProfileConfig, nil
 }
 
-func getResolveConfOptions(cloudProfileConfig *apisopenstack.CloudProfileConfig) string {
-	if cloudProfileConfig == nil || cloudProfileConfig.ResolvConfOptions == nil {
-		return ""
+func getResolveConfOptions(cloudProfileConfig *apisopenstack.CloudProfileConfig) []string {
+	if cloudProfileConfig == nil {
+		return nil
 	}
-	return *cloudProfileConfig.ResolvConfOptions
+	return cloudProfileConfig.ResolvConfOptions
 }
 
 // appendUniqueFile appends a unit file only if it does not exist, otherwise overwrite content of previous files

--- a/pkg/webhook/controlplane/ensurer.go
+++ b/pkg/webhook/controlplane/ensurer.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"fmt"
 
+	apisopenstack "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack"
+	"github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack/helper"
 	"github.com/gardener/gardener-extension-provider-openstack/pkg/openstack"
 
 	"github.com/coreos/go-systemd/v22/unit"
@@ -28,6 +30,7 @@ import (
 	"github.com/gardener/gardener/extensions/pkg/webhook/controlplane"
 	"github.com/gardener/gardener/extensions/pkg/webhook/controlplane/genericmutator"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	versionutils "github.com/gardener/gardener/pkg/utils/version"
 	"github.com/go-logr/logr"
@@ -450,4 +453,130 @@ func (e *ensurer) EnsureKubeletCloudProviderConfig(ctx context.Context, gctx gco
 
 	*data = string(secret.Data[openstack.CloudProviderConfigDataKey])
 	return nil
+}
+
+// EnsureAdditionalUnits ensures that additional required system units are added.
+func (e *ensurer) EnsureAdditionalUnits(ctx context.Context, gctx gcontext.GardenContext, new, old *[]extensionsv1alpha1.Unit) error {
+	cloudProfileConfig, err := getCloudProfileConfig(ctx, gctx)
+	if err != nil {
+		return err
+	}
+	if cloudProfileConfig.ResolvConfOptions != nil && *cloudProfileConfig.ResolvConfOptions != "" {
+		err = e.ensureAdditionalUnitsForResolvConfOptions(new)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ensureAdditionalUnitsForResolvConfOptions installs a systemd service to update `resolv.conf`
+// after each change of `/run/systemd/resolve/resolv.conf`.
+func (e *ensurer) ensureAdditionalUnitsForResolvConfOptions(new *[]extensionsv1alpha1.Unit) error {
+	var (
+		trueVar           = true
+		customPathContent = `[Path]
+PathChanged=/run/systemd/resolve/resolv.conf
+
+[Install]
+WantedBy=multi-user.target
+`
+		customUnitContent = `[Unit]
+Description=add options to /etc/resolv.conf after every change of /run/systemd/resolve/resolv.conf
+After=network.target
+StartLimitIntervalSec=0
+
+[Service]
+Type=oneshot
+ExecStart=/var/lib/gardener/update-resolv-conf.sh
+`
+	)
+
+	extensionswebhook.AppendUniqueUnit(new, extensionsv1alpha1.Unit{
+		Name:    "update-resolv-conf.path",
+		Enable:  &trueVar,
+		Content: &customPathContent,
+	})
+	extensionswebhook.AppendUniqueUnit(new, extensionsv1alpha1.Unit{
+		Name:    "update-resolv-conf.service",
+		Enable:  &trueVar,
+		Content: &customUnitContent,
+	})
+	return nil
+}
+
+// EnsureAdditionalFiles ensures that additional required system files are added.
+func (e *ensurer) EnsureAdditionalFiles(ctx context.Context, gctx gcontext.GardenContext, new, old *[]extensionsv1alpha1.File) error {
+	cloudProfileConfig, err := getCloudProfileConfig(ctx, gctx)
+	if err != nil {
+		return err
+	}
+	if cloudProfileConfig.ResolvConfOptions != nil && *cloudProfileConfig.ResolvConfOptions != "" {
+		err = e.ensureAdditionalFilesForResolvConfOptions(*cloudProfileConfig.ResolvConfOptions, new)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ensureAdditionalFilesForResolvConfOptions writes the script to update `/etc/resolv.conf` from
+// `/run/systemd/resolve/resolv.conf` and adds a options line to it.
+func (e *ensurer) ensureAdditionalFilesForResolvConfOptions(options string, new *[]extensionsv1alpha1.File) error {
+	var (
+		permissions int32 = 0755
+		template          = `#!/bin/sh
+
+file=/run/systemd/resolve/resolv.conf
+tmp=/etc/resolv.conf.new
+dest=/etc/resolv.conf
+line=%q
+
+if [ -f "$file" ]; then
+  cp "$file" "$tmp"
+  echo "\n# updated by update-resolv-conf.service (installed by gardener-extension-provider-openstack)" >> "$tmp"
+  echo "$line" >> "$tmp"
+  mv "$tmp" "$dest"
+fi`
+	)
+
+	content := fmt.Sprintf(template, fmt.Sprintf("options %s", options))
+	file := extensionsv1alpha1.File{
+		Path:        "/var/lib/gardener/update-resolv-conf.sh",
+		Permissions: &permissions,
+		Content: extensionsv1alpha1.FileContent{
+			Inline: &extensionsv1alpha1.FileContentInline{
+				Encoding: "",
+				Data:     content,
+			},
+		},
+	}
+	appendUniqueFile(new, file)
+
+	return nil
+}
+
+func getCloudProfileConfig(ctx context.Context, gctx gcontext.GardenContext) (*apisopenstack.CloudProfileConfig, error) {
+	cluster, err := gctx.GetCluster(ctx)
+	if err != nil {
+		return nil, err
+	}
+	cloudProfileConfig, err := helper.CloudProfileConfigFromCluster(cluster)
+	if err != nil {
+		return nil, err
+	}
+	return cloudProfileConfig, nil
+}
+
+// appendUniqueFile appends a unit file only if it does not exist, otherwise overwrite content of previous files
+func appendUniqueFile(files *[]extensionsv1alpha1.File, file extensionsv1alpha1.File) {
+	resFiles := make([]extensionsv1alpha1.File, 0, len(*files))
+
+	for _, f := range *files {
+		if f.Path != file.Path {
+			resFiles = append(resFiles, f)
+		}
+	}
+
+	*files = append(resFiles, file)
 }

--- a/pkg/webhook/controlplane/ensurer_test.go
+++ b/pkg/webhook/controlplane/ensurer_test.go
@@ -134,7 +134,6 @@ var _ = Describe("Ensurer", func() {
 				},
 			},
 		)
-		resolvConfOptions                   = "rotate timeout:1"
 		eContextK8s121WithResolvConfOptions = gcontext.NewInternalGardenContext(
 			&extensionscontroller.Cluster{
 				CloudProfile: &gardencorev1beta1.CloudProfile{
@@ -145,7 +144,7 @@ var _ = Describe("Ensurer", func() {
 									FloatingPools:         []api.FloatingPool{},
 									LoadBalancerProviders: []api.LoadBalancerProvider{},
 								},
-								ResolvConfOptions: &resolvConfOptions,
+								ResolvConfOptions: []string{"rotate", "timeout:1"},
 							}),
 						},
 					},
@@ -657,7 +656,8 @@ line="options rotate timeout:1"
 
 if [ -f "$file" ]; then
   cp "$file" "$tmp"
-  echo "\n# updated by update-resolv-conf.service (installed by gardener-extension-provider-openstack)" >> "$tmp"
+  echo "" >> "$tmp"
+  echo "# updated by update-resolv-conf.service (installed by gardener-extension-provider-openstack)" >> "$tmp"
   echo "$line" >> "$tmp"
   mv "$tmp" "$dest"
 fi`
@@ -700,7 +700,8 @@ line="options rotate timeout:1"
 
 if [ -f "$file" ]; then
   cp "$file" "$tmp"
-  echo "\n# updated by update-resolv-conf.service (installed by gardener-extension-provider-openstack)" >> "$tmp"
+  echo "" >> "$tmp"
+  echo "# updated by update-resolv-conf.service (installed by gardener-extension-provider-openstack)" >> "$tmp"
   echo "$line" >> "$tmp"
   mv "$tmp" "$dest"
 fi`

--- a/pkg/webhook/controlplane/ensurer_test.go
+++ b/pkg/webhook/controlplane/ensurer_test.go
@@ -16,9 +16,12 @@ package controlplane
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
+	api "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack"
 	"github.com/gardener/gardener-extension-provider-openstack/pkg/openstack"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 
 	"github.com/coreos/go-systemd/v22/unit"
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
@@ -120,6 +123,31 @@ var _ = Describe("Ensurer", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
 						csimigration.AnnotationKeyNeedsComplete: "true",
+					},
+				},
+				Shoot: &gardencorev1beta1.Shoot{
+					Spec: gardencorev1beta1.ShootSpec{
+						Kubernetes: gardencorev1beta1.Kubernetes{
+							Version: "1.21.0",
+						},
+					},
+				},
+			},
+		)
+		resolvConfOptions                   = "rotate timeout:1"
+		eContextK8s121WithResolvConfOptions = gcontext.NewInternalGardenContext(
+			&extensionscontroller.Cluster{
+				CloudProfile: &gardencorev1beta1.CloudProfile{
+					Spec: gardencorev1beta1.CloudProfileSpec{
+						ProviderConfig: &runtime.RawExtension{
+							Raw: encode(&api.CloudProfileConfig{
+								Constraints: api.Constraints{
+									FloatingPools:         []api.FloatingPool{},
+									LoadBalancerProviders: []api.LoadBalancerProvider{},
+								},
+								ResolvConfOptions: &resolvConfOptions,
+							}),
+						},
 					},
 				},
 				Shoot: &gardencorev1beta1.Shoot{
@@ -550,6 +578,160 @@ var _ = Describe("Ensurer", func() {
 			Expect(*existingData).To(Equal(string(cloudProviderConfigContent)))
 		})
 	})
+
+	Describe("#EnsureAdditionalUnits", func() {
+		It("should add no additional units if resolvConfOptions field is not set", func() {
+			var (
+				oldUnit = extensionsv1alpha1.Unit{Name: "oldunit"}
+				units   = []extensionsv1alpha1.Unit{oldUnit}
+			)
+			// Create ensurer
+			ensurer := NewEnsurer(logger)
+
+			// Call EnsureAdditionalUnits method and check the result
+			err := ensurer.EnsureAdditionalUnits(ctx, eContextK8s121, &units, nil)
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(units).To(ConsistOf(oldUnit))
+		})
+
+		It("should add additional units to the current ones if resolvConfOptions field is set", func() {
+			var (
+				customUnitContent = `[Unit]
+Description=add options to /etc/resolv.conf after every change of /run/systemd/resolve/resolv.conf
+After=network.target
+StartLimitIntervalSec=0
+
+[Service]
+Type=oneshot
+ExecStart=/opt/bin/update-resolv-conf.sh
+`
+
+				customPathContent = `[Path]
+PathChanged=/run/systemd/resolve/resolv.conf
+
+[Install]
+WantedBy=multi-user.target
+`
+				trueVar = true
+
+				oldUnit        = extensionsv1alpha1.Unit{Name: "oldunit"}
+				additionalPath = extensionsv1alpha1.Unit{Name: "update-resolv-conf.path", Enable: &trueVar, Content: &customPathContent}
+				additionalUnit = extensionsv1alpha1.Unit{Name: "update-resolv-conf.service", Enable: &trueVar, Content: &customUnitContent}
+
+				units = []extensionsv1alpha1.Unit{oldUnit}
+			)
+
+			// Create ensurer
+			ensurer := NewEnsurer(logger)
+
+			// Call EnsureAdditionalUnits method and check the result
+			err := ensurer.EnsureAdditionalUnits(ctx, eContextK8s121WithResolvConfOptions, &units, nil)
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(units).To(ConsistOf(oldUnit, additionalPath, additionalUnit))
+		})
+	})
+
+	Describe("#EnsureAdditionalFiles", func() {
+		It("should add no additional files to the current ones if resolvConfOptions field is not set", func() {
+			var (
+				oldFile = extensionsv1alpha1.File{Path: "oldpath"}
+				files   = []extensionsv1alpha1.File{oldFile}
+			)
+			// Create ensurer
+			ensurer := NewEnsurer(logger)
+
+			// Call EnsureAdditionalFiles method and check the result
+			err := ensurer.EnsureAdditionalFiles(ctx, eContextK8s121, &files, nil)
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(files).To(ConsistOf(oldFile))
+		})
+		It("should add additional files to the current ones if resolvConfOptions field is set", func() {
+			var (
+				permissions       int32 = 0755
+				customFileContent       = `#!/bin/sh
+
+file=/run/systemd/resolve/resolv.conf
+tmp=/etc/resolv.conf.new
+dest=/etc/resolv.conf
+line="options rotate timeout:1"
+
+if [ -f "$file" ]; then
+  cp "$file" "$tmp"
+  echo "\n# updated by update-resolv-conf.service (installed by gardener-extension-provider-openstack)" >> "$tmp"
+  echo "$line" >> "$tmp"
+  mv "$tmp" "$dest"
+fi`
+
+				filePath = "/opt/bin/update-resolv-conf.sh"
+
+				oldFile        = extensionsv1alpha1.File{Path: "oldpath"}
+				additionalFile = extensionsv1alpha1.File{
+					Path:        filePath,
+					Permissions: &permissions,
+					Content: extensionsv1alpha1.FileContent{
+						Inline: &extensionsv1alpha1.FileContentInline{
+							Encoding: "",
+							Data:     customFileContent,
+						},
+					},
+				}
+
+				files = []extensionsv1alpha1.File{oldFile}
+			)
+
+			// Create ensurer
+			ensurer := NewEnsurer(logger)
+
+			// Call EnsureAdditionalFiles method and check the result
+			err := ensurer.EnsureAdditionalFiles(ctx, eContextK8s121WithResolvConfOptions, &files, nil)
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(files).To(ConsistOf(oldFile, additionalFile))
+		})
+
+		It("should overwrite existing files of the current ones", func() {
+			var (
+				permissions       int32 = 0755
+				customFileContent       = `#!/bin/sh
+
+file=/run/systemd/resolve/resolv.conf
+tmp=/etc/resolv.conf.new
+dest=/etc/resolv.conf
+line="options rotate timeout:1"
+
+if [ -f "$file" ]; then
+  cp "$file" "$tmp"
+  echo "\n# updated by update-resolv-conf.service (installed by gardener-extension-provider-openstack)" >> "$tmp"
+  echo "$line" >> "$tmp"
+  mv "$tmp" "$dest"
+fi`
+
+				filePath = "/opt/bin/update-resolv-conf.sh"
+
+				oldFile        = extensionsv1alpha1.File{Path: "oldpath"}
+				additionalFile = extensionsv1alpha1.File{
+					Path:        filePath,
+					Permissions: &permissions,
+					Content: extensionsv1alpha1.FileContent{
+						Inline: &extensionsv1alpha1.FileContentInline{
+							Encoding: "",
+							Data:     customFileContent,
+						},
+					},
+				}
+
+				files = []extensionsv1alpha1.File{oldFile, additionalFile}
+			)
+
+			// Create ensurer
+			ensurer := NewEnsurer(logger)
+
+			// Call EnsureAdditionalFiles method and check the result
+			err := ensurer.EnsureAdditionalFiles(ctx, eContextK8s121WithResolvConfOptions, &files, nil)
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(files).To(ConsistOf(oldFile, additionalFile))
+			Expect(files).To(HaveLen(2))
+		})
+	})
 })
 
 func checkKubeAPIServerDeployment(dep *appsv1.Deployment, annotations map[string]string, k8sVersion string, needsCSIMigrationCompletedFeatureGates bool) {
@@ -665,4 +847,9 @@ func clientGet(result runtime.Object) interface{} {
 		}
 		return nil
 	}
+}
+
+func encode(obj runtime.Object) []byte {
+	data, _ := json.Marshal(obj)
+	return data
 }


### PR DESCRIPTION

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement
/platform openstack

**What this PR does / why we need it**:
The optional field `resolvConfOptions` is added to the `CloudProfileConfig`. If it is set, an additional systemd service will be deployed on the worker nodes to update the file `/etc/resolv.conf` on every change of `/run/systemd/resolve/resolv.conf` and appends a line with the given options.

**Which issue(s) this PR fixes**:
Fixes #340 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Added optional field `resolvConfOptions` to the provider config of the cloud profile to allow to add options to `/etc/resolv.conf` on worker nodes
```
