### PR TITLE
Upgrade terraformer to v2.13.0, a version that uses terraform 0.13

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -2,7 +2,7 @@ images:
 - name: terraformer
   sourceRepository: github.com/gardener/terraformer
   repository: eu.gcr.io/gardener-project/gardener/terraformer-openstack
-  tag: "v2.9.0"
+  tag: "v2.13.0"
 
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes/cloud-provider-openstack

--- a/pkg/internal/infrastructure/templates/main.tpl.tf
+++ b/pkg/internal/infrastructure/templates/main.tpl.tf
@@ -1,3 +1,11 @@
+terraform {
+  required_providers {
+    openstack = {
+      source  = "terraform-provider-openstack/openstack"
+    }
+  }
+}
+
 provider "openstack" {
   auth_url    = "{{ .openstack.authURL }}"
   domain_name = var.DOMAIN_NAME


### PR DESCRIPTION
**How to categorize this PR?**

/area control-plane
/kind enhancement
/platform openstack

**What this PR does / why we need it**:
Upgrades `terraformer` image to v2.13.0, a version that uses `terraform` 0.13.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release Notes**:
``` other operator github.com/gardener/terraformer #105 @stoyanr
terraform has been upgraded to 0.13.7
```

``` other operator github.com/gardener/terraformer #104 @ialidzhikov
The following terraform provider plugins are updated:
- hashicorp/terraform-provider-aws: 3.54.0 -> 3.63.0
```

``` noteworthy developer github.com/gardener/terraformer #103 @rfranzke
The version for the `equinixmetal` Terraform provider plugin has been updated to `3.1.0`.
```

``` bugfix developer github.com/gardener/terraformer #102 @rfranzke
A bug has been fixed preventing to use Terraformer with a Terraform version >= 0.13.
```

``` other operator github.com/gardener/terraformer #101 @ialidzhikov
The following terraform provider plugins are updated:
- hashicorp/terraform-provider-aws: 3.32.0 -> 3.54.0
```
