### PR TITLE
use v1.21.0 for K8s >=1.18 <1.22

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -12,17 +12,17 @@ images:
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes/cloud-provider-openstack
   repository: k8scloudprovider/openstack-cloud-controller-manager
-  tag: "v1.18.2"
+  tag: "v1.21.0"
   targetVersion: "1.18.x"
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes/cloud-provider-openstack
   repository: k8scloudprovider/openstack-cloud-controller-manager
-  tag: "v1.19.2"
+  tag: "v1.21.0"
   targetVersion: "1.19.x"
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes/cloud-provider-openstack
   repository: k8scloudprovider/openstack-cloud-controller-manager
-  tag: "v1.20.1"
+  tag: "v1.21.0"
   targetVersion: "1.20.x"
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes/cloud-provider-openstack


### PR DESCRIPTION
**How to categorize this PR?**

/area control-plane
/kind enhancement
/kind regression
/platform openstack

**What this PR does / why we need it**:
With this change Kubernetes clusters with versions >=1.18 and < 1.22 will always get version v1.21.0 of the cloud-controller-manager.
As features will not backported to older versions of ccm we need to use a more recent version (which contains a required  feature: pattern based subnet detection, see https://github.com/kubernetes/cloud-provider-openstack/pull/1375) also for older k8s versions.

**Release note**:
```breaking operator
Kubernetes versions >=1.18 and < 1.22 will get cloud-controller-manager with version v1.21.0
```
