### PR TITLE
Remove OpenstackMachineclass cleanup

### DIFF
--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -56,12 +56,6 @@ func (w *workerDelegate) DeployMachineClasses(ctx context.Context) error {
 		}
 	}
 
-	// Delete any older version machine class CRs.
-	// TODO: This can safely be removed after a few releases. It only facilitates the transition between OpenStackMachineClass -> MachineClass for existing shoots.
-	if err := w.Client().DeleteAllOf(ctx, &machinev1alpha1.OpenStackMachineClass{}, client.InNamespace(w.worker.Namespace)); err != nil {
-		return fmt.Errorf("cleaning up old OpenstackMachineClass resources failed: %w", err)
-	}
-
 	return w.seedChartApplier.Apply(ctx, filepath.Join(openstack.InternalChartsPath, "machineclass"), w.worker.Namespace, "machineclass", kubernetes.Values(map[string]interface{}{"machineClasses": w.machineClasses}))
 }
 
@@ -214,7 +208,7 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 }
 
 func (w *workerDelegate) generateWorkerPoolHash(pool extensionsv1alpha1.WorkerPool, serverGroupDependency *api.ServerGroupDependency) (string, error) {
-	var additionalHashData = []string{}
+	additionalHashData := []string{}
 
 	// Include the given worker pool dependencies into the hash.
 	if serverGroupDependency != nil {

--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -445,10 +445,7 @@ var _ = Describe("Machines", func() {
 					setup(region, machineImage, "")
 					workerDelegate, _ := NewWorkerDelegate(common.NewClientContext(c, scheme, decoder), chartApplier, "", w, cluster, nil)
 
-					c.EXPECT().DeleteAllOf(context.TODO(), &machinev1alpha1.OpenStackMachineClass{}, client.InNamespace(namespace))
-
 					// Test workerDelegate.DeployMachineClasses()
-
 					chartApplier.
 						EXPECT().
 						Apply(
@@ -503,8 +500,6 @@ var _ = Describe("Machines", func() {
 					setup(regionWithImages, "", machineImageID)
 					workerDelegate, _ := NewWorkerDelegate(common.NewClientContext(c, scheme, decoder), chartApplier, "", workerWithRegion, clusterWithRegion, nil)
 					clusterWithRegion.Shoot.Spec.Hibernation = &gardencorev1beta1.Hibernation{Enabled: pointer.BoolPtr(true)}
-
-					c.EXPECT().DeleteAllOf(context.TODO(), &machinev1alpha1.OpenStackMachineClass{}, client.InNamespace(namespace))
 
 					// Test workerDelegate.DeployMachineClasses()
 
@@ -570,7 +565,6 @@ var _ = Describe("Machines", func() {
 						)
 
 						setup(region, machineImage, "")
-						c.EXPECT().DeleteAllOf(context.TODO(), &machinev1alpha1.OpenStackMachineClass{}, client.InNamespace(namespace))
 
 						workerWithServerGroup := w.DeepCopy()
 						workerWithServerGroup.Spec.Pools[0].ProviderConfig = &runtime.RawExtension{
@@ -670,27 +664,6 @@ var _ = Describe("Machines", func() {
 						err := workerDelegate.DeployMachineClasses(context.TODO())
 						Expect(err).NotTo(HaveOccurred())
 					})
-
-					It("should delete the old OpenStackMachineClass", func() {
-						setup(region, machineImage, "")
-						workerDelegate, _ := NewWorkerDelegate(common.NewClientContext(c, scheme, decoder), chartApplier, "", w, cluster, nil)
-
-						c.EXPECT().DeleteAllOf(context.TODO(), &machinev1alpha1.OpenStackMachineClass{}, client.InNamespace(namespace))
-
-						chartApplier.
-							EXPECT().
-							Apply(
-								context.TODO(),
-								filepath.Join(openstack.InternalChartsPath, "machineclass"),
-								namespace,
-								"machineclass",
-								kubernetes.Values(machineClasses),
-							).
-							Return(nil)
-
-						err := workerDelegate.DeployMachineClasses(context.TODO())
-						Expect(err).NotTo(HaveOccurred())
-					})
 				})
 
 				It("should fail if the server group dependencies do not exist", func() {
@@ -714,7 +687,6 @@ var _ = Describe("Machines", func() {
 					Expect(err).To(HaveOccurred())
 					Expect(err.Error()).To(Equal(`server group is required for pool "pool-1", but no server group dependency found`))
 				})
-
 			})
 
 			It("should fail because the version is invalid", func() {
@@ -818,6 +790,7 @@ func useDefaultMachineClassWith(def map[string]interface{}, add map[string]inter
 
 	return out
 }
+
 func addNameAndSecretToMachineClass(class map[string]interface{}, name string, credentialsSecretRef corev1.SecretReference) {
 	class["name"] = name
 	class["labels"] = map[string]string{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind cleanup
/platform openstack

**What this PR does / why we need it**:
Removes deprecated OpenstackMachineClass removal logic
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
Removes deprecated OpenstackMachineClass removal logic.
```
