### PR TITLE
Volume type support for root disk of VMs

### DIFF
--- a/charts/internal/machineclass/templates/machineclass.yaml
+++ b/charts/internal/machineclass/templates/machineclass.yaml
@@ -47,7 +47,10 @@ providerSpec:
     podNetworkCidr: {{ $machineClass.podNetworkCidr }}
 {{- if $machineClass.rootDiskSize }}
     rootDiskSize: {{ $machineClass.rootDiskSize }}
-{{- end}}
+{{- end }}
+{{- if $machineClass.rootDiskType}}
+    rootDiskType: {{ $machineClass.rootDiskType }}
+{{- end }}
 {{- if $machineClass.serverGroupID }}
     serverGroupID: {{ $machineClass.serverGroupID }}
 {{- end }}

--- a/charts/internal/machineclass/values.yaml
+++ b/charts/internal/machineclass/values.yaml
@@ -11,6 +11,7 @@ machineClasses:
   networkID: 426428cd-5e88-4005-9fad-9555d4dfd0fb
   podNetworkCidr: 100.96.0.0/11
   # rootDiskSize: 100 # 100GB
+  # rootDiskType: standard_hdd
   # serverGroupID: b35e94c1-15a7-4b54-a0f6-8789fasdf79s
   securityGroups:
   - my-security-group

--- a/pkg/apis/openstack/validation/shoot.go
+++ b/pkg/apis/openstack/validation/shoot.go
@@ -77,6 +77,10 @@ func ValidateWorkers(workers []core.Worker, cloudProfileCfg *api.CloudProfileCon
 			allErrs = append(allErrs, field.Forbidden(workerFldPath.Child("minimum"), "minimum value must be >= 1 if maximum value > 0 (auto scaling to 0 is not supported)"))
 		}
 
+		if worker.Volume != nil && worker.Volume.Type != nil && worker.Volume.VolumeSize == "" {
+			allErrs = append(allErrs, field.Forbidden(workerFldPath.Child("volume", "type"), "specifying volume type without a custom volume size is not allowed"))
+		}
+
 		if worker.ProviderConfig != nil {
 			workerConfig, err := helper.WorkerConfigFromRawExtension(worker.ProviderConfig)
 			if err != nil {

--- a/pkg/apis/openstack/validation/shoot_test.go
+++ b/pkg/apis/openstack/validation/shoot_test.go
@@ -33,9 +33,7 @@ import (
 
 var _ = Describe("Shoot validation", func() {
 	Describe("#ValidateShootCredentialsForK8sVersion", func() {
-		var (
-			versionPath = field.NewPath("spec", "kubernetes", "version")
-		)
+		versionPath := field.NewPath("spec", "kubernetes", "version")
 
 		It("should allow using application credentials for k8s version >=1.19", func() {
 			errorList := ValidateShootCredentialsForK8sVersion("1.19.0", credentials.Credentials{ApplicationCredentialSecret: "secret"}, versionPath)
@@ -67,7 +65,7 @@ var _ = Describe("Shoot validation", func() {
 	})
 
 	Describe("#ValidateNetworking", func() {
-		var networkingPath = field.NewPath("spec", "networking")
+		networkingPath := field.NewPath("spec", "networking")
 
 		It("should return no error because nodes CIDR was provided", func() {
 			networking := core.Networking{
@@ -125,7 +123,6 @@ var _ = Describe("Shoot validation", func() {
 
 		Describe("#ValidateWorkers", func() {
 			It("should pass because workers are configured correctly", func() {
-
 				errorList := ValidateWorkers(workers, nil, nilPath)
 
 				Expect(errorList).To(BeEmpty())
@@ -153,6 +150,21 @@ var _ = Describe("Shoot validation", func() {
 					PointTo(MatchFields(IgnoreExtras, Fields{
 						"Type":  Equal(field.ErrorTypeForbidden),
 						"Field": Equal("[0].minimum"),
+					})),
+				))
+			})
+
+			It("should forbid specifying volume type without size", func() {
+				workers[0].Volume = &core.Volume{
+					Type: pointer.String("standard"),
+				}
+
+				errorList := ValidateWorkers(workers, nil, nilPath)
+
+				Expect(errorList).To(ConsistOf(
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeForbidden),
+						"Field": Equal("[0].volume.type"),
 					})),
 				))
 			})

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -162,6 +162,11 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 				machineClassSpec["rootDiskSize"] = volumeSize
 			}
 
+			// specifying the volume type requires a custom volume size to be specified too.
+			if pool.Volume != nil && pool.Volume.Type != nil {
+				machineClassSpec["rootDiskType"] = *pool.Volume.Type
+			}
+
 			if machineImage.ID != "" {
 				machineClassSpec["imageID"] = machineImage.ID
 			} else {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement
/platform openstack

**What this PR does / why we need it**:
Allows specifying the type of the root volume used in instances and passes that to the MCM extension (as implemented [here](https://github.com/gardener/machine-controller-manager-provider-openstack/pull/43))

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Provider now supports specifying the volume type for the root disk of nodes.
```
