### PR TITLE
Add `internalNetworkName` to cloud-provider-config

### DIFF
--- a/charts/internal/cloud-provider-config/templates/_cloud-provider-config-networking.tpl
+++ b/charts/internal/cloud-provider-config/templates/_cloud-provider-config-networking.tpl
@@ -1,0 +1,6 @@
+{{- define "cloud-provider-config-networking" -}}
+[Networking]
+{{- if .Values.internalNetworkName }}
+internal-network-name="{{ .Values.internalNetworkName }}"
+{{- end }}
+{{- end -}}

--- a/charts/internal/cloud-provider-config/templates/cloud-provider-config.yaml
+++ b/charts/internal/cloud-provider-config/templates/cloud-provider-config.yaml
@@ -3,6 +3,7 @@
 {{ include "cloud-provider-config-credentials" . }}
 {{ include "cloud-provider-config-meta" . }}
 {{ include "cloud-provider-config-loadbalancer" . }}
+{{ include "cloud-provider-config-networking" . }}
 {{- end -}}
 ---
 apiVersion: v1

--- a/charts/internal/cloud-provider-config/values.yaml
+++ b/charts/internal/cloud-provider-config/values.yaml
@@ -31,6 +31,8 @@ useOctavia: false
 # - name: D
 #   floatingNetworkID: "1234"
 #   floatingSubnetTags: tag1,tag2
+# [Networking]
+# internalNetworkName: shoot--my-project--my-cluster
 # [BlockStorage]
 rescanBlockStorageOnResize: false
 ignoreVolumeAZ: false

--- a/hack/api-reference/api.md
+++ b/hack/api-reference/api.md
@@ -1087,6 +1087,17 @@ string
 </tr>
 <tr>
 <td>
+<code>name</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Name is the Network name.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>floatingPool</code></br>
 <em>
 <a href="#openstack.provider.extensions.gardener.cloud/v1alpha1.FloatingPoolStatus">

--- a/pkg/apis/openstack/types_infrastructure.go
+++ b/pkg/apis/openstack/types_infrastructure.go
@@ -74,6 +74,8 @@ type NodeStatus struct {
 type NetworkStatus struct {
 	// ID is the Network id.
 	ID string
+	// Name is the Network name.
+	Name string
 	// FloatingPool contains information about the floating pool.
 	FloatingPool FloatingPoolStatus
 	// Router contains information about the Router and related resources.

--- a/pkg/apis/openstack/v1alpha1/types_infrastructure.go
+++ b/pkg/apis/openstack/v1alpha1/types_infrastructure.go
@@ -78,6 +78,8 @@ type NodeStatus struct {
 type NetworkStatus struct {
 	// ID is the Network id.
 	ID string `json:"id"`
+	// Name is the Network name.
+	Name string `json:"name"`
 	// FloatingPool contains information about the floating pool.
 	FloatingPool FloatingPoolStatus `json:"floatingPool"`
 	// Router contains information about the Router and related resources.

--- a/pkg/apis/openstack/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/openstack/v1alpha1/zz_generated.conversion.go
@@ -680,6 +680,7 @@ func Convert_openstack_MachineImages_To_v1alpha1_MachineImages(in *openstack.Mac
 
 func autoConvert_v1alpha1_NetworkStatus_To_openstack_NetworkStatus(in *NetworkStatus, out *openstack.NetworkStatus, s conversion.Scope) error {
 	out.ID = in.ID
+	out.Name = in.Name
 	if err := Convert_v1alpha1_FloatingPoolStatus_To_openstack_FloatingPoolStatus(&in.FloatingPool, &out.FloatingPool, s); err != nil {
 		return err
 	}
@@ -697,6 +698,7 @@ func Convert_v1alpha1_NetworkStatus_To_openstack_NetworkStatus(in *NetworkStatus
 
 func autoConvert_openstack_NetworkStatus_To_v1alpha1_NetworkStatus(in *openstack.NetworkStatus, out *NetworkStatus, s conversion.Scope) error {
 	out.ID = in.ID
+	out.Name = in.Name
 	if err := Convert_openstack_FloatingPoolStatus_To_v1alpha1_FloatingPoolStatus(&in.FloatingPool, &out.FloatingPool, s); err != nil {
 		return err
 	}

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -481,11 +481,6 @@ func getConfigChartValues(
 		return nil, err
 	}
 
-	internalNetworkName := cluster.Shoot.Status.TechnicalID
-	if len(infraStatus.Networks.Name) > 0 {
-		internalNetworkName = infraStatus.Networks.Name
-	}
-
 	values := map[string]interface{}{
 		"kubernetesVersion":           cluster.Shoot.Spec.Kubernetes.Version,
 		"domainName":                  c.DomainName,
@@ -508,7 +503,7 @@ func getConfigChartValues(
 		"nodeVolumeAttachLimit":       cloudProfileConfig.NodeVolumeAttachLimit,
 		// detect internal network.
 		// See https://github.com/kubernetes/cloud-provider-openstack/blob/v1.22.1/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md#networking
-		"internalNetworkName": internalNetworkName,
+		"internalNetworkName": infraStatus.Networks.Name,
 	}
 
 	var loadBalancerClassesFromCloudProfile = []api.LoadBalancerClass{}

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -501,6 +501,9 @@ func getConfigChartValues(
 		"rescanBlockStorageOnResize":  cloudProfileConfig.RescanBlockStorageOnResize != nil && *cloudProfileConfig.RescanBlockStorageOnResize,
 		"ignoreVolumeAZ":              cloudProfileConfig.IgnoreVolumeAZ != nil && *cloudProfileConfig.IgnoreVolumeAZ,
 		"nodeVolumeAttachLimit":       cloudProfileConfig.NodeVolumeAttachLimit,
+		// detect internal network.
+		// See https://github.com/kubernetes/cloud-provider-openstack/blob/v1.22.1/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md#networking
+		"internalNetworkName": cluster.Shoot.Status.TechnicalID,
 	}
 
 	var loadBalancerClassesFromCloudProfile = []api.LoadBalancerClass{}

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -280,6 +280,7 @@ var _ = Describe("ValuesProvider", func() {
 			"applicationCredentialID":     "",
 			"applicationCredentialSecret": "",
 			"applicationCredentialName":   "",
+			"internalNetworkName":         technicalID,
 		}
 
 		It("should return correct config chart values", func() {

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -42,9 +42,10 @@ import (
 )
 
 const (
-	namespace = "test"
-	authURL   = "someurl"
-	region    = "europe"
+	namespace   = "test"
+	authURL     = "someurl"
+	region      = "europe"
+	technicalID = "shoot--dev--test"
 )
 
 var (
@@ -87,6 +88,7 @@ func controlPlane(floatingPoolID string, cfg *api.ControlPlaneConfig) *extension
 			InfrastructureProviderStatus: &runtime.RawExtension{
 				Raw: encode(&api.InfrastructureStatus{
 					Networks: api.NetworkStatus{
+						Name: technicalID,
 						FloatingPool: api.FloatingPoolStatus{
 							ID: floatingPoolID,
 						},
@@ -122,7 +124,7 @@ var _ = Describe("ValuesProvider", func() {
 		rescanBlockStorageOnResize       = true
 		ignoreVolumeAZ                   = true
 		nodeVoluemAttachLimit      int32 = 25
-		technicalID                      = "shoot--dev--test"
+		technicalID                      = technicalID
 
 		cloudProfileConfig = &api.CloudProfileConfig{
 			KeyStoneURL:                authURL,

--- a/pkg/internal/infrastructure/templates/main.tpl.tf
+++ b/pkg/internal/infrastructure/templates/main.tpl.tf
@@ -56,7 +56,7 @@ resource "openstack_networking_network_v2" "cluster" {
 }
 {{ else -}}
 data "openstack_networking_network_v2" "cluster" {
-  network_id = "{{ .networks.id }}"
+  network_id   = "{{ .networks.id }}"
 }
 {{- end }}
 
@@ -143,6 +143,10 @@ output "{{ .outputKeys.networkID }}" {
   value = {{ template "network-id" $ }}
 }
 
+output "{{ .outputKeys.networkName }}" {
+  value = {{ template "network-name" $ }}
+}
+
 output "{{ .outputKeys.keyName }}" {
   value = openstack_compute_keypair_v2.ssh_key.name
 }
@@ -172,5 +176,12 @@ output "{{ .outputKeys.subnetID }}" {
 openstack_networking_network_v2.cluster.id
 {{ else -}}
 data.openstack_networking_network_v2.cluster.id
+{{ end -}}
+{{- end -}}
+{{- define "network-name" -}}
+{{ if .create.network -}}
+openstack_networking_network_v2.cluster.name
+{{ else -}}
+data.openstack_networking_network_v2.cluster.name
 {{ end -}}
 {{- end -}}

--- a/pkg/internal/infrastructure/terraform.go
+++ b/pkg/internal/infrastructure/terraform.go
@@ -39,6 +39,8 @@ const (
 	TerraformOutputKeyRouterID = "router_id"
 	// TerraformOutputKeyNetworkID is the private worker network.
 	TerraformOutputKeyNetworkID = "network_id"
+	// TerraformOutputKeyNetworkName is the private worker network name.
+	TerraformOutputKeyNetworkName = "network_name"
 	// TerraformOutputKeySecurityGroupID is the id of worker security group.
 	TerraformOutputKeySecurityGroupID = "security_group_id"
 	// TerraformOutputKeySecurityGroupName is the name of the worker security group.
@@ -74,6 +76,7 @@ func ComputeTerraformerTemplateValues(
 		outputKeysConfig = map[string]interface{}{
 			"routerID":          TerraformOutputKeyRouterID,
 			"networkID":         TerraformOutputKeyNetworkID,
+			"networkName":       TerraformOutputKeyNetworkName,
 			"keyName":           TerraformOutputKeySSHKeyName,
 			"securityGroupID":   TerraformOutputKeySecurityGroupID,
 			"securityGroupName": TerraformOutputKeySecurityGroupName,
@@ -195,6 +198,8 @@ type TerraformState struct {
 	RouterID string
 	// NetworkID is the private worker network.
 	NetworkID string
+	// NetworkName is the private worker network name.
+	NetworkName string
 	// SubnetID is the id of the worker subnet.
 	SubnetID string
 	// FloatingNetworkID is the id of the provider network.
@@ -211,6 +216,7 @@ func ExtractTerraformState(ctx context.Context, tf terraformer.Terraformer) (*Te
 		TerraformOutputKeySSHKeyName,
 		TerraformOutputKeyRouterID,
 		TerraformOutputKeyNetworkID,
+		TerraformOutputKeyNetworkName,
 		TerraformOutputKeySubnetID,
 		TerraformOutputKeyFloatingNetworkID,
 		TerraformOutputKeySecurityGroupID,
@@ -226,6 +232,7 @@ func ExtractTerraformState(ctx context.Context, tf terraformer.Terraformer) (*Te
 		SSHKeyName:        vars[TerraformOutputKeySSHKeyName],
 		RouterID:          vars[TerraformOutputKeyRouterID],
 		NetworkID:         vars[TerraformOutputKeyNetworkID],
+		NetworkName:       vars[TerraformOutputKeyNetworkName],
 		SubnetID:          vars[TerraformOutputKeySubnetID],
 		FloatingNetworkID: vars[TerraformOutputKeyFloatingNetworkID],
 		SecurityGroupID:   vars[TerraformOutputKeySecurityGroupID],
@@ -242,7 +249,8 @@ func StatusFromTerraformState(state *TerraformState) *apiv1alpha1.Infrastructure
 			Kind:       "InfrastructureStatus",
 		},
 		Networks: apiv1alpha1.NetworkStatus{
-			ID: state.NetworkID,
+			ID:   state.NetworkID,
+			Name: state.NetworkName,
 			FloatingPool: apiv1alpha1.FloatingPoolStatus{
 				ID: state.FloatingNetworkID,
 			},

--- a/pkg/internal/infrastructure/terraform_test.go
+++ b/pkg/internal/infrastructure/terraform_test.go
@@ -134,6 +134,7 @@ var _ = Describe("Terraform", func() {
 			expectedOutputKeysValues = map[string]interface{}{
 				"routerID":          TerraformOutputKeyRouterID,
 				"networkID":         TerraformOutputKeyNetworkID,
+				"networkName":       TerraformOutputKeyNetworkName,
 				"keyName":           TerraformOutputKeySSHKeyName,
 				"securityGroupID":   TerraformOutputKeySecurityGroupID,
 				"securityGroupName": TerraformOutputKeySecurityGroupName,

--- a/pkg/openstack/client/networking.go
+++ b/pkg/openstack/client/networking.go
@@ -48,12 +48,3 @@ func (c *NetworkingClient) GetExternalNetworkNames(_ context.Context) ([]string,
 	}
 	return externalNetworkNames, nil
 }
-
-func (c *NetworkingClient) GetNetworkNameFromID(_ context.Context, id string) (string, error) {
-	network, err := networks.Get(c.client, id).Extract()
-	if err != nil {
-		return "", err
-	}
-
-	return network.Name, nil
-}

--- a/pkg/openstack/client/networking.go
+++ b/pkg/openstack/client/networking.go
@@ -16,6 +16,7 @@ package client
 
 import (
 	"context"
+
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/external"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/networks"
 	"k8s.io/utils/pointer"

--- a/pkg/openstack/client/networking.go
+++ b/pkg/openstack/client/networking.go
@@ -16,7 +16,6 @@ package client
 
 import (
 	"context"
-
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/external"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/networks"
 	"k8s.io/utils/pointer"
@@ -28,7 +27,7 @@ type networkWithExternalExt struct {
 }
 
 // GetExternalNetworkNames returns a list of all external network names.
-func (c *NetworkingClient) GetExternalNetworkNames(ctx context.Context) ([]string, error) {
+func (c *NetworkingClient) GetExternalNetworkNames(_ context.Context) ([]string, error) {
 	allPages, err := networks.List(c.client, external.ListOptsExt{
 		ListOptsBuilder: networks.ListOpts{},
 		External:        pointer.Bool(true),
@@ -48,4 +47,13 @@ func (c *NetworkingClient) GetExternalNetworkNames(ctx context.Context) ([]strin
 		externalNetworkNames = append(externalNetworkNames, externalNetwork.Name)
 	}
 	return externalNetworkNames, nil
+}
+
+func (c *NetworkingClient) GetNetworkNameFromID(_ context.Context, id string) (string, error) {
+	network, err := networks.Get(c.client, id).Extract()
+	if err != nil {
+		return "", err
+	}
+
+	return network.Name, nil
 }

--- a/pkg/openstack/client/types.go
+++ b/pkg/openstack/client/types.go
@@ -84,7 +84,6 @@ type DNS interface {
 // Networking describes the operations of a client interacting with OpenStack's Networking service.
 type Networking interface {
 	GetExternalNetworkNames(ctx context.Context) ([]string, error)
-	GetNetworkNameFromID(ctx context.Context, id string) (string, error)
 }
 
 // FactoryFactory creates instances of Factory.

--- a/pkg/openstack/client/types.go
+++ b/pkg/openstack/client/types.go
@@ -84,6 +84,7 @@ type DNS interface {
 // Networking describes the operations of a client interacting with OpenStack's Networking service.
 type Networking interface {
 	GetExternalNetworkNames(ctx context.Context) ([]string, error)
+	GetNetworkNameFromID(ctx context.Context, id string) (string, error)
 }
 
 // FactoryFactory creates instances of Factory.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug
/platform openstack

**What this PR does / why we need it**:
[cloud-provider-openstack](https://github.com/kubernetes/cloud-provider-openstack) offers the possibility to [identify the internal network](https://github.com/kubernetes/cloud-provider-openstack/blob/v1.22.1/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md#networking). This PR adds this option to the `cloud-provider-config`

This is necessary so that nodes can identify the correct internal IP when more than one network interface is attached to them.

**Which issue(s) this PR fixes**:
Fixes gardener/gardener-extension-provider-openstack#372

**Special notes for your reviewer**:

I have tried to find the right places in the code to make this change, but I am not sure I have found them.
Unfortunately I could not find out if `technicalID` is the best choice to determine the network name and hope for hints...

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Add `internalNetworkName` to cloud-provider-config
```
