### PR TITLE
Use separate resolv.conf for kubelet

### DIFF
--- a/pkg/webhook/controlplane/ensurer.go
+++ b/pkg/webhook/controlplane/ensurer.go
@@ -505,8 +505,7 @@ func (e *ensurer) EnsureAdditionalFiles(ctx context.Context, gctx gcontext.Garde
 	if err != nil {
 		return err
 	}
-	options := getResolveConfOptions(cloudProfileConfig)
-	e.addAdditionalFilesForResolvConfOptions(options, new)
+	e.addAdditionalFilesForResolvConfOptions(getResolveConfOptions(cloudProfileConfig), new)
 	return nil
 }
 

--- a/pkg/webhook/controlplane/ensurer.go
+++ b/pkg/webhook/controlplane/ensurer.go
@@ -419,6 +419,9 @@ func (e *ensurer) EnsureKubeletConfiguration(ctx context.Context, gctx gcontext.
 		new.FeatureGates[csiMigrationCompleteFeatureGate] = true
 	}
 
+	// resolv-for-kubelet.conf is created by update-resolv-conf.service
+	new.ResolverConfig = "/etc/resolv-for-kubelet.conf"
+
 	return nil
 }
 
@@ -458,17 +461,11 @@ func (e *ensurer) EnsureKubeletCloudProviderConfig(ctx context.Context, gctx gco
 
 // EnsureAdditionalUnits ensures that additional required system units are added.
 func (e *ensurer) EnsureAdditionalUnits(ctx context.Context, gctx gcontext.GardenContext, new, old *[]extensionsv1alpha1.Unit) error {
-	cloudProfileConfig, err := getCloudProfileConfig(ctx, gctx)
-	if err != nil {
-		return err
-	}
-	if len(getResolveConfOptions(cloudProfileConfig)) > 0 {
-		e.addAdditionalUnitsForResolvConfOptions(new)
-	}
+	e.addAdditionalUnitsForResolvConfOptions(new)
 	return nil
 }
 
-// addAdditionalUnitsForResolvConfOptions installs a systemd service to update `resolv.conf`
+// addAdditionalUnitsForResolvConfOptions installs a systemd service to update `resolv-for-kubelet.conf`
 // after each change of `/run/systemd/resolve/resolv.conf`.
 func (e *ensurer) addAdditionalUnitsForResolvConfOptions(new *[]extensionsv1alpha1.Unit) {
 	var (
@@ -480,7 +477,7 @@ PathChanged=/run/systemd/resolve/resolv.conf
 WantedBy=multi-user.target
 `
 		customUnitContent = `[Unit]
-Description=add options to /etc/resolv.conf after every change of /run/systemd/resolve/resolv.conf
+Description=update /etc/resolv-for-kubelet.conf on start and after each change of /run/systemd/resolve/resolv.conf
 After=network.target
 StartLimitIntervalSec=0
 
@@ -508,9 +505,8 @@ func (e *ensurer) EnsureAdditionalFiles(ctx context.Context, gctx gcontext.Garde
 	if err != nil {
 		return err
 	}
-	if options := getResolveConfOptions(cloudProfileConfig); len(options) > 0 {
-		e.addAdditionalFilesForResolvConfOptions(options, new)
-	}
+	options := getResolveConfOptions(cloudProfileConfig)
+	e.addAdditionalFilesForResolvConfOptions(options, new)
 	return nil
 }
 
@@ -521,21 +517,41 @@ func (e *ensurer) addAdditionalFilesForResolvConfOptions(options []string, new *
 		permissions int32 = 0755
 		template          = `#!/bin/sh
 
-file=/run/systemd/resolve/resolv.conf
-tmp=/etc/resolv.conf.new
-dest=/etc/resolv.conf
+tmp=/etc/resolv-for-kubelet.conf.new
+dest=/etc/resolv-for-kubelet.conf
 line=%q
 
-if [ -f "$file" ]; then
-  cp "$file" "$tmp"
-  echo "" >> "$tmp"
-  echo "# updated by update-resolv-conf.service (installed by gardener-extension-provider-openstack)" >> "$tmp"
-  echo "$line" >> "$tmp"
-  mv "$tmp" "$dest"
-fi`
+is_systemd_resolved_system()
+{
+    if [ -f /run/systemd/resolve/resolv.conf ]; then
+      return 0
+    else
+      return 1
+    fi
+}
+
+rm -f "$tmp"
+if is_systemd_resolved_system; then
+  if [ "$line" = "" ]; then
+    ln -s /run/systemd/resolve/resolv.conf "$tmp"
+  else
+    cp /run/systemd/resolve/resolv.conf "$tmp"
+    echo "" >> "$tmp"
+    echo "# updated by update-resolv-conf.service (installed by gardener-extension-provider-openstack)" >> "$tmp"
+    echo "$line" >> "$tmp"
+  fi
+else
+  ln -s /etc/resolv.conf "$tmp"
+fi
+mv "$tmp" "$dest" && echo updated "$dest"
+`
 	)
 
-	content := fmt.Sprintf(template, fmt.Sprintf("options %s", strings.Join(options, " ")))
+	optionLine := ""
+	if len(options) > 0 {
+		optionLine = fmt.Sprintf("options %s", strings.Join(options, " "))
+	}
+	content := fmt.Sprintf(template, optionLine)
 	file := extensionsv1alpha1.File{
 		Path:        "/opt/bin/update-resolv-conf.sh",
 		Permissions: &permissions,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement
/platform openstack

**What this PR does / why we need it**:
Debian derivates like Garden Linux and Ubuntu are using `systemd-resolved` for  network name resolution. This service also contains a full-featured local resolver at `127.0.0.53`.
With this PR, the kubelet uses a separate resolve config file `/etc/resolv-for-kubelet.conf` linked to `/run/systemd/resolve/resolv.conf`. If the cloud profile defines `resolvConfOptions`, the kubelet will use a patched copy of `/run/systemd/resolve/resolv.conf` as already introduced with PR #342. As the kubelet configuration is defined globally for all worker pools, the implementation is a little complicated. It needs to provide the separate `/etc/resolv-for-kubelet.conf` even if the OS is has no `systemd-resolved`. The `update-resolv-conf.service` is dealing with this case.
A separate resolve config file for the kubelet is useful on OS with `systemd-resolved`. The standard `/etc/resolv.conf` can then reference the standard local resolver. 
Besides, the (harmless) duplicate name server issue seen on Garden Linux disappears with these changes.

**Special notes for your reviewer**:
As these changes have impact for all used operating systems, it has been validated for Garden Linux, SUSE chost, and Ubuntu (both with and without resolvConfOptions in the cloud profile)

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Use separate resolv.conf for kubelet (optionally patched with resolvConfOptions from the cloud profile)
```
