### PR TITLE
Kubernetes Version Configurability per Worker Pool

### DIFF
--- a/docs/usage-as-end-user.md
+++ b/docs/usage-as-end-user.md
@@ -205,3 +205,8 @@ Every OpenStack shoot cluster that has at least Kubernetes v1.19 will be deploye
 It is compatible with the legacy in-tree volume provisioner that was deprecated by the Kubernetes community and will be removed in future versions of Kubernetes.
 End-users might want to update their custom `StorageClass`es to the new `cinder.csi.openstack.org` provisioner.
 Shoot clusters with Kubernetes v1.18 or less will use the in-tree `kubernetes.io/cinder` volume provisioner in the kube-controller-manager and the kubelet.
+
+## Kubernetes Versions per Worker Pool
+
+This extension supports `gardener/gardener`'s `WorkerPoolKubernetesVersion` feature gate, i.e., having [worker pools with overridden Kubernetes versions](https://github.com/gardener/gardener/blob/8a9c88866ec5fce59b5acf57d4227eeeb73669d7/example/90-shoot.yaml#L69-L70) since `gardener-extension-provider-openstack@v1.23`.
+Note that this feature is only usable for `Shoot`s whose `.spec.kubernetes.version` is greater or equal than the CSI migration version (`1.19`).

--- a/pkg/apis/openstack/validation/shoot.go
+++ b/pkg/apis/openstack/validation/shoot.go
@@ -38,7 +38,7 @@ func ValidateShootCredentialsForK8sVersion(k8sVersion string, credentials openst
 
 	// The Kubernetes version is the version of the CSI migration, where we stopped using the in-tree providers.
 	// see: pkg/webhook/controlplane/ensurer.go
-	k8sVersionLessThan19, err := version.CompareVersions(k8sVersion, "<", "1.19")
+	k8sVersionLessThan19, err := version.CompareVersions(k8sVersion, "<", openstack.CSIMigrationKubernetesVersion)
 	if err != nil {
 		allErrs = append(allErrs, field.Invalid(fldPath, k8sVersion, "not a valid version"))
 	}

--- a/pkg/apis/openstack/validation/shoot.go
+++ b/pkg/apis/openstack/validation/shoot.go
@@ -17,6 +17,7 @@ package validation
 import (
 	"fmt"
 
+	"github.com/Masterminds/semver"
 	"github.com/gardener/gardener/pkg/apis/core"
 	"github.com/gardener/gardener/pkg/apis/core/validation"
 	"github.com/gardener/gardener/pkg/utils/version"
@@ -66,8 +67,30 @@ func ValidateNetworking(networking core.Networking, fldPath *field.Path) field.E
 func ValidateWorkers(workers []core.Worker, cloudProfileCfg *api.CloudProfileConfig, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
+	csiMigrationVersion, err := semver.NewVersion(openstack.CSIMigrationKubernetesVersion)
+	if err != nil {
+		allErrs = append(allErrs, field.InternalError(fldPath, err))
+		return allErrs
+	}
+
 	for i, worker := range workers {
 		workerFldPath := fldPath.Index(i)
+
+		// Ensure the kubelet version is not lower than the version in which the extension performs CSI migration.
+		if worker.Kubernetes != nil && worker.Kubernetes.Version != nil {
+			versionPath := workerFldPath.Child("kubernetes", "version")
+
+			v, err := semver.NewVersion(*worker.Kubernetes.Version)
+			if err != nil {
+				allErrs = append(allErrs, field.Invalid(versionPath, *worker.Kubernetes.Version, err.Error()))
+				return allErrs
+			}
+
+			if v.LessThan(csiMigrationVersion) {
+				allErrs = append(allErrs, field.Forbidden(versionPath, fmt.Sprintf("cannot use kubelet version (%s) lower than CSI migration version (%s)", v.String(), csiMigrationVersion.String())))
+			}
+		}
+
 		if len(worker.Zones) == 0 {
 			allErrs = append(allErrs, field.Required(workerFldPath.Child("zones"), "at least one zone must be configured"))
 			continue
@@ -84,7 +107,7 @@ func ValidateWorkers(workers []core.Worker, cloudProfileCfg *api.CloudProfileCon
 		if worker.ProviderConfig != nil {
 			workerConfig, err := helper.WorkerConfigFromRawExtension(worker.ProviderConfig)
 			if err != nil {
-				allErrs = append(allErrs, field.Invalid(fldPath.Index(i).Child("providerConfig"), string(worker.ProviderConfig.Raw), fmt.Sprint("providerConfig could not be decoded", err)))
+				allErrs = append(allErrs, field.Invalid(workerFldPath.Child("providerConfig"), string(worker.ProviderConfig.Raw), fmt.Sprint("providerConfig could not be decoded", err)))
 				continue
 			}
 

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -350,7 +350,7 @@ func (vp *valuesProvider) GetControlPlaneChartValues(
 	}
 	checksums[openstack.CloudProviderConfigName] = gutil.ComputeChecksum(cpConfigSecret.Data)
 
-	k8sVersionLessThan119, err := version.CompareVersions(cluster.Shoot.Spec.Kubernetes.Version, "<", "1.19")
+	k8sVersionLessThan119, err := version.CompareVersions(cluster.Shoot.Spec.Kubernetes.Version, "<", openstack.CSIMigrationKubernetesVersion)
 	if err != nil {
 		return nil, err
 	}
@@ -375,7 +375,7 @@ func (vp *valuesProvider) GetControlPlaneShootChartValues(
 	cluster *extensionscontroller.Cluster,
 	checksums map[string]string,
 ) (map[string]interface{}, error) {
-	k8sVersionLessThan119, err := version.CompareVersions(cluster.Shoot.Spec.Kubernetes.Version, "<", "1.19")
+	k8sVersionLessThan119, err := version.CompareVersions(cluster.Shoot.Spec.Kubernetes.Version, "<", openstack.CSIMigrationKubernetesVersion)
 	if err != nil {
 		return nil, err
 	}
@@ -405,7 +405,7 @@ func (vp *valuesProvider) GetControlPlaneShootCRDsChartValues(
 	_ *extensionsv1alpha1.ControlPlane,
 	cluster *extensionscontroller.Cluster,
 ) (map[string]interface{}, error) {
-	k8sVersionLessThan119, err := version.CompareVersions(cluster.Shoot.Spec.Kubernetes.Version, "<", "1.19")
+	k8sVersionLessThan119, err := version.CompareVersions(cluster.Shoot.Spec.Kubernetes.Version, "<", openstack.CSIMigrationKubernetesVersion)
 	if err != nil {
 		return nil, err
 	}
@@ -423,7 +423,7 @@ func (vp *valuesProvider) GetStorageClassesChartValues(
 	_ *extensionsv1alpha1.ControlPlane,
 	cluster *extensionscontroller.Cluster,
 ) (map[string]interface{}, error) {
-	k8sVersionLessThan119, err := version.CompareVersions(cluster.Shoot.Spec.Kubernetes.Version, "<", "1.19")
+	k8sVersionLessThan119, err := version.CompareVersions(cluster.Shoot.Spec.Kubernetes.Version, "<", openstack.CSIMigrationKubernetesVersion)
 	if err != nil {
 		return nil, err
 	}
@@ -680,7 +680,7 @@ func getCSIControllerChartValues(
 	checksums map[string]string,
 	scaledDown bool,
 ) (map[string]interface{}, error) {
-	k8sVersionLessThan119, err := version.CompareVersions(cluster.Shoot.Spec.Kubernetes.Version, "<", "1.19")
+	k8sVersionLessThan119, err := version.CompareVersions(cluster.Shoot.Spec.Kubernetes.Version, "<", openstack.CSIMigrationKubernetesVersion)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/csimigration/add.go
+++ b/pkg/controller/csimigration/add.go
@@ -36,7 +36,7 @@ type AddOptions struct {
 func AddToManagerWithOptions(mgr manager.Manager, opts AddOptions) error {
 	return csimigration.Add(mgr, csimigration.AddArgs{
 		ControllerOptions:             opts.Controller,
-		CSIMigrationKubernetesVersion: "1.19",
+		CSIMigrationKubernetesVersion: openstack.CSIMigrationKubernetesVersion,
 		Type:                          openstack.Type,
 		StorageClassNameToLegacyProvisioner: map[string]string{
 			"default":       "kubernetes.io/cinder",

--- a/pkg/controller/healthcheck/add.go
+++ b/pkg/controller/healthcheck/add.go
@@ -48,7 +48,7 @@ var (
 // HealthChecks are grouped by extension (e.g worker), extension.type (e.g aws) and  Health Check Type (e.g SystemComponentsHealthy)
 func RegisterHealthChecks(mgr manager.Manager, opts healthcheck.DefaultAddArgs) error {
 	csiEnabledPreCheckFunc := func(_ client.Object, cluster *extensionscontroller.Cluster) bool {
-		csiEnabled, err := version.CompareVersions(cluster.Shoot.Spec.Kubernetes.Version, ">=", "1.19")
+		csiEnabled, err := version.CompareVersions(cluster.Shoot.Spec.Kubernetes.Version, ">=", openstack.CSIMigrationKubernetesVersion)
 		if err != nil {
 			return false
 		}

--- a/pkg/openstack/types.go
+++ b/pkg/openstack/types.go
@@ -125,6 +125,10 @@ const (
 	MachineControllerManagerVpaName = "machine-controller-manager-vpa"
 	// MachineControllerManagerMonitoringConfigName is the name of the ConfigMap containing monitoring stack configurations for machine-controller-manager.
 	MachineControllerManagerMonitoringConfigName = "machine-controller-manager-monitoring-config"
+
+	// CSIMigrationKubernetesVersion is a constant for the Kubernetes version for which the Shoot's CSI migration will be
+	// performed.
+	CSIMigrationKubernetesVersion = "1.19"
 )
 
 var (

--- a/pkg/webhook/controlplane/ensurer.go
+++ b/pkg/webhook/controlplane/ensurer.go
@@ -19,11 +19,11 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/Masterminds/semver"
 	apisopenstack "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack"
 	"github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack/helper"
 	"github.com/gardener/gardener-extension-provider-openstack/pkg/openstack"
 
+	"github.com/Masterminds/semver"
 	"github.com/coreos/go-systemd/v22/unit"
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
 	"github.com/gardener/gardener/extensions/pkg/controller/csimigration"
@@ -42,8 +42,6 @@ import (
 	kubeletconfigv1beta1 "k8s.io/kubelet/config/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
-
-const csiMigrationVersion = "1.19"
 
 // NewEnsurer creates a new controlplane ensurer.
 func NewEnsurer(logger logr.Logger) genericmutator.Ensurer {
@@ -86,7 +84,7 @@ func (e *ensurer) EnsureKubeAPIServerDeployment(ctx context.Context, gctx gconte
 		return err
 	}
 
-	csiEnabled, csiMigrationComplete, err := csimigration.CheckCSIConditions(cluster, csiMigrationVersion)
+	csiEnabled, csiMigrationComplete, err := csimigration.CheckCSIConditions(cluster, openstack.CSIMigrationKubernetesVersion)
 	if err != nil {
 		return err
 	}
@@ -114,7 +112,7 @@ func (e *ensurer) EnsureKubeControllerManagerDeployment(ctx context.Context, gct
 		return err
 	}
 
-	csiEnabled, csiMigrationComplete, err := csimigration.CheckCSIConditions(cluster, csiMigrationVersion)
+	csiEnabled, csiMigrationComplete, err := csimigration.CheckCSIConditions(cluster, openstack.CSIMigrationKubernetesVersion)
 	if err != nil {
 		return err
 	}
@@ -143,7 +141,7 @@ func (e *ensurer) EnsureKubeSchedulerDeployment(ctx context.Context, gctx gconte
 		return err
 	}
 
-	csiEnabled, csiMigrationComplete, err := csimigration.CheckCSIConditions(cluster, csiMigrationVersion)
+	csiEnabled, csiMigrationComplete, err := csimigration.CheckCSIConditions(cluster, openstack.CSIMigrationKubernetesVersion)
 	if err != nil {
 		return err
 	}
@@ -363,7 +361,7 @@ func (e *ensurer) EnsureKubeletServiceUnitOptions(ctx context.Context, gctx gcon
 		return nil, err
 	}
 
-	csiEnabled, _, err := csimigration.CheckCSIConditions(cluster, csiMigrationVersion)
+	csiEnabled, _, err := csimigration.CheckCSIConditions(cluster, openstack.CSIMigrationKubernetesVersion)
 	if err != nil {
 		return nil, err
 	}
@@ -400,7 +398,7 @@ func (e *ensurer) EnsureKubeletConfiguration(ctx context.Context, gctx gcontext.
 		return err
 	}
 
-	csiEnabled, _, err := csimigration.CheckCSIConditions(cluster, csiMigrationVersion)
+	csiEnabled, _, err := csimigration.CheckCSIConditions(cluster, openstack.CSIMigrationKubernetesVersion)
 	if err != nil {
 		return err
 	}
@@ -433,7 +431,7 @@ func (e *ensurer) ShouldProvisionKubeletCloudProviderConfig(ctx context.Context,
 		return false
 	}
 
-	csiEnabled, _, err := csimigration.CheckCSIConditions(cluster, csiMigrationVersion)
+	csiEnabled, _, err := csimigration.CheckCSIConditions(cluster, openstack.CSIMigrationKubernetesVersion)
 	if err != nil {
 		return false
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement
/platform openstack
/merge squash

**What this PR does / why we need it**:
This PR implements support for `gardener/gardener`'s `WorkerPoolKubernetesVersion` feature gate. As explained in https://github.com/gardener/gardener/issues/3501#issuecomment-1009061189, it
- adds validation to prevent using kubelet versions lower than the CSI migration version (note that this ensures that the feature is only usable once the cluster with its control plane and **all** its worker pools was upgraded to at least the CSI migration version).
- adapts the `controlpane` webhook to use the effective kubelet version when computing the CSI migration feature gate names.

**Which issue(s) this PR fixes**:
Part of gardener/gardener#3501

**Special notes for your reviewer**:
✅ ~Depends on #383, hence, PR is in draft state.~

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
This extension does now support `gardener/gardener`'s `WorkerPoolKubernetesVersion` feature gate, i.e., having [worker pools with overridden Kubernetes versions](https://github.com/gardener/gardener/blob/8a9c88866ec5fce59b5acf57d4227eeeb73669d7/example/90-shoot.yaml#L69-L70).
```
```feature user
In case `gardener/gardener`'s `WorkerPoolKubernetesVersion` feature gate is enabled, it's possible having [worker pools with overridden Kubernetes versions](https://github.com/gardener/gardener/blob/8a9c88866ec5fce59b5acf57d4227eeeb73669d7/example/90-shoot.yaml#L69-L70) for `Shoot`s whose `.spec.kubernetes.version` is greater or equal than the CSI migration version (`1.19`).
```