### PR TITLE
Vendor gardener/gardener@v1.39.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/ahmetb/gen-crd-api-reference-docs v0.2.0
 	github.com/coreos/go-systemd/v22 v22.3.2
 	github.com/gardener/etcd-druid v0.7.0
-	github.com/gardener/gardener v1.39.0
+	github.com/gardener/gardener v1.39.3
 	github.com/gardener/machine-controller-manager v0.41.0
 	github.com/go-logr/logr v0.4.0
 	github.com/golang/mock v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -249,8 +249,8 @@ github.com/gardener/gardener v1.6.5/go.mod h1:w5IHIQDccvSxZJFOtBa8YConyyFgt07DBH
 github.com/gardener/gardener v1.11.3/go.mod h1:5DzqfOm+G8UftKu5zUbYJ+9Cnfd4XrvRNDabkM9AIp4=
 github.com/gardener/gardener v1.17.1/go.mod h1:uucRHq0xV46xd9MpJJjRswx/Slq3+ipbbJg09FVUtvM=
 github.com/gardener/gardener v1.23.0/go.mod h1:xS/sYyzYsq2W0C79mT98G/qoOTvy/hHTfApHIVF3v2o=
-github.com/gardener/gardener v1.39.0 h1:DTtuSlgV7yZnJHmh8tRdLi2pBm6fQ6LdpueFQ0nBErM=
-github.com/gardener/gardener v1.39.0/go.mod h1:NwK0dGM8H+lgLncEa0iQKWRLqGNqYHtDkwia+msLuc0=
+github.com/gardener/gardener v1.39.3 h1:b6k3XyfA6bprbcuAr9E9Sand/enOQVcKdx59awVN3Ec=
+github.com/gardener/gardener v1.39.3/go.mod h1:NwK0dGM8H+lgLncEa0iQKWRLqGNqYHtDkwia+msLuc0=
 github.com/gardener/gardener-resource-manager v0.10.0/go.mod h1:0pKTHOhvU91eQB0EYr/6Ymd7lXc/5Hi8P8tF/gpV0VQ=
 github.com/gardener/gardener-resource-manager v0.13.1/go.mod h1:0No/XttYRUwDn5lSppq9EqlKdo/XJQ44aCZz5BVu3Vw=
 github.com/gardener/gardener-resource-manager v0.18.0/go.mod h1:k53Yw2iDAIpTxnChQY9qFHrRtuPQWJDNnCP9eE6TnWQ=

--- a/vendor/github.com/gardener/gardener/extensions/pkg/controller/controlplane/genericactuator/actuator.go
+++ b/vendor/github.com/gardener/gardener/extensions/pkg/controller/controlplane/genericactuator/actuator.go
@@ -78,8 +78,8 @@ type ValuesProvider interface {
 // the values provided by the given values provider.
 func NewActuator(
 	providerName string,
-	secrets secretutil.Interface, shootAccessSecrets []*gutil.ShootAccessSecret, legacySecretNamesToCleanup []string,
-	exposureSecrets secretutil.Interface, exposureShootAccessSecrets []*gutil.ShootAccessSecret, legacyExposureSecretNamesToCleanup []string,
+	secrets secretutil.Interface, shootAccessSecrets func(namespace string) []*gutil.ShootAccessSecret, legacySecretNamesToCleanup []string,
+	exposureSecrets secretutil.Interface, exposureShootAccessSecrets func(namespace string) []*gutil.ShootAccessSecret, legacyExposureSecretNamesToCleanup []string,
 	configChart, controlPlaneChart, controlPlaneShootChart, controlPlaneShootCRDsChart, storageClassesChart, controlPlaneExposureChart chart.Interface,
 	vp ValuesProvider,
 	chartRendererFactory extensionscontroller.ChartRendererFactory,
@@ -93,11 +93,11 @@ func NewActuator(
 		providerName: providerName,
 
 		secrets:                    secrets,
-		shootAccessSecrets:         shootAccessSecrets,
+		shootAccessSecretsFunc:     shootAccessSecrets,
 		legacySecretNamesToCleanup: legacySecretNamesToCleanup,
 
 		exposureSecrets:                    exposureSecrets,
-		exposureShootAccessSecrets:         exposureShootAccessSecrets,
+		exposureShootAccessSecretsFunc:     exposureShootAccessSecrets,
 		legacyExposureSecretNamesToCleanup: legacyExposureSecretNamesToCleanup,
 
 		configChart:                configChart,
@@ -120,14 +120,14 @@ func NewActuator(
 type actuator struct {
 	providerName string
 
-	// Deprecated: Use 'shootAccessSecrets' instead.
+	// Deprecated: Use 'shootAccessSecretsFunc' instead.
 	secrets                    secretutil.Interface
-	shootAccessSecrets         []*gutil.ShootAccessSecret
+	shootAccessSecretsFunc     func(namespace string) []*gutil.ShootAccessSecret
 	legacySecretNamesToCleanup []string
 
-	// Deprecated: Use 'exposureShootAccessSecrets' instead.
+	// Deprecated: Use 'exposureShootAccessSecretsFunc' instead.
 	exposureSecrets                    secretutil.Interface
-	exposureShootAccessSecrets         []*gutil.ShootAccessSecret
+	exposureShootAccessSecretsFunc     func(namespace string) []*gutil.ShootAccessSecret
 	legacyExposureSecretNamesToCleanup []string
 
 	configChart                chart.Interface
@@ -226,9 +226,11 @@ func (a *actuator) reconcileControlPlaneExposure(
 		checksums = controlplane.ComputeChecksums(deployedSecrets, nil)
 	}
 
-	for _, shootAccessSecret := range a.exposureShootAccessSecrets {
-		if err := shootAccessSecret.WithNamespaceOverride(cp.Namespace).Reconcile(ctx, a.client); err != nil {
-			return false, fmt.Errorf("could not reconcile control plane exposure shoot access secret '%s' for controlplane '%s': %w", shootAccessSecret.Secret.Name, kutil.ObjectName(cp), err)
+	if a.exposureShootAccessSecretsFunc != nil {
+		for _, shootAccessSecret := range a.exposureShootAccessSecretsFunc(cp.Namespace) {
+			if err := shootAccessSecret.Reconcile(ctx, a.client); err != nil {
+				return false, fmt.Errorf("could not reconcile control plane exposure shoot access secret '%s' for controlplane '%s': %w", shootAccessSecret.Secret.Name, kutil.ObjectName(cp), err)
+			}
 		}
 	}
 
@@ -284,9 +286,11 @@ func (a *actuator) reconcileControlPlane(
 		}
 	}
 
-	for _, shootAccessSecret := range a.shootAccessSecrets {
-		if err := shootAccessSecret.WithNamespaceOverride(cp.Namespace).Reconcile(ctx, a.client); err != nil {
-			return false, fmt.Errorf("could not reconcile shoot access secret '%s' for controlplane '%s': %w", shootAccessSecret.Secret.Name, kutil.ObjectName(cp), err)
+	if a.shootAccessSecretsFunc != nil {
+		for _, shootAccessSecret := range a.shootAccessSecretsFunc(cp.Namespace) {
+			if err := shootAccessSecret.Reconcile(ctx, a.client); err != nil {
+				return false, fmt.Errorf("could not reconcile shoot access secret '%s' for controlplane '%s': %w", shootAccessSecret.Secret.Name, kutil.ObjectName(cp), err)
+			}
 		}
 	}
 
@@ -437,9 +441,11 @@ func (a *actuator) deleteControlPlaneExposure(
 		}
 	}
 
-	for _, shootAccessSecret := range a.exposureShootAccessSecrets {
-		if err := kutil.DeleteObject(ctx, a.client, shootAccessSecret.WithNamespaceOverride(cp.Namespace).Secret); err != nil {
-			return fmt.Errorf("could not delete control plane exposure shoot access secret '%s' for controlplane '%s': %w", shootAccessSecret.Secret.Name, kutil.ObjectName(cp), err)
+	if a.exposureShootAccessSecretsFunc != nil {
+		for _, shootAccessSecret := range a.exposureShootAccessSecretsFunc(cp.Namespace) {
+			if err := kutil.DeleteObject(ctx, a.client, shootAccessSecret.Secret); err != nil {
+				return fmt.Errorf("could not delete control plane exposure shoot access secret '%s' for controlplane '%s': %w", shootAccessSecret.Secret.Name, kutil.ObjectName(cp), err)
+			}
 		}
 	}
 
@@ -515,9 +521,11 @@ func (a *actuator) deleteControlPlane(
 		}
 	}
 
-	for _, shootAccessSecret := range a.shootAccessSecrets {
-		if err := kutil.DeleteObject(ctx, a.client, shootAccessSecret.WithNamespaceOverride(cp.Namespace).Secret); err != nil {
-			return fmt.Errorf("could not delete shoot access secret '%s' for controlplane '%s': %w", shootAccessSecret.Secret.Name, kutil.ObjectName(cp), err)
+	if a.shootAccessSecretsFunc != nil {
+		for _, shootAccessSecret := range a.shootAccessSecretsFunc(cp.Namespace) {
+			if err := kutil.DeleteObject(ctx, a.client, shootAccessSecret.Secret); err != nil {
+				return fmt.Errorf("could not delete shoot access secret '%s' for controlplane '%s': %w", shootAccessSecret.Secret.Name, kutil.ObjectName(cp), err)
+			}
 		}
 	}
 

--- a/vendor/github.com/gardener/gardener/pkg/apis/core/helper/helpers.go
+++ b/vendor/github.com/gardener/gardener/pkg/apis/core/helper/helpers.go
@@ -319,6 +319,24 @@ func FindVersionsWithSameMajorMinor(versions []core.ExpirableVersion, version se
 	return result, nil
 }
 
+// GetShootAuditPolicyConfigMapName returns the Shoot's ConfigMap reference name for the audit policy.
+func GetShootAuditPolicyConfigMapName(apiServerConfig *core.KubeAPIServerConfig) string {
+	if ref := GetShootAuditPolicyConfigMapRef(apiServerConfig); ref != nil {
+		return ref.Name
+	}
+	return ""
+}
+
+// GetShootAuditPolicyConfigMapRef returns the Shoot's ConfigMap reference for the audit policy.
+func GetShootAuditPolicyConfigMapRef(apiServerConfig *core.KubeAPIServerConfig) *corev1.ObjectReference {
+	if apiServerConfig != nil &&
+		apiServerConfig.AuditConfig != nil &&
+		apiServerConfig.AuditConfig.AuditPolicy != nil {
+		return apiServerConfig.AuditConfig.AuditPolicy.ConfigMapRef
+	}
+	return nil
+}
+
 // HibernationIsEnabled checks if the given shoot's desired state is hibernated.
 func HibernationIsEnabled(shoot *core.Shoot) bool {
 	return shoot.Spec.Hibernation != nil && shoot.Spec.Hibernation.Enabled != nil && *shoot.Spec.Hibernation.Enabled

--- a/vendor/github.com/gardener/gardener/pkg/apis/core/v1beta1/helper/helper.go
+++ b/vendor/github.com/gardener/gardener/pkg/apis/core/v1beta1/helper/helper.go
@@ -1322,31 +1322,6 @@ func SeedBackupSecretRefEqual(oldBackup, newBackup *gardencorev1beta1.SeedBackup
 	return apiequality.Semantic.DeepEqual(oldSecretRef, newSecretRef)
 }
 
-// ShootAuditPolicyConfigMapRefEqual returns true if the name of the ConfigMap reference for the audit policy
-// configuration is the same.
-func ShootAuditPolicyConfigMapRefEqual(oldAPIServerConfig, newAPIServerConfig *gardencorev1beta1.KubeAPIServerConfig) bool {
-	var (
-		oldConfigMapRefName string
-		newConfigMapRefName string
-	)
-
-	if oldAPIServerConfig != nil &&
-		oldAPIServerConfig.AuditConfig != nil &&
-		oldAPIServerConfig.AuditConfig.AuditPolicy != nil &&
-		oldAPIServerConfig.AuditConfig.AuditPolicy.ConfigMapRef != nil {
-		oldConfigMapRefName = oldAPIServerConfig.AuditConfig.AuditPolicy.ConfigMapRef.Name
-	}
-
-	if newAPIServerConfig != nil &&
-		newAPIServerConfig.AuditConfig != nil &&
-		newAPIServerConfig.AuditConfig.AuditPolicy != nil &&
-		newAPIServerConfig.AuditConfig.AuditPolicy.ConfigMapRef != nil {
-		newConfigMapRefName = newAPIServerConfig.AuditConfig.AuditPolicy.ConfigMapRef.Name
-	}
-
-	return oldConfigMapRefName == newConfigMapRefName
-}
-
 // ShootDNSProviderSecretNamesEqual returns true when all the secretNames in the `.spec.dns.providers[]` list are the
 // same.
 func ShootDNSProviderSecretNamesEqual(oldDNS, newDNS *gardencorev1beta1.DNS) bool {
@@ -1395,6 +1370,24 @@ func ShootSecretResourceReferencesEqual(oldResources, newResources []gardencorev
 	}
 
 	return oldNames.Equal(newNames)
+}
+
+// GetShootAuditPolicyConfigMapName returns the Shoot's ConfigMap reference name for the audit policy.
+func GetShootAuditPolicyConfigMapName(apiServerConfig *gardencorev1beta1.KubeAPIServerConfig) string {
+	if ref := GetShootAuditPolicyConfigMapRef(apiServerConfig); ref != nil {
+		return ref.Name
+	}
+	return ""
+}
+
+// GetShootAuditPolicyConfigMapRef returns the Shoot's ConfigMap reference for the audit policy.
+func GetShootAuditPolicyConfigMapRef(apiServerConfig *gardencorev1beta1.KubeAPIServerConfig) *corev1.ObjectReference {
+	if apiServerConfig != nil &&
+		apiServerConfig.AuditConfig != nil &&
+		apiServerConfig.AuditConfig.AuditPolicy != nil {
+		return apiServerConfig.AuditConfig.AuditPolicy.ConfigMapRef
+	}
+	return nil
 }
 
 // ShootWantsAnonymousAuthentication returns true if anonymous authentication is set explicitly to 'true' and false otherwise.

--- a/vendor/github.com/gardener/gardener/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kubelet/config.go
+++ b/vendor/github.com/gardener/gardener/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kubelet/config.go
@@ -51,7 +51,7 @@ func Config(kubernetesVersion *semver.Version, clusterDNSAddress, clusterDomain 
 				CacheUnauthorizedTTL: metav1.Duration{Duration: 30 * time.Second},
 			},
 		},
-		CgroupDriver:                     "systemd",
+		CgroupDriver:                     "cgroupfs",
 		CgroupRoot:                       "/",
 		CgroupsPerQOS:                    pointer.Bool(true),
 		ClusterDNS:                       []string{clusterDNSAddress},
@@ -101,10 +101,6 @@ func Config(kubernetesVersion *semver.Version, clusterDNSAddress, clusterDomain 
 
 	if !version.ConstraintK8sLess119.Check(kubernetesVersion) {
 		config.VolumePluginDir = pathVolumePluginDirectory
-	}
-
-	if version.ConstraintK8sLessEqual122.Check(kubernetesVersion) {
-		config.CgroupDriver = "cgroupfs"
 	}
 
 	return config

--- a/vendor/github.com/gardener/gardener/pkg/operation/botanist/component/kubeapiserver/kube_apiserver.go
+++ b/vendor/github.com/gardener/gardener/pkg/operation/botanist/component/kubeapiserver/kube_apiserver.go
@@ -53,6 +53,8 @@ const (
 type Interface interface {
 	component.DeployWaiter
 	component.MonitoringComponent
+	// GetAutoscalingReplicas gets the Replicas field in the AutoscalingConfig of the Values of the deployer.
+	GetAutoscalingReplicas() *int32
 	// GetValues returns the current configuration values of the deployer.
 	GetValues() Values
 	// SetSecrets sets the secrets.
@@ -401,6 +403,10 @@ func (k *kubeAPIServer) GetValues() Values {
 
 func (k *kubeAPIServer) SetAutoscalingAPIServerResources(resources corev1.ResourceRequirements) {
 	k.values.Autoscaling.APIServerResources = resources
+}
+
+func (k *kubeAPIServer) GetAutoscalingReplicas() *int32 {
+	return k.values.Autoscaling.Replicas
 }
 
 func (k *kubeAPIServer) SetAutoscalingReplicas(replicas *int32) {

--- a/vendor/github.com/gardener/gardener/pkg/operation/botanist/secrets.go
+++ b/vendor/github.com/gardener/gardener/pkg/operation/botanist/secrets.go
@@ -110,6 +110,7 @@ func (b *Botanist) GenerateAndSaveSecrets(ctx context.Context) error {
 					vpnseedserver.DeploymentName,
 					vpnshoot.SecretNameVPNShootClient,
 					vpnseedserver.VpnSeedServerTLSAuth,
+					kubeapiserver.SecretNameHTTPProxy,
 				); err != nil {
 					return err
 				}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -56,7 +56,7 @@ github.com/gardener/etcd-druid/pkg/utils
 # github.com/gardener/external-dns-management v0.7.18
 github.com/gardener/external-dns-management/pkg/apis/dns
 github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1
-# github.com/gardener/gardener v1.39.0
+# github.com/gardener/gardener v1.39.3
 ## explicit
 github.com/gardener/gardener/.github
 github.com/gardener/gardener/.github/ISSUE_TEMPLATE


### PR DESCRIPTION
/area control-plane-migration
/kind bug
/platform openstack

Compared to `gardener/gardener@v1.39.0`, `gardener/gardener@v1.39.3` contains the following fixes that are related to the extension library:
- https://github.com/gardener/gardener/pull/5339
- https://github.com/gardener/gardener/pull/5408

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
The following dependency is updated:
- github.com/gardener/gardener: v1.39.0 -> v1.39.3
```
