### PR TITLE
Vendor gardener/gardener@v1.39.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/ahmetb/gen-crd-api-reference-docs v0.2.0
 	github.com/coreos/go-systemd/v22 v22.3.2
 	github.com/gardener/etcd-druid v0.7.0
-	github.com/gardener/gardener v1.39.4
+	github.com/gardener/gardener v1.39.5
 	github.com/gardener/machine-controller-manager v0.41.0
 	github.com/go-logr/logr v0.4.0
 	github.com/golang/mock v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -249,8 +249,8 @@ github.com/gardener/gardener v1.6.5/go.mod h1:w5IHIQDccvSxZJFOtBa8YConyyFgt07DBH
 github.com/gardener/gardener v1.11.3/go.mod h1:5DzqfOm+G8UftKu5zUbYJ+9Cnfd4XrvRNDabkM9AIp4=
 github.com/gardener/gardener v1.17.1/go.mod h1:uucRHq0xV46xd9MpJJjRswx/Slq3+ipbbJg09FVUtvM=
 github.com/gardener/gardener v1.23.0/go.mod h1:xS/sYyzYsq2W0C79mT98G/qoOTvy/hHTfApHIVF3v2o=
-github.com/gardener/gardener v1.39.4 h1:El48zEYEKJGTqe91S9YTikopGicOnjHe3tNAhuz0tp8=
-github.com/gardener/gardener v1.39.4/go.mod h1:NwK0dGM8H+lgLncEa0iQKWRLqGNqYHtDkwia+msLuc0=
+github.com/gardener/gardener v1.39.5 h1:i6vMyyU0LvW5nwGMgTdVXu6ymNK3jz+R25HarAnUsTk=
+github.com/gardener/gardener v1.39.5/go.mod h1:NwK0dGM8H+lgLncEa0iQKWRLqGNqYHtDkwia+msLuc0=
 github.com/gardener/gardener-resource-manager v0.10.0/go.mod h1:0pKTHOhvU91eQB0EYr/6Ymd7lXc/5Hi8P8tF/gpV0VQ=
 github.com/gardener/gardener-resource-manager v0.13.1/go.mod h1:0No/XttYRUwDn5lSppq9EqlKdo/XJQ44aCZz5BVu3Vw=
 github.com/gardener/gardener-resource-manager v0.18.0/go.mod h1:k53Yw2iDAIpTxnChQY9qFHrRtuPQWJDNnCP9eE6TnWQ=

--- a/vendor/github.com/gardener/gardener/extensions/pkg/controller/worker/genericactuator/update.go
+++ b/vendor/github.com/gardener/gardener/extensions/pkg/controller/worker/genericactuator/update.go
@@ -1,0 +1,92 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package genericactuator
+
+import (
+	"context"
+	"reflect"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// tryUpdateStatus tries to apply the given transformation function onto the given object, and to update its
+// status afterwards. It retries the status update with an exponential backoff.
+// Deprecated: This function is deprecated and will be removed in a future version. Please don't consider using it.
+// See https://github.com/gardener/gardener/blob/master/docs/development/kubernetes-clients.md#dont-retry-on-conflict
+// for more information.
+func tryUpdateStatus(ctx context.Context, backoff wait.Backoff, c client.Client, obj client.Object, transform func() error) error {
+	return tryUpdate(ctx, backoff, c, obj, c.Status().Update, transform)
+}
+
+func tryUpdate(ctx context.Context, backoff wait.Backoff, c client.Client, obj client.Object, updateFunc func(context.Context, client.Object, ...client.UpdateOption) error, transform func() error) error {
+	resetCopy := obj.DeepCopyObject()
+	return exponentialBackoff(ctx, backoff, func() (bool, error) {
+		if err := c.Get(ctx, client.ObjectKeyFromObject(obj), obj); err != nil {
+			return false, err
+		}
+
+		beforeTransform := obj.DeepCopyObject()
+		if err := transform(); err != nil {
+			return false, err
+		}
+
+		if reflect.DeepEqual(obj, beforeTransform) {
+			return true, nil
+		}
+
+		if err := updateFunc(ctx, obj); err != nil {
+			if apierrors.IsConflict(err) {
+				// In case of a conflict we are resetting the obj to its original version, as it was
+				// passed to the function, to ensure that, on the next iteration the
+				// equality check of the obj recieved from the server and the object after
+				// its transformation would be valid. Otherwise the obj would be with mutated
+				// fields in result of the transform function from previous iteration.
+				reflect.ValueOf(obj).Elem().Set(reflect.ValueOf(resetCopy).Elem())
+				return false, nil
+			}
+			return false, err
+		}
+		return true, nil
+	})
+}
+
+func exponentialBackoff(ctx context.Context, backoff wait.Backoff, condition wait.ConditionFunc) error {
+	duration := backoff.Duration
+
+	for i := 0; i < backoff.Steps; i++ {
+		if ok, err := condition(); err != nil || ok {
+			return err
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+			adjusted := duration
+			if backoff.Jitter > 0.0 {
+				adjusted = wait.Jitter(duration, backoff.Jitter)
+			}
+			time.Sleep(adjusted)
+			duration = time.Duration(float64(duration) * backoff.Factor)
+		}
+
+		i++
+	}
+
+	return wait.ErrWaitTimeout
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -56,7 +56,7 @@ github.com/gardener/etcd-druid/pkg/utils
 # github.com/gardener/external-dns-management v0.7.18
 github.com/gardener/external-dns-management/pkg/apis/dns
 github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1
-# github.com/gardener/gardener v1.39.4
+# github.com/gardener/gardener v1.39.5
 ## explicit
 github.com/gardener/gardener/.github
 github.com/gardener/gardener/.github/ISSUE_TEMPLATE


### PR DESCRIPTION
/kind bug
/platform openstack

Compared to `gardener/gardener@v1.39.4`, `gardener/gardener@v1.39.5` contains the following fixes that are related to the extension library:
- https://github.com/gardener/gardener/pull/5455

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
The following dependency is updated:
- github.com/gardener/gardener: v1.39.4 -> v1.39.5
```
