### PR TITLE
use ccm image version v1.21.0 for K8s >= 1.18 < 1.22

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -13,22 +13,7 @@ images:
   sourceRepository: github.com/kubernetes/cloud-provider-openstack
   repository: k8scloudprovider/openstack-cloud-controller-manager
   tag: "v1.21.0"
-  targetVersion: "1.18.x"
-- name: cloud-controller-manager
-  sourceRepository: github.com/kubernetes/cloud-provider-openstack
-  repository: k8scloudprovider/openstack-cloud-controller-manager
-  tag: "v1.21.0"
-  targetVersion: "1.19.x"
-- name: cloud-controller-manager
-  sourceRepository: github.com/kubernetes/cloud-provider-openstack
-  repository: k8scloudprovider/openstack-cloud-controller-manager
-  tag: "v1.21.0"
-  targetVersion: "1.20.x"
-- name: cloud-controller-manager
-  sourceRepository: github.com/kubernetes/cloud-provider-openstack
-  repository: k8scloudprovider/openstack-cloud-controller-manager
-  tag: "v1.21.0"
-  targetVersion: "1.21.x"
+  targetVersion: ">= 1.18, < 1.22"
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes/cloud-provider-openstack
   repository: k8scloudprovider/openstack-cloud-controller-manager


### PR DESCRIPTION
**How to categorize this PR?**
/area control-plane
/platform openstack

**What this PR does / why we need it**:
use range expression to match cloud-controller-manager image versions to K8s versions