### PR TITLE
[release-v1.23] Automated cherry pick of #398: [ci:component:github.com/gardener/machine-controller-manager-provider-openstack:v0.8.0->v0.8.1]

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -47,7 +47,7 @@ images:
 - name: machine-controller-manager-provider-openstack
   sourceRepository: github.com/gardener/machine-controller-manager-provider-openstack
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager-provider-openstack
-  tag: "v0.8.0"
+  tag: "v0.8.1"
 
 - name: csi-driver-cinder
   sourceRepository: github.com/kubernetes/cloud-provider-openstack


### PR DESCRIPTION
/area/ops-productivity
/area/quality
/kind/regression

Cherry pick of #398 on release-v1.23.

#398: [ci:component:github.com/gardener/machine-controller-manager-provider-openstack:v0.8.0->v0.8.1]

**Release Notes:**
``` bugfix user github.com/gardener/machine-controller-manager-provider-openstack #51 @ialidzhikov
A regression in Machine creation from imageName is now fixed.
```
``` bugfix operator github.com/gardener/machine-controller-manager-provider-openstack #50 @ialidzhikov
An issue causing klog's `--v` flag to be not respected is now fixed.
```