### PR TITLE
[release-v1.23] Automated cherry pick of #402: Increase cpu resources for csi-driver

### DIFF
--- a/charts/internal/shoot-system-components/charts/csi-driver-node/templates/vpa.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/templates/vpa.yaml
@@ -9,6 +9,7 @@ spec:
     containerPolicies:
     - containerName: '*'
       minAllowed:
+        cpu: 10m
         memory: 25Mi
   targetRef:
     apiVersion: apps/v1

--- a/charts/internal/shoot-system-components/charts/csi-driver-node/values.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/values.yaml
@@ -16,7 +16,7 @@ resources:
       cpu: 20m
       memory: 50Mi
     limits:
-      cpu: 50m
+      cpu: 100m
       memory: 80Mi
   nodeDriverRegistrar:
     requests:


### PR DESCRIPTION
/area/storage
/kind/enhancement

Cherry pick of #402 on release-v1.23.

#402: Increase cpu resources for csi-driver

**Release Notes:**
```other operator
The CPU limit of `csi-driver-node/csi-driver` is increased from 50m to 100m to allow bigger bursts.
```