### PR TITLE
Update kubernetes-csi/external-snapshotter

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -71,11 +71,11 @@ images:
 - name: csi-snapshotter
   sourceRepository: github.com/kubernetes-csi/external-snapshotter
   repository: k8s.gcr.io/sig-storage/csi-snapshotter
-  tag: "v2.1.5"
+  tag: "v3.0.3"
 - name: csi-snapshot-controller
   sourceRepository: github.com/kubernetes-csi/external-snapshotter
   repository: k8s.gcr.io/sig-storage/snapshot-controller
-  tag: "v2.1.5"
+  tag: "v3.0.3"
 - name: csi-resizer
   sourceRepository: github.com/kubernetes-csi/external-resizer
   repository: k8s.gcr.io/sig-storage/csi-resizer


### PR DESCRIPTION
/area storage
/kind enhancement
/platform openstack

Similar to https://github.com/gardener/gardener-extension-provider-aws/pull/366. The volumesnapshot CRDs were already updated with https://github.com/gardener/gardener-extension-provider-openstack/pull/330.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
The following images are updated (see [CHANGELOG](https://github.com/kubernetes-csi/external-snapshotter/blob/v3.0.3/CHANGELOG/CHANGELOG-3.0.md) for more details):
- k8s.gcr.io/sig-storage/csi-snapshotter: v2.1.5 -> v3.0.3
- k8s.gcr.io/sig-storage/snapshot-controller: v2.1.5 -> v3.0.3
```
