### PR TITLE
Use projected token mount for terraformer

### DIFF
--- a/cmd/gardener-extension-provider-openstack/app/app.go
+++ b/cmd/gardener-extension-provider-openstack/app/app.go
@@ -187,6 +187,7 @@ func NewControllerManagerCommand(ctx context.Context) *cobra.Command {
 				controllercmd.LogErrAndExit(err, "Could not determine whether service account token volume projection should be used")
 			}
 			openstackcontrolplane.DefaultAddOptions.UseProjectedTokenMount = useProjectedTokenMount
+			openstackinfrastructure.DefaultAddOptions.UseProjectedTokenMount = useProjectedTokenMount
 			openstackworker.DefaultAddOptions.UseProjectedTokenMount = useProjectedTokenMount
 
 			configFileOpts.Completed().ApplyETCDStorage(&openstackcontrolplaneexposure.DefaultAddOptions.ETCDStorage)

--- a/pkg/controller/infrastructure/actuator.go
+++ b/pkg/controller/infrastructure/actuator.go
@@ -33,12 +33,14 @@ import (
 type actuator struct {
 	logger logr.Logger
 	common.RESTConfigContext
+	useProjectedTokenMount bool
 }
 
 // NewActuator creates a new Actuator that updates the status of the handled Infrastructure resources.
-func NewActuator() infrastructure.Actuator {
+func NewActuator(useProjectedTokenMount bool) infrastructure.Actuator {
 	return &actuator{
-		logger: log.Log.WithName("infrastructure-actuator"),
+		logger:                 log.Log.WithName("infrastructure-actuator"),
+		useProjectedTokenMount: useProjectedTokenMount,
 	}
 }
 

--- a/pkg/controller/infrastructure/actuator_delete.go
+++ b/pkg/controller/infrastructure/actuator_delete.go
@@ -32,7 +32,7 @@ import (
 func (a *actuator) Delete(ctx context.Context, infra *extensionsv1alpha1.Infrastructure, cluster *extensionscontroller.Cluster) error {
 	logger := a.logger.WithValues("infrastructure", client.ObjectKeyFromObject(infra), "operation", "delete")
 
-	tf, err := internal.NewTerraformer(logger, a.RESTConfig(), infrastructure.TerraformerPurpose, infra)
+	tf, err := internal.NewTerraformer(logger, a.RESTConfig(), infrastructure.TerraformerPurpose, infra, a.useProjectedTokenMount)
 	if err != nil {
 		return fmt.Errorf("could not create the Terraformer: %+v", err)
 	}

--- a/pkg/controller/infrastructure/actuator_migrate.go
+++ b/pkg/controller/infrastructure/actuator_migrate.go
@@ -28,7 +28,7 @@ import (
 
 func (a *actuator) Migrate(ctx context.Context, infra *extensionsv1alpha1.Infrastructure, cluster *extensionscontroller.Cluster) error {
 	logger := a.logger.WithValues("infrastructure", client.ObjectKeyFromObject(infra), "operation", "migrate")
-	tf, err := internal.NewTerraformer(logger, a.RESTConfig(), infrastructure.TerraformerPurpose, infra)
+	tf, err := internal.NewTerraformer(logger, a.RESTConfig(), infrastructure.TerraformerPurpose, infra, a.useProjectedTokenMount)
 	if err != nil {
 		return fmt.Errorf("could not create the Terraformer: %+v", err)
 	}

--- a/pkg/controller/infrastructure/actuator_reconcile.go
+++ b/pkg/controller/infrastructure/actuator_reconcile.go
@@ -52,7 +52,7 @@ func (a *actuator) reconcile(ctx context.Context, logger logr.Logger, infra *ext
 		return err
 	}
 
-	tf, err := internal.NewTerraformerWithAuth(logger, a.RESTConfig(), infrastructure.TerraformerPurpose, infra, credentials)
+	tf, err := internal.NewTerraformerWithAuth(logger, a.RESTConfig(), infrastructure.TerraformerPurpose, infra, credentials, a.useProjectedTokenMount)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/infrastructure/add.go
+++ b/pkg/controller/infrastructure/add.go
@@ -35,13 +35,15 @@ type AddOptions struct {
 	Controller controller.Options
 	// IgnoreOperationAnnotation specifies whether to ignore the operation annotation or not.
 	IgnoreOperationAnnotation bool
+	// UseProjectedTokenMount specifies whether the projected token mount shall be used for the terraformer.
+	UseProjectedTokenMount bool
 }
 
 // AddToManagerWithOptions adds a controller with the given AddOptions to the given manager.
 // The opts.Reconciler is being set with a newly instantiated actuator.
 func AddToManagerWithOptions(mgr manager.Manager, options AddOptions) error {
 	return infrastructure.Add(mgr, infrastructure.AddArgs{
-		Actuator:          NewActuator(),
+		Actuator:          NewActuator(options.UseProjectedTokenMount),
 		ConfigValidator:   NewConfigValidator(openstackclient.FactoryFactoryFunc(openstackclient.NewOpenstackClientFromCredentials), log.Log),
 		ControllerOptions: options.Controller,
 		Predicates:        infrastructure.DefaultPredicates(options.IgnoreOperationAnnotation),

--- a/pkg/internal/terraform.go
+++ b/pkg/internal/terraform.go
@@ -80,7 +80,11 @@ func NewTerraformer(
 	restConfig *rest.Config,
 	purpose string,
 	infra *extensionsv1alpha1.Infrastructure,
-) (terraformer.Terraformer, error) {
+	useProjectedTokenMount bool,
+) (
+	terraformer.Terraformer,
+	error,
+) {
 	tf, err := terraformer.NewForConfig(logger, restConfig, purpose, infra.Namespace, infra.Name, imagevector.TerraformerImage())
 	if err != nil {
 		return nil, err
@@ -88,6 +92,7 @@ func NewTerraformer(
 
 	owner := metav1.NewControllerRef(infra, extensionsv1alpha1.SchemeGroupVersion.WithKind(extensionsv1alpha1.InfrastructureResource))
 	return tf.
+		UseProjectedTokenMount(useProjectedTokenMount).
 		SetTerminationGracePeriodSeconds(630).
 		SetDeadlineCleaning(5 * time.Minute).
 		SetDeadlinePod(15 * time.Minute).
@@ -101,8 +106,12 @@ func NewTerraformerWithAuth(
 	purpose string,
 	infra *extensionsv1alpha1.Infrastructure,
 	credentials *openstack.Credentials,
-) (terraformer.Terraformer, error) {
-	tf, err := NewTerraformer(logger, restConfig, purpose, infra)
+	useProjectedTokenMount bool,
+) (
+	terraformer.Terraformer,
+	error,
+) {
+	tf, err := NewTerraformer(logger, restConfig, purpose, infra, useProjectedTokenMount)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement

**What this PR does / why we need it**:
This PR enables projected token mounts for the `terraformer` pods.

**Which issue(s) this PR fixes**:
Part of gardener/gardener#4659
Part of gardener/gardener#4878

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The `terraformer` pod deployed as part of shoot control planes is now using auto-rotated `ServiceAccount` tokens when communicating with the seed cluster.
```
