### PR TITLE
[release-v1.24] Automated cherry pick of #411: [ci:component:github.com/gardener/machine-controller-manager:v0.43.0->v0.43.1]

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -28,7 +28,7 @@ images:
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager
-  tag: "v0.43.0"
+  tag: "v0.43.1"
 - name: machine-controller-manager-provider-openstack
   sourceRepository: github.com/gardener/machine-controller-manager-provider-openstack
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager-provider-openstack


### PR DESCRIPTION
/kind/bug

Cherry pick of #411 on release-v1.24.

#411: [ci:component:github.com/gardener/machine-controller-manager:v0.43.0->v0.43.1]

**Release Notes:**
``` bugfix user github.com/gardener/machine-controller-manager #687 @himanshu-kun
typo stopping scaleDown disabling during cluster rollout is fixed
```