### PR TITLE
Allow projected volumes in the csi-driver-node PSP

### DIFF
--- a/charts/internal/shoot-system-components/charts/csi-driver-node/templates/podsecuritypolicy.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/templates/podsecuritypolicy.yaml
@@ -10,6 +10,7 @@ spec:
   - SYS_ADMIN
   volumes:
   - hostPath
+  - projected
   - secret
   hostNetwork: true
   hostPorts:


### PR DESCRIPTION
/kind bug
/platform openstack

Similar to https://github.com/gardener/gardener-extension-provider-aws/pull/510.

We were not able to reproduce similar PSP issue for K8s >= 1.19 but even though that I think it still makes sense to keep the PSP up-to-date and to have it reflecting the needed permissions.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
