### PR TITLE
[release-v1.24] Automated cherry pick of #415: Keep kubelet's `--cloud-provider` flag even for 1.23+

### DIFF
--- a/pkg/webhook/controlplane/ensurer.go
+++ b/pkg/webhook/controlplane/ensurer.go
@@ -382,8 +382,9 @@ func (e *ensurer) EnsureKubeletServiceUnitOptions(ctx context.Context, gctx gcon
 
 func ensureKubeletCommandLineArgs(command []string, csiEnabled bool, kubeletVersion *semver.Version) []string {
 	if csiEnabled {
+		command = extensionswebhook.EnsureStringWithPrefix(command, "--cloud-provider=", "external")
+
 		if !versionutils.ConstraintK8sGreaterEqual123.Check(kubeletVersion) {
-			command = extensionswebhook.EnsureStringWithPrefix(command, "--cloud-provider=", "external")
 			command = extensionswebhook.EnsureStringWithPrefix(command, "--enable-controller-attach-detach=", "true")
 		}
 	} else {

--- a/pkg/webhook/controlplane/ensurer_test.go
+++ b/pkg/webhook/controlplane/ensurer_test.go
@@ -510,7 +510,7 @@ var _ = Describe("Ensurer", func() {
 
 			Entry("kubelet version < 1.19", eContextK8s116, semver.MustParse("1.16.0"), "openstack", false),
 			Entry("1.19 <= kubelet version < 1.23", eContextK8s119, semver.MustParse("1.19.0"), "external", true),
-			Entry("kubelet version >= 1.23", eContextK8s119, semver.MustParse("1.23.0"), "", false),
+			Entry("kubelet version >= 1.23", eContextK8s119, semver.MustParse("1.23.0"), "external", false),
 		)
 	})
 


### PR DESCRIPTION
/area/usability
/kind/bug

Cherry pick of #415 on release-v1.24.

#415: Keep kubelet's `--cloud-provider` flag even for 1.23+

**Release Notes:**
```bugfix user
An issue preventing load balancers from being functional for K8s 1.23 clusters has been fixed.
```