### PR TITLE
update cloudprovider webhook for objectSelector

### DIFF
--- a/cmd/gardener-extension-provider-openstack/app/app.go
+++ b/cmd/gardener-extension-provider-openstack/app/app.go
@@ -111,8 +111,9 @@ func NewControllerManagerCommand(ctx context.Context) *cobra.Command {
 			Namespace: os.Getenv("WEBHOOK_CONFIG_NAMESPACE"),
 		}
 
+		gardenerVersion    = new(string)
 		controllerSwitches = openstackcmd.ControllerSwitchOptions()
-		webhookSwitches    = openstackcmd.WebhookSwitchOptions()
+		webhookSwitches    = openstackcmd.WebhookSwitchOptions(gardenerVersion)
 		webhookOptions     = webhookcmd.NewAddToManagerOptions(openstack.Name, webhookServerOptions, webhookSwitches)
 
 		aggOption = controllercmd.NewOptionAggregator(
@@ -175,6 +176,7 @@ func NewControllerManagerCommand(ctx context.Context) *cobra.Command {
 			// add common meta types to schema for controller-runtime to use v1.ListOptions
 			metav1.AddToGroupVersion(scheme, machinev1alpha1.SchemeGroupVersion)
 
+			*gardenerVersion = generalOpts.Completed().GardenerVersion
 			useTokenRequestor, err := controller.UseTokenRequestor(generalOpts.Completed().GardenerVersion)
 			if err != nil {
 				return fmt.Errorf("could not determine whether token requestor should be used: %w", err)

--- a/pkg/cmd/options.go
+++ b/pkg/cmd/options.go
@@ -56,10 +56,10 @@ func ControllerSwitchOptions() *controllercmd.SwitchOptions {
 }
 
 // WebhookSwitchOptions are the webhookcmd.SwitchOptions for the provider webhooks.
-func WebhookSwitchOptions() *webhookcmd.SwitchOptions {
+func WebhookSwitchOptions(gardenerVersion *string) *webhookcmd.SwitchOptions {
 	return webhookcmd.NewSwitchOptions(
 		webhookcmd.Switch(extensioncontrolplanewebhook.WebhookName, controlplanewebhook.AddToManager),
 		webhookcmd.Switch(extensioncontrolplanewebhook.ExposureWebhookName, controlplaneexposurewebhook.AddToManager),
-		webhookcmd.Switch(extensionscloudproviderwebhook.WebhookName, cloudproviderwebhook.AddToManager),
+		webhookcmd.Switch(extensionscloudproviderwebhook.WebhookName, cloudproviderwebhook.AddToManager(gardenerVersion)),
 	)
 }

--- a/pkg/webhook/cloudprovider/add.go
+++ b/pkg/webhook/cloudprovider/add.go
@@ -15,21 +15,46 @@
 package cloudprovider
 
 import (
-	"github.com/gardener/gardener-extension-provider-openstack/pkg/openstack"
+	"fmt"
 
+	"github.com/Masterminds/semver"
+	"github.com/gardener/gardener-extension-provider-openstack/pkg/openstack"
 	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
 	"github.com/gardener/gardener/extensions/pkg/webhook/cloudprovider"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
-var logger = log.Log.WithName("openstack-cloudprovider-webhook")
+var (
+	logger                           = log.Log.WithName("openstack-cloudprovider-webhook")
+	versionConstraintGreaterEqual142 *semver.Constraints
+)
+
+func init() {
+	var err error
+	versionConstraintGreaterEqual142, err = semver.NewConstraint(">= 1.42")
+	utilruntime.Must(err)
+}
 
 // AddToManager creates the cloudprovider webhook and adds it to the manager.
-func AddToManager(mgr manager.Manager) (*extensionswebhook.Webhook, error) {
-	logger.Info("adding webhook to manager")
-	return cloudprovider.New(mgr, cloudprovider.Args{
-		Provider: openstack.Type,
-		Mutator:  cloudprovider.NewMutator(logger, NewEnsurer(logger)),
-	})
+func AddToManager(gardenerVersion *string) func(mgr manager.Manager) (*extensionswebhook.Webhook, error) {
+	return func(mgr manager.Manager) (*extensionswebhook.Webhook, error) {
+		enable := false
+		if gardenerVersion != nil && len(*gardenerVersion) > 0 {
+			version, err := semver.NewVersion(*gardenerVersion)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse gardener version: %v", err)
+			}
+			if versionConstraintGreaterEqual142.Check(version) {
+				enable = true
+			}
+		}
+		logger.Info("adding webhook to manager")
+		return cloudprovider.New(mgr, cloudprovider.Args{
+			Provider:             openstack.Type,
+			Mutator:              cloudprovider.NewMutator(logger, NewEnsurer(logger)),
+			EnableObjectSelector: enable,
+		})
+	}
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement
/platform openstack

**What this PR does / why we need it**:

Update the cloudprovider mutating webhook to use an `objectSelector` based on the specific labels of the `cloudprovider` secret. This way the webhook will only react on updates to the `cloudprovider` particular secret  which reduces load and avoid situations where an issue with the extension may prevent any and all updates to secrets (even other secrets than `cloudprovider`).

This is automatically enabled when the `gardener-version` is larger than `1.42` which is the version that gardenlet started adding the necessary labels to the secret.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The `cloudprovider` webhook will now use `objectSelector` to filter secrets when gardener-version `>=1.42`.
```
