### PR TITLE
remove --external-hostname flag from kube-apiserver to succeed k8s conformance check

### DIFF
--- a/pkg/webhook/controlplaneexposure/ensurer.go
+++ b/pkg/webhook/controlplaneexposure/ensurer.go
@@ -80,7 +80,6 @@ func (e *ensurer) EnsureKubeAPIServerDeployment(ctx context.Context, gctx gconte
 
 	if c := extensionswebhook.ContainerWithName(new.Spec.Template.Spec.Containers, "kube-apiserver"); c != nil {
 		c.Command = extensionswebhook.EnsureStringWithPrefix(c.Command, "--advertise-address=", address)
-		c.Command = extensionswebhook.EnsureStringWithPrefix(c.Command, "--external-hostname=", address)
 	}
 	return nil
 }


### PR DESCRIPTION
**How to categorize this PR?**
/area certification
/kind bug
/platform openstack

**What this PR does / why we need it**:

If `ManagedIstio` and `APIServerSNI` are disabled the k8s conformance check fails. More details see: #366 

**Which issue(s) this PR fixes**:
Fixes #366

**Release note**:
```breaking operator
Fix failing k8s conformance check if ManagedIstio and APIServerSNI are disabled
```
