### PR TITLE
Fix incorrect validator deployment value

### DIFF
--- a/charts/gardener-extension-admission-openstack/charts/runtime/templates/deployment.yaml
+++ b/charts/gardener-extension-admission-openstack/charts/runtime/templates/deployment.yaml
@@ -46,7 +46,7 @@ spec:
         {{- if .Values.global.kubeconfig }}
         - --kubeconfig=/etc/gardener-extension-admission-openstack/kubeconfig/kubeconfig
         {{- end }}
-        - --health-bind-address=:{{ .Values.healthPort }}
+        - --health-bind-address=:{{ .Values.global.healthPort }}
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
/area quality
/kind bug
/platform openstack

Similar to https://github.com/gardener/gardener-extension-provider-aws/pull/535

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
