### PR TITLE
Move `Name` field to `ControlPlaneSecretConfig`

### DIFF
--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -71,8 +71,8 @@ func getSecretConfigsFuncs(useTokenRequestor bool) secrets.Interface {
 					},
 				},
 				&secrets.ControlPlaneSecretConfig{
+					Name: openstack.CSISnapshotValidation,
 					CertificateSecretConfig: &secrets.CertificateSecretConfig{
-						Name:       openstack.CSISnapshotValidation,
 						CommonName: openstack.UsernamePrefix + openstack.CSISnapshotValidation,
 						DNSNames:   kutil.DNSNamesForService(openstack.CSISnapshotValidation, clusterName),
 						CertType:   secrets.ServerCert,


### PR DESCRIPTION
/area security
/kind bug
/platform openstack

With the current master the Shoot creation fails with:
```yaml
  lastErrors:
    - description: >-
        task "Waiting until shoot control plane has been reconciled" failed:
        Error while waiting for ControlPlane shoot--foo--bar/bar
        to become ready: error during reconciliation: Error reconciling
        controlplane: could not deploy secrets for controlplane
        'shoot--foo--bar/bar': could not generate cluster
        secrets in namespace 'shoot--foo--bar': errors occurred during
        shoot secrets generation: [Secret "" is invalid: metadata.name: Required
        value: name or generateName is required]
      taskID: Waiting until shoot control plane has been reconciled
      lastUpdateTime: '2022-04-19T15:07:28Z'
```

Similar to https://github.com/gardener/gardener-extension-provider-aws/pull/528

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
