### PR TITLE
fix cloud-provider-config generation

### DIFF
--- a/charts/internal/cloud-provider-config/templates/_cloud-provider-config-loadbalancer.tpl
+++ b/charts/internal/cloud-provider-config/templates/_cloud-provider-config-loadbalancer.tpl
@@ -1,10 +1,10 @@
 {{- define "cloud-provider-config-loadbalancer" -}}
 [LoadBalancer]
 create-monitor=true
-monitor-delay=60s
-monitor-timeout=30s
+monitor-delay="60s"
+monitor-timeout="30s"
 monitor-max-retries=5
-lb-version=v2
+lb-version="v2"
 lb-provider="{{ .Values.lbProvider }}"
 floating-network-id="{{ .Values.floatingNetworkID }}"
 use-octavia="{{ .Values.useOctavia }}"


### PR DESCRIPTION
**How to categorize this PR?**
/area quality
/kind bug
/platform openstack

**Which issue(s) this PR fixes**:
It fixes the correctness of the generated `ini` file. Everything that is not a boolean or integer value has to be quoted. Some parsers may still parse the file but some are not able to.

**Release note**:

```bugfix operator
Fixes missing quotes in the generated cloud-provider-config file
```
Signed-off-by: Felix Breuer <fbreuer@pm.me>