### PR TITLE
introduce openstack project-name in cloud-provider-config

### DIFF
--- a/charts/internal/cloud-provider-config/templates/_cloud-provider-config-global.tpl
+++ b/charts/internal/cloud-provider-config/templates/_cloud-provider-config-global.tpl
@@ -2,6 +2,7 @@
 auth-url="{{ .Values.authUrl }}"
 domain-name="{{ .Values.domainName }}"
 tenant-name="{{ .Values.tenantName }}"
+project-name="{{ .Values.tenantName }}"
 username="{{ .Values.username }}"
 {{- if .Values.password }}
 password="{{ .Values.password }}"


### PR DESCRIPTION
**How to categorize this PR?**

/area quality
/kind api-change
/platform openstack

**What this PR does / why we need it**:
The term `tenant` is going be phased out slowly according to [this](https://stackoverflow.com/questions/50593290/confused-by-tenant-project-user-account-in-openstack-and-swift) stack-overflow post.  
[The official Openstack Documentation](https://wiki.openstack.org/wiki/Tenant) states the same.  
Our change introduces the new term `project-name` without breaking existing usages of this configuration file. In future versions the term `tenant` can be removed completely.

**Release note**:
```feature operator
Introduce project-name in cloud-provider-config
```
Signed-off-by: Felix Breuer <fbreuer@pm.me>