### PR TITLE
Remove validation avoiding sfz

### DIFF
--- a/pkg/apis/openstack/validation/shoot.go
+++ b/pkg/apis/openstack/validation/shoot.go
@@ -96,10 +96,6 @@ func ValidateWorkers(workers []core.Worker, cloudProfileCfg *api.CloudProfileCon
 			continue
 		}
 
-		if worker.Maximum != 0 && worker.Minimum == 0 {
-			allErrs = append(allErrs, field.Forbidden(workerFldPath.Child("minimum"), "minimum value must be >= 1 if maximum value > 0 (auto scaling to 0 is not supported)"))
-		}
-
 		if worker.Volume != nil && worker.Volume.Type != nil && worker.Volume.VolumeSize == "" {
 			allErrs = append(allErrs, field.Forbidden(workerFldPath.Child("volume", "type"), "specifying volume type without a custom volume size is not allowed"))
 		}

--- a/pkg/apis/openstack/validation/shoot_test.go
+++ b/pkg/apis/openstack/validation/shoot_test.go
@@ -170,19 +170,6 @@ var _ = Describe("Shoot validation", func() {
 				))
 			})
 
-			It("should enforce workers min > 0 if max > 0", func() {
-				workers[0].Minimum = 0
-
-				errorList := ValidateWorkers(workers, nil, nilPath)
-
-				Expect(errorList).To(ConsistOf(
-					PointTo(MatchFields(IgnoreExtras, Fields{
-						"Type":  Equal(field.ErrorTypeForbidden),
-						"Field": Equal("[0].minimum"),
-					})),
-				))
-			})
-
 			It("should forbid specifying volume type without size", func() {
 				workers[0].Volume = &core.Volume{
 					Type: pointer.String("standard"),


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind enhancement
/platform openstack

**What this PR does / why we need it**:
remove validation which avoids worker grp to specify min=0.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
