### PR TITLE
Bump cloud-controller-manager image  for 1.23 clusters

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -22,7 +22,7 @@ images:
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes/cloud-provider-openstack
   repository: k8scloudprovider/openstack-cloud-controller-manager
-  tag: "v1.23.0"
+  tag: "v1.23.1"
   targetVersion: ">= 1.23"
 
 - name: machine-controller-manager


### PR DESCRIPTION
https://hub.docker.com/r/k8scloudprovider/openstack-cloud-controller-manager:

> Fix updating octavia port when using externalClusterPolicy Local.
> issue: https://github.com/kubernetes/cloud-provider-openstack/pull/1757

**How to categorize this PR?**
/area control-plane

/kind bug

**What this PR does / why we need it**:

It fixes a bug with services that use `externalTrafficPolicy: Local` 


**Which issue(s) this PR fixes**:
https://github.com/kubernetes/cloud-provider-openstack/pull/1757

