### PR TITLE
[release-v1.25] Automated cherry pick of #446: Update CCM version to 1.23.1

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -22,7 +22,7 @@ images:
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes/cloud-provider-openstack
   repository: k8scloudprovider/openstack-cloud-controller-manager
-  tag: "v1.23.0"
+  tag: "v1.23.1"
   targetVersion: ">= 1.23"
 
 - name: machine-controller-manager


### PR DESCRIPTION
/area/control-plane
/kind/bug
/kind/enhancement

Cherry pick of #446 on release-v1.25.

#446: Update CCM version to 1.23.1

**Release Notes:**
```other operator
The following image is updated:
- k8scloudprovider/openstack-cloud-controller-manager: v1.23.0 -> v1.23.1
```