### PR TITLE
fix typo in requirements.yaml

### DIFF
--- a/charts/internal/shoot-system-components/requirements.yaml
+++ b/charts/internal/shoot-system-components/requirements.yaml
@@ -4,6 +4,6 @@ dependencies:
   version: 0.1.0
   condition: cloud-controller-manager.enabled
 - name: csi-driver-node
-  repository: http://locwalhost:10191
+  repository: http://localhost:10191
   version: 0.1.0
   condition: csi-driver-node.enabled


### PR DESCRIPTION
This PR fixes a typo i stumbled upon in `./charts/internal/shoot-system-components/requirements.yaml`.