### PR TITLE
Fix Shoot creation for K8s 1.24

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -27,8 +27,8 @@ images:
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes/cloud-provider-openstack
   repository: k8scloudprovider/openstack-cloud-controller-manager
-  tag: "v1.24.0"
-  targetVersion: "1.24"
+  tag: "v1.24.1"
+  targetVersion: ">= 1.24"
 
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager


### PR DESCRIPTION
/area control-plane
/kind bug
/platform openstack

Currently the ControlPlane resource for K8s 1.24 Shoot cluster fails to be reconciled with:
```yaml
    lastError:
      description: 'Error reconciling controlplane: could not apply control plane
        chart for controlplane ''shoot--foo--bar/bar'': could not
        inject chart ''cloud-controller-manager'' images: could not find image "cloud-controller-manager"
        opts runtime version v1.21.10 target version 1.24.1'
      lastUpdateTime: "2022-06-13T16:04:43Z"
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
An issue preventing ControlPlane resource to be successfully reconciled for K8s 1.24 Shoots is now fixed.
```
