### PR TITLE
[release-v1.26] Automated cherry pick of #459: Fix Shoot creation for K8s 1.24

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -27,8 +27,8 @@ images:
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes/cloud-provider-openstack
   repository: k8scloudprovider/openstack-cloud-controller-manager
-  tag: "v1.24.0"
-  targetVersion: "1.24"
+  tag: "v1.24.1"
+  targetVersion: ">= 1.24"
 
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager


### PR DESCRIPTION
/area/control-plane
/kind/bug

Cherry pick of #459 on release-v1.26.

#459: Fix Shoot creation for K8s 1.24

**Release Notes:**
```bugfix user
An issue preventing ControlPlane resource to be successfully reconciled for K8s 1.24 Shoots is now fixed.
```