### PR TITLE
Add CSI migration feature gates to the cluster-autoscaler

### DIFF
--- a/pkg/webhook/controlplane/ensurer_test.go
+++ b/pkg/webhook/controlplane/ensurer_test.go
@@ -139,7 +139,22 @@ var _ = Describe("Ensurer", func() {
 				},
 			},
 		)
-
+		eContextK8s120WithCSIAnnotation = gcontext.NewInternalGardenContext(
+			&extensionscontroller.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						csimigration.AnnotationKeyNeedsComplete: "true",
+					},
+				},
+				Shoot: &gardencorev1beta1.Shoot{
+					Spec: gardencorev1beta1.ShootSpec{
+						Kubernetes: gardencorev1beta1.Kubernetes{
+							Version: "1.20.0",
+						},
+					},
+				},
+			},
+		)
 		eContextK8s121 = gcontext.NewInternalGardenContext(
 			&extensionscontroller.Cluster{
 				Shoot: &gardencorev1beta1.Shoot{
@@ -407,7 +422,7 @@ var _ = Describe("Ensurer", func() {
 
 		BeforeEach(func() {
 			dep = &appsv1.Deployment{
-				ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: v1beta1constants.DeploymentNameKubeControllerManager},
+				ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: v1beta1constants.DeploymentNameKubeScheduler},
 				Spec: appsv1.DeploymentSpec{
 					Template: corev1.PodTemplateSpec{
 						Spec: corev1.PodSpec{
@@ -424,7 +439,7 @@ var _ = Describe("Ensurer", func() {
 			ensurer = NewEnsurer(logger)
 		})
 
-		It("should add missing elements to kube-scheduler deployment (k8s < 1.19)", func() {
+		It("should not add anything to kube-scheduler deployment (k8s < 1.19)", func() {
 			err := ensurer.EnsureKubeSchedulerDeployment(ctx, eContextK8s116, dep, nil)
 			Expect(err).To(Not(HaveOccurred()))
 
@@ -450,6 +465,53 @@ var _ = Describe("Ensurer", func() {
 			Expect(err).To(Not(HaveOccurred()))
 
 			checkKubeSchedulerDeployment(dep, "1.21.0", true)
+		})
+	})
+
+	Describe("#EnsureClusterAutoscalerDeployment", func() {
+		var (
+			dep     *appsv1.Deployment
+			ensurer genericmutator.Ensurer
+		)
+
+		BeforeEach(func() {
+			dep = &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: v1beta1constants.DeploymentNameClusterAutoscaler},
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name: "cluster-autoscaler",
+								},
+							},
+						},
+					},
+				},
+			}
+
+			ensurer = NewEnsurer(logger)
+		})
+
+		It("should not add anything to cluster-autoscaler deployment (k8s < 1.20)", func() {
+			err := ensurer.EnsureClusterAutoscalerDeployment(ctx, eContextK8s119, dep, nil)
+			Expect(err).To(Not(HaveOccurred()))
+
+			checkClusterAutoscalerDeployment(dep, "1.19.0")
+		})
+
+		It("should add missing elements to cluster-autoscaler deployment (k8s 1.20)", func() {
+			err := ensurer.EnsureClusterAutoscalerDeployment(ctx, eContextK8s120WithCSIAnnotation, dep, nil)
+			Expect(err).To(Not(HaveOccurred()))
+
+			checkClusterAutoscalerDeployment(dep, "1.20.0")
+		})
+
+		It("should add missing elements to cluster-autoscaler deployment (k8s >= 1.21)", func() {
+			err := ensurer.EnsureClusterAutoscalerDeployment(ctx, eContextK8s121WithCSIAnnotation, dep, nil)
+			Expect(err).To(Not(HaveOccurred()))
+
+			checkClusterAutoscalerDeployment(dep, "1.21.0")
 		})
 	})
 
@@ -812,6 +874,23 @@ func checkKubeSchedulerDeployment(dep *appsv1.Deployment, k8sVersion string, nee
 		} else {
 			Expect(c.Command).To(ContainElement("--feature-gates=CSIMigration=true,CSIMigrationOpenStack=true,CSIMigrationOpenStackComplete=true"))
 		}
+	}
+}
+
+func checkClusterAutoscalerDeployment(dep *appsv1.Deployment, k8sVersion string) {
+	if k8sVersionAtLeast120, _ := version.CompareVersions(k8sVersion, ">=", "1.20"); !k8sVersionAtLeast120 {
+		return
+	}
+	k8sVersionAtLeast121, _ := version.CompareVersions(k8sVersion, ">=", "1.21")
+
+	// Check that the cluster-autoscaler container still exists and contains all needed command line args.
+	c := extensionswebhook.ContainerWithName(dep.Spec.Template.Spec.Containers, "cluster-autoscaler")
+	Expect(c).To(Not(BeNil()))
+
+	if k8sVersionAtLeast121 {
+		Expect(c.Command).To(ContainElement("--feature-gates=CSIMigration=true,CSIMigrationOpenStack=true,InTreePluginOpenStackUnregister=true"))
+	} else {
+		Expect(c.Command).To(ContainElement("--feature-gates=CSIMigration=true,CSIMigrationOpenStack=true,CSIMigrationOpenStackComplete=true"))
 	}
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
/area control-plane auto-scaling
/kind bug
/platform openstack

**What this PR does / why we need it**:
More details can be found on https://github.com/gardener/gardener/issues/5064

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/5064

**Special notes for your reviewer**:
This PR depends on:
- [x] ✅  New cluster-autoscaler patch releases to be cut and adopted in gardener/gardener - ref https://github.com/gardener/gardener/pull/6163

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
This version of provider-openstack requires Gardener v1.50.0.
```

```bugfix operator
provider-openstack now mutates the `cluster-autoscaler` Deployment by implementing the `EnsureClusterAutoscalerDeployment` function. This is required in the context of https://github.com/kubernetes/autoscaler/issues/4517 - cluster-autoscaler supports `--feature-gates` flag and provider extensions have to mutate the cluster-autoscaler Deployment to add the CSI related feature gates to it.
```
