### PR TITLE
Upgrade github.com/kubernetes/cloud-provider-openstack

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -22,7 +22,7 @@ images:
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes/cloud-provider-openstack
   repository: k8scloudprovider/openstack-cloud-controller-manager
-  tag: "v1.23.1"
+  tag: "v1.23.2"
   targetVersion: "1.23.x"
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes/cloud-provider-openstack


### PR DESCRIPTION
/area control-plane
/kind bug
/platform openstack

Adopts the fix for https://github.com/kubernetes/cloud-provider-openstack/issues/1912 for K8s 1.23.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
The following image is updated:
- k8scloudprovider/openstack-cloud-controller-manager: v1.23.1 -> v1.23.2
```
