### PR TITLE
Use occm `v1.22.0` for `v1.23.x` shoots

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -18,12 +18,7 @@ images:
   sourceRepository: github.com/kubernetes/cloud-provider-openstack
   repository: k8scloudprovider/openstack-cloud-controller-manager
   tag: "v1.22.0"
-  targetVersion: "1.22.x"
-- name: cloud-controller-manager
-  sourceRepository: github.com/kubernetes/cloud-provider-openstack
-  repository: k8scloudprovider/openstack-cloud-controller-manager
-  tag: "v1.23.2"
-  targetVersion: "1.23.x"
+  targetVersion: ">= 1.22, < 1.24"
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes/cloud-provider-openstack
   repository: k8scloudprovider/openstack-cloud-controller-manager


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind bug
/platform openstack

**What this PR does / why we need it**:
Use openstack cloud-controller-manager `v1.22.0` for Shoots with target k8s version `v1.23.x`.
Ref: https://github.com/kubernetes/cloud-provider-openstack/issues/1795

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bug operator
Use openstack cloud-controller-manager `v1.22.0` for Shoots with target k8s version `v1.23.x`. [ref](https://github.com/kubernetes/cloud-provider-openstack/issues/1795)
```
