### PR TITLE
[release-v1.26] Automated cherry pick of #471: Use openstack-cloud-controller-manager@v1.23.3 for K8s 1.23 Shoots #462: Upgrade github.com/kubernetes/cloud-provider-openstack

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -18,7 +18,12 @@ images:
   sourceRepository: github.com/kubernetes/cloud-provider-openstack
   repository: k8scloudprovider/openstack-cloud-controller-manager
   tag: "v1.22.0"
-  targetVersion: ">= 1.22, < 1.24"
+  targetVersion: "1.22.x"
+- name: cloud-controller-manager
+  sourceRepository: github.com/kubernetes/cloud-provider-openstack
+  repository: k8scloudprovider/openstack-cloud-controller-manager
+  tag: "v1.23.3"
+  targetVersion: "1.23.x"
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes/cloud-provider-openstack
   repository: k8scloudprovider/openstack-cloud-controller-manager

--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -27,7 +27,7 @@ images:
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes/cloud-provider-openstack
   repository: k8scloudprovider/openstack-cloud-controller-manager
-  tag: "v1.24.1"
+  tag: "v1.24.2"
   targetVersion: ">= 1.24"
 
 - name: machine-controller-manager


### PR DESCRIPTION
/area/open-source
/kind/enhancement

Cherry pick of #471 #462 on release-v1.26.

#471: Use openstack-cloud-controller-manager@v1.23.3 for K8s 1.23 Shoots
#462: Upgrade github.com/kubernetes/cloud-provider-openstack

**Release Notes:**
```other operator
The following images are updated:
- k8scloudprovider/openstack-cloud-controller-manager: v1.22.0 -> v1.23.3 (for Kubernetes 1.23 Shoots)
- k8scloudprovider/openstack-cloud-controller-manager: v1.24.1 -> v1.24.2 (for Kubernetes 1.24 Shoots)
```