### PR TITLE
Adds MaxAllowed for VPA objects

### DIFF
--- a/charts/internal/machine-controller-manager/seed/templates/vpa.yaml
+++ b/charts/internal/machine-controller-manager/seed/templates/vpa.yaml
@@ -17,10 +17,16 @@ spec:
       minAllowed:
         cpu: {{ .Values.resources.mcmProviderOpenstack.requests.cpu }}
         memory: {{ .Values.resources.mcmProviderOpenstack.requests.memory }}
+      maxAllowed:
+        cpu: {{ .Values.vpa.resourcePolicy.mcmProviderOpenstack.maxAllowed.cpu }}
+        memory: {{ .Values.vpa.resourcePolicy.mcmProviderOpenstack.maxAllowed.memory }}
       controlledValues: RequestsOnly
     - containerName: openstack-machine-controller-manager
       minAllowed:
         cpu: {{ .Values.resources.mcm.requests.cpu }}
         memory: {{ .Values.resources.mcm.requests.memory }}
+      maxAllowed:
+        cpu: {{ .Values.vpa.resourcePolicy.mcm.maxAllowed.cpu }}
+        memory: {{ .Values.vpa.resourcePolicy.mcm.maxAllowed.memory }}
       controlledValues: RequestsOnly
 {{- end }}

--- a/charts/internal/machine-controller-manager/seed/values.yaml
+++ b/charts/internal/machine-controller-manager/seed/values.yaml
@@ -23,6 +23,15 @@ vpa:
   enabled: true
   updatePolicy:
     updateMode: "Auto"
+  resourcePolicy:
+    mcm:
+      maxAllowed:
+        cpu: 2
+        memory: 5G
+    mcmProviderOpenstack:
+      maxAllowed:
+        cpu: 2
+        memory: 5G
 
 resources:
   mcm:

--- a/charts/internal/seed-controlplane/charts/cloud-controller-manager/templates/vpa.yaml
+++ b/charts/internal/seed-controlplane/charts/cloud-controller-manager/templates/vpa.yaml
@@ -16,4 +16,7 @@ spec:
       minAllowed:
         cpu: 20m
         memory: 40M
+      maxAllowed:
+        cpu: {{ .Values.vpa.resourcePolicy.maxAllowed.cpu }}
+        memory: {{ .Values.vpa.resourcePolicy.maxAllowed.memory }}
       controlledValues: RequestsOnly

--- a/charts/internal/seed-controlplane/charts/cloud-controller-manager/values.yaml
+++ b/charts/internal/seed-controlplane/charts/cloud-controller-manager/values.yaml
@@ -19,3 +19,8 @@ resources:
 tlsCipherSuites: []
 secrets:
   server: cloud-controller-manager-server
+vpa:
+  resourcePolicy:
+    maxAllowed:
+      cpu: 4
+      memory: 10G

--- a/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/csi-driver-controller-vpa.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/csi-driver-controller-vpa.yaml
@@ -10,26 +10,44 @@ spec:
     - containerName: openstack-csi-driver
       minAllowed:
         memory: {{ .Values.resources.driver.requests.memory }}
+      maxAllowed:
+        cpu: {{ .Values.vpa.resourcePolicy.driver.maxAllowed.cpu }}
+        memory: {{ .Values.vpa.resourcePolicy.driver.maxAllowed.memory }}
       controlledValues: RequestsOnly
     - containerName: openstack-csi-provisioner
       minAllowed:
         memory: {{ .Values.resources.provisioner.requests.memory }}
+      maxAllowed:
+        cpu: {{ .Values.vpa.resourcePolicy.provisioner.maxAllowed.cpu }}
+        memory: {{ .Values.vpa.resourcePolicy.provisioner.maxAllowed.memory }}
       controlledValues: RequestsOnly
     - containerName: openstack-csi-attacher
       minAllowed:
         memory: {{ .Values.resources.attacher.requests.memory }}
+      maxAllowed:
+        cpu: {{ .Values.vpa.resourcePolicy.attacher.maxAllowed.cpu }}
+        memory: {{ .Values.vpa.resourcePolicy.attacher.maxAllowed.memory }}
       controlledValues: RequestsOnly
     - containerName: openstack-csi-snapshotter
       minAllowed:
         memory: {{ .Values.resources.snapshotter.requests.memory }}
+      maxAllowed:
+        cpu: {{ .Values.vpa.resourcePolicy.snapshotter.maxAllowed.cpu }}
+        memory: {{ .Values.vpa.resourcePolicy.snapshotter.maxAllowed.memory }}
       controlledValues: RequestsOnly
     - containerName: openstack-csi-resizer
       minAllowed:
         memory: {{ .Values.resources.resizer.requests.memory }}
+      maxAllowed:
+        cpu: {{ .Values.vpa.resourcePolicy.resizer.maxAllowed.cpu }}
+        memory: {{ .Values.vpa.resourcePolicy.resizer.maxAllowed.memory }}
       controlledValues: RequestsOnly
     - containerName: openstack-csi-liveness-probe
       minAllowed:
         memory: {{ .Values.resources.livenessProbe.requests.memory }}
+      maxAllowed:
+        cpu: {{ .Values.vpa.resourcePolicy.livenessProbe.maxAllowed.cpu }}
+        memory: {{ .Values.vpa.resourcePolicy.livenessProbe.maxAllowed.memory }}
       controlledValues: RequestsOnly
   targetRef:
     apiVersion: apps/v1

--- a/charts/internal/seed-controlplane/charts/csi-driver-controller/values.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-driver-controller/values.yaml
@@ -53,6 +53,33 @@ resources:
     limits:
       memory: 220Mi
 
+vpa:
+  resourcePolicy:
+    driver:
+      maxAllowed:
+        cpu: 800m
+        memory: 4G
+    provisioner:
+      maxAllowed:
+        cpu: 800m
+        memory: 4G
+    attacher:
+      maxAllowed:
+        cpu: 500m
+        memory: 4G
+    snapshotter:
+      maxAllowed:
+        cpu: 700m
+        memory: 3G
+    resizer:
+      maxAllowed:
+        cpu: 700m
+        memory: 3G
+    livenessProbe:
+      maxAllowed:
+        cpu: 500m
+        memory: 2G
+
 csiSnapshotController:
   replicas: 1
   podAnnotations: {}

--- a/charts/internal/shoot-system-components/charts/csi-driver-node/templates/vpa.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/templates/vpa.yaml
@@ -11,16 +11,25 @@ spec:
       minAllowed:
         cpu: {{ .Values.resources.driver.requests.cpu }}
         memory: {{ .Values.resources.driver.requests.memory }}
+      maxAllowed:
+        cpu: {{ .Values.vpa.resourcePolicy.driver.maxAllowed.cpu }}
+        memory: {{ .Values.vpa.resourcePolicy.driver.maxAllowed.memory }}
       controlledValues: RequestsOnly
     - containerName: csi-node-driver-registrar
       minAllowed:
         cpu: {{ .Values.resources.nodeDriverRegistrar.requests.cpu }}
         memory: {{ .Values.resources.nodeDriverRegistrar.requests.memory }}
+      maxAllowed:
+        cpu: {{ .Values.vpa.resourcePolicy.nodeDriverRegistrar.maxAllowed.cpu }}
+        memory: {{ .Values.vpa.resourcePolicy.nodeDriverRegistrar.maxAllowed.memory }}
       controlledValues: RequestsOnly
     - containerName: csi-liveness-probe
       minAllowed:
         cpu: {{ .Values.resources.livenessProbe.requests.cpu }}
         memory: {{ .Values.resources.livenessProbe.requests.memory }}
+      maxAllowed:
+        cpu: {{ .Values.vpa.resourcePolicy.livenessProbe.maxAllowed.cpu }}
+        memory: {{ .Values.vpa.resourcePolicy.livenessProbe.maxAllowed.memory }}
       controlledValues: RequestsOnly
   targetRef:
     apiVersion: apps/v1

--- a/charts/internal/shoot-system-components/charts/csi-driver-node/values.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/values.yaml
@@ -35,6 +35,21 @@ resources:
       cpu: 11m
       memory: 32Mi
     limits:
-      memory: 200Mi 
+      memory: 200Mi
 
 pspDisabled: false
+
+vpa:
+  resourcePolicy:
+    driver:
+      maxAllowed:
+        cpu: 2
+        memory: 4G
+    nodeDriverRegistrar:
+      maxAllowed:
+        cpu: 1
+        memory: 3G
+    livenessProbe:
+      maxAllowed:
+        cpu: 1
+        memory: 3G


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind enhancement
/platform openstack

**What this PR does / why we need it**:
Limits the range of maximum allowed resource requests to ensure that pods are schedulable
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
