### PR TITLE
Upgrade cinder-csi-plugin

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -47,7 +47,7 @@ images:
 - name: csi-driver-cinder
   sourceRepository: github.com/kubernetes/cloud-provider-openstack
   repository: docker.io/k8scloudprovider/cinder-csi-plugin
-  tag: "v1.20.0"
+  tag: "v1.20.3"
   targetVersion: "1.20.x"
 - name: csi-driver-cinder
   sourceRepository: github.com/kubernetes/cloud-provider-openstack
@@ -67,7 +67,7 @@ images:
 - name: csi-driver-cinder
   sourceRepository: github.com/kubernetes/cloud-provider-openstack
   repository: docker.io/k8scloudprovider/cinder-csi-plugin
-  tag: "v1.24.0"
+  tag: "v1.24.2"
   targetVersion: ">= 1.24"
 
 - name: csi-provisioner


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area storage
/kind enhancement
/platform openstack

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The following images are updated:
- docker.io/k8scloudprovider/cinder-csi-plugin: v1.20.0 -> v1.20.3 (for Kubernetes 1.20 Shoots)
- docker.io/k8scloudprovider/cinder-csi-plugin: v1.24.0 -> v1.24.2 (for Kubernetes 1.24 Shoots)
```
