### PR TITLE
Upgrade cinder-csi-plugin

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -62,7 +62,7 @@ images:
 - name: csi-driver-cinder
   sourceRepository: github.com/kubernetes/cloud-provider-openstack
   repository: docker.io/k8scloudprovider/cinder-csi-plugin
-  tag: "v1.23.0"
+  tag: "v1.23.4"
   targetVersion: "1.23.x"
 - name: csi-driver-cinder
   sourceRepository: github.com/kubernetes/cloud-provider-openstack


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area storage
/kind enhancement
/platform openstack

https://github.com/kubernetes/cloud-provider-openstack/issues/1948 is now fixed in v1.23.4. Ref https://github.com/gardener/gardener-extension-provider-openstack/pull/476#issuecomment-1192486016

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The following image is updated:
- docker.io/k8scloudprovider/cinder-csi-plugin: v1.23.0 -> v1.23.4 (for Kubernetes 1.23 Shoots)
```
