### PR TITLE
Don't deploy `PSP`s when `PodSecurityPolicy` plugin is disabled 

### DIFF
--- a/charts/internal/shoot-system-components/charts/csi-driver-node/templates/clusterrole-csi-driver.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/templates/clusterrole-csi-driver.yaml
@@ -16,7 +16,9 @@ rules:
 - apiGroups: ["storage.k8s.io"]
   resources: ["volumeattachments"]
   verbs: ["get", "list", "watch", "update", "patch"]
+{{- if not .Values.pspDisabled }}
 - apiGroups: ["policy", "extensions"]
   resourceNames: ["{{ include "csi-driver-node.extensionsGroup" . }}.{{ include "csi-driver-node.name" . }}.csi-driver-node"]
   resources: ["podsecuritypolicies"]
   verbs: ["use"]
+{{- end }}

--- a/charts/internal/shoot-system-components/charts/csi-driver-node/templates/podsecuritypolicy.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/templates/podsecuritypolicy.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.pspDisabled }}
 ---
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
@@ -28,3 +29,4 @@ spec:
   fsGroup:
     rule: RunAsAny
   readOnlyRootFilesystem: false
+{{- end }}

--- a/charts/internal/shoot-system-components/charts/csi-driver-node/values.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/values.yaml
@@ -36,3 +36,5 @@ resources:
       memory: 32Mi
     limits:
       memory: 200Mi 
+
+pspDisabled: false

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -722,6 +722,7 @@ func (vp *valuesProvider) getControlPlaneShootChartValues(
 			"url":      "https://" + openstack.CSISnapshotValidation + "." + cp.Namespace + "/volumesnapshot",
 			"caBundle": caBundle,
 		},
+		"pspDisabled": gardencorev1beta1helper.IsPSPDisabled(cluster.Shoot),
 	}
 	if userAgentHeader != nil {
 		csiNodeDriverValues["userAgentHeaders"] = userAgentHeader

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -37,7 +37,6 @@ import (
 	"github.com/gardener/gardener/pkg/utils/chart"
 	gutil "github.com/gardener/gardener/pkg/utils/gardener"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
-	"github.com/gardener/gardener/pkg/utils/secrets"
 	secretutils "github.com/gardener/gardener/pkg/utils/secrets"
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
 	"github.com/gardener/gardener/pkg/utils/version"
@@ -73,7 +72,7 @@ func secretConfigsFunc(namespace string) []extensionssecretsmanager.SecretConfig
 				Name:                        cloudControllerManagerServerName,
 				CommonName:                  openstack.CloudControllerManagerName,
 				DNSNames:                    kutil.DNSNamesForService(openstack.CloudControllerManagerName, namespace),
-				CertType:                    secrets.ServerCert,
+				CertType:                    secretutils.ServerCert,
 				SkipPublishingCACertificate: true,
 			},
 			Options: []secretsmanager.GenerateOption{secretsmanager.SignedByCA(caNameControlPlane)},
@@ -83,7 +82,7 @@ func secretConfigsFunc(namespace string) []extensionssecretsmanager.SecretConfig
 				Name:                        csiSnapshotValidationServerName,
 				CommonName:                  openstack.UsernamePrefix + openstack.CSISnapshotValidation,
 				DNSNames:                    kutil.DNSNamesForService(openstack.CSISnapshotValidation, namespace),
-				CertType:                    secrets.ServerCert,
+				CertType:                    secretutils.ServerCert,
 				SkipPublishingCACertificate: true,
 			},
 			// use current CA for signing server cert to prevent mismatches when dropping the old CA from the webhook


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind enhancement
/platform openstack

**What this PR does / why we need it**:
`PodSecurityPolicy` is deprecated and will be disabled in kubernetes v1.25+.
End-users are provided an option to migrate their PSPs before upgrading and disable the `PodSecurityPolicy` admission plugin in the ShootSpec. 
In that case, we should stop deploying our PSPs as well.

- This PR stops deploying PSPs related to `provider-openstack` if the plugin is disabled in the Shoot

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/5250

**Special notes for your reviewer**:
Similar to https://github.com/gardener/gardener-extension-provider-aws/pull/587
/hold
Depends on #484 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
Please make sure you're running gardener@v1.52 or above before upgrading to this version.
```