### PR TITLE
Fix log formatting

### DIFF
--- a/test/integration/bastion/bastion_test.go
+++ b/test/integration/bastion/bastion_test.go
@@ -313,7 +313,7 @@ func verifyPort42IsClosed(ctx context.Context, c client.Client, bastion *extensi
 }
 
 func prepareNewRouter(log logr.Logger, routerName, subnetID string, openstackClient *OpenstackClient) (*string, error) {
-	log.Info("Waiting until router '%s' is created...", routerName)
+	log.Info("Waiting until router is created", "routerName", routerName)
 
 	allPages, err := networks.List(openstackClient.NetworkingClient, external.ListOptsExt{
 		ListOptsBuilder: networks.ListOpts{
@@ -341,32 +341,32 @@ func prepareNewRouter(log logr.Logger, routerName, subnetID string, openstackCli
 	_, err = routers.AddInterface(openstackClient.NetworkingClient, router.ID, intOpts).Extract()
 	Expect(err).NotTo(HaveOccurred())
 
-	log.Info("Router '%s' is created...", routerName)
+	log.Info("Router is created", "routerName", routerName)
 	return &router.ID, nil
 }
 
 func teardownRouter(log logr.Logger, routerID string, openstackClient *OpenstackClient) error {
-	log.Info("Waiting until router '%s' is deleted...", routerID)
+	log.Info("Waiting until router is deleted", "routerID", routerID)
 
 	err := routers.Delete(openstackClient.NetworkingClient, routerID).ExtractErr()
 	Expect(err).NotTo(HaveOccurred())
 
-	log.Info("Router '%s' is deleted...", routerID)
+	log.Info("Router is deleted", "routerID", routerID)
 	return nil
 }
 
 func prepareNewNetwork(log logr.Logger, networkName string, openstackClient *OpenstackClient) (*string, error) {
-	log.Info("Waiting until network '%s' is created...", networkName)
+	log.Info("Waiting until network is created", "networkName", networkName)
 
 	network, err := networks.Create(openstackClient.NetworkingClient, networks.CreateOpts{Name: networkName}).Extract()
 	Expect(err).NotTo(HaveOccurred())
 
-	log.Info("Network '%s' is created...", networkName)
+	log.Info("Network is created", "networkName", networkName)
 	return &network.ID, nil
 }
 
 func prepareSubNet(log logr.Logger, subnetName, networkid string, openstackClient *OpenstackClient) (*string, error) {
-	log.Info("Waiting until Subnet '%s' is created...", subnetName)
+	log.Info("Waiting until Subnet is created", "subnetName", subnetName)
 
 	createOpts := subnets.CreateOpts{
 		Name:      subnetName,
@@ -383,29 +383,29 @@ func prepareSubNet(log logr.Logger, subnetName, networkid string, openstackClien
 	}
 	subnet, err := subnets.Create(openstackClient.NetworkingClient, createOpts).Extract()
 	Expect(err).NotTo(HaveOccurred())
-	log.Info("Subnet '%s' is created...", subnetName)
+	log.Info("Subnet is created", "subnetName", subnetName)
 	return &subnet.ID, nil
 }
 
 // prepareShootSecurityGroup create fake shoot security group which will be used in EgressAllowSSHToWorker remoteGroupID
 func prepareShootSecurityGroup(log logr.Logger, shootSgName string, openstackClient *OpenstackClient) (*string, error) {
-	log.Info("Waiting until Shoot Security Group '%s' is created...", shootSgName)
+	log.Info("Waiting until Shoot Security Group is created", "shootSecurityGroupName", shootSgName)
 
 	sgroups, err := groups.Create(openstackClient.NetworkingClient, groups.CreateOpts{Name: shootSgName, Description: shootSgName}).Extract()
 	Expect(err).NotTo(HaveOccurred())
-	log.Info("Shoot Security Group '%s' is created...", shootSgName)
+	log.Info("Shoot Security Group is created", "shootSecurityGroupName", shootSgName)
 	return &sgroups.ID, nil
 }
 
 func teardownShootSecurityGroup(log logr.Logger, groupID string, openstackClient *OpenstackClient) error {
 	err := groups.Delete(openstackClient.NetworkingClient, groupID).ExtractErr()
 	Expect(err).NotTo(HaveOccurred())
-	log.Info("Shoot Security Group '%s' is deleted...", groupID)
+	log.Info("Shoot Security Group is deleted", "shootSecurityGroupID", groupID)
 	return nil
 }
 
 func teardownNetwork(log logr.Logger, networkID, routerID, subnetID string, openstackClient *OpenstackClient) error {
-	log.Info("Waiting until network '%s' is deleted...", networkID)
+	log.Info("Waiting until network is deleted", "networkID", networkID)
 
 	_, err := routers.RemoveInterface(openstackClient.NetworkingClient, routerID, routers.RemoveInterfaceOpts{SubnetID: subnetID}).Extract()
 	Expect(err).NotTo(HaveOccurred())
@@ -413,7 +413,7 @@ func teardownNetwork(log logr.Logger, networkID, routerID, subnetID string, open
 	err = networks.Delete(openstackClient.NetworkingClient, networkID).ExtractErr()
 	Expect(err).NotTo(HaveOccurred())
 
-	log.Info("Network '%s' is deleted...", networkID)
+	log.Info("Network is deleted", "networkID", networkID)
 	return nil
 }
 

--- a/test/integration/infrastructure/infrastructure_test.go
+++ b/test/integration/infrastructure/infrastructure_test.go
@@ -458,7 +458,7 @@ func runTest(
 
 // newProviderConfig creates a providerConfig with the network and router details.
 // If routerID is set to "", it requests a new router creation.
-// Else it reuses the suppiled routerID.
+// Else it reuses the supplied routerID.
 func newProviderConfig(routerID string, networkID *string) *openstackv1alpha1.InfrastructureConfig {
 	var router *openstackv1alpha1.Router
 
@@ -535,7 +535,7 @@ func generateNamespaceName() (string, error) {
 }
 
 func prepareNewRouter(ctx context.Context, log logr.Logger, routerName string, openstackClient *OpenstackClient) (*string, error) {
-	log.Info("Waiting until router '%s' is created...", routerName)
+	log.Info("Waiting until router is created", "routerName", routerName)
 
 	createOpts := routers.CreateOpts{
 		Name: routerName,
@@ -543,22 +543,22 @@ func prepareNewRouter(ctx context.Context, log logr.Logger, routerName string, o
 	router, err := routers.Create(openstackClient.NetworkingClient, createOpts).Extract()
 	Expect(err).NotTo(HaveOccurred())
 
-	log.Info("Router '%s' is created...", routerName)
+	log.Info("Router is created", "routerName", routerName)
 	return &router.ID, nil
 }
 
 func teardownRouter(ctx context.Context, log logr.Logger, routerID string, openstackClient *OpenstackClient) error {
-	log.Info("Waiting until router '%s' is deleted...", routerID)
+	log.Info("Waiting until router is deleted", "routerID", routerID)
 
 	err := routers.Delete(openstackClient.NetworkingClient, routerID).ExtractErr()
 	Expect(err).NotTo(HaveOccurred())
 
-	log.Info("Router '%s' is deleted...", routerID)
+	log.Info("Router is deleted", "routerID", routerID)
 	return nil
 }
 
 func prepareNewNetwork(ctx context.Context, log logr.Logger, networkName string, openstackClient *OpenstackClient) (*string, error) {
-	log.Info("Waiting until network '%s' is created...", networkName)
+	log.Info("Waiting until network is created", "networkName", networkName)
 
 	createOpts := networks.CreateOpts{
 		Name: networkName,
@@ -566,17 +566,17 @@ func prepareNewNetwork(ctx context.Context, log logr.Logger, networkName string,
 	network, err := networks.Create(openstackClient.NetworkingClient, createOpts).Extract()
 	Expect(err).NotTo(HaveOccurred())
 
-	log.Info("Network '%s' is created...", networkName)
+	log.Info("Network is created", "networkName", networkName)
 	return &network.ID, nil
 }
 
 func teardownNetwork(ctx context.Context, log logr.Logger, networkID string, openstackClient *OpenstackClient) error {
-	log.Info("Waiting until network '%s' is deleted...", networkID)
+	log.Info("Waiting until network is deleted", "networkID", networkID)
 
 	err := networks.Delete(openstackClient.NetworkingClient, networkID).ExtractErr()
 	Expect(err).NotTo(HaveOccurred())
 
-	log.Info("Network '%s' is deleted...", networkID)
+	log.Info("Network is deleted", "networkID", networkID)
 	return nil
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind enhancement
/platform openstack

**What this PR does / why we need it**:
With https://github.com/gardener/gardener-extension-provider-openstack/pull/484 , `log.Info` had wrong argument signature.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
