### PR TITLE
allow passthrough of worker labels to VM metadata

### DIFF
--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -85,6 +85,24 @@ var _ = Describe("Machines", func() {
 			})
 		})
 
+		Describe("#TestLabelNormalization", func() {
+			It("should return the correct list of labels", func() {
+				input := map[string]string{
+					"a/b/c":     "value",
+					"test/node": "value",
+					"node-role": "value",
+				}
+
+				output := NormalizeLabelsForMachineClass(input)
+				expected := map[string]string{
+					"a-b-c":     "value",
+					"test-node": "value",
+					"node-role": "value",
+				}
+				Expect(output).To(Equal(expected))
+			})
+		})
+
 		Describe("#GenerateMachineDeployments, #DeployMachineClasses", func() {
 			var (
 				namespace        string


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement
/platform openstack

**What this PR does / why we need it**:
With this PR the labels in a worker pool will be used to annotate the OpenStack server instance (in addition to the node object - that already being done). Because in OpenStack the metadata key is more restrictive than K8s we need to transform the key by replacing illegal characters.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Allow adding the `Labels` of a worker pool to the corresponding OpenStack Instance.
```
