### PR TITLE
expose routerIP to infrastructure.status

### DIFF
--- a/hack/api-reference/api.md
+++ b/hack/api-reference/api.md
@@ -1344,6 +1344,17 @@ string
 <p>ID is the Router id.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>ip</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<p>IP is the router ip.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="openstack.provider.extensions.gardener.cloud/v1alpha1.SecurityGroup">SecurityGroup

--- a/pkg/apis/openstack/types_infrastructure.go
+++ b/pkg/apis/openstack/types_infrastructure.go
@@ -88,6 +88,8 @@ type NetworkStatus struct {
 type RouterStatus struct {
 	// ID is the Router id.
 	ID string
+	// IP is the router ip.
+	IP string
 }
 
 // FloatingPoolStatus contains information about the floating pool.

--- a/pkg/apis/openstack/v1alpha1/types_infrastructure.go
+++ b/pkg/apis/openstack/v1alpha1/types_infrastructure.go
@@ -92,6 +92,8 @@ type NetworkStatus struct {
 type RouterStatus struct {
 	// ID is the Router id.
 	ID string `json:"id"`
+	// IP is the router ip.
+	IP string `json:"ip"`
 }
 
 // FloatingPoolStatus contains information about the floating pool.

--- a/pkg/apis/openstack/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/openstack/v1alpha1/zz_generated.conversion.go
@@ -804,6 +804,7 @@ func Convert_openstack_Router_To_v1alpha1_Router(in *openstack.Router, out *Rout
 
 func autoConvert_v1alpha1_RouterStatus_To_openstack_RouterStatus(in *RouterStatus, out *openstack.RouterStatus, s conversion.Scope) error {
 	out.ID = in.ID
+	out.IP = in.IP
 	return nil
 }
 
@@ -814,6 +815,7 @@ func Convert_v1alpha1_RouterStatus_To_openstack_RouterStatus(in *RouterStatus, o
 
 func autoConvert_openstack_RouterStatus_To_v1alpha1_RouterStatus(in *openstack.RouterStatus, out *RouterStatus, s conversion.Scope) error {
 	out.ID = in.ID
+	out.IP = in.IP
 	return nil
 }
 

--- a/pkg/internal/infrastructure/templates/main.tpl.tf
+++ b/pkg/internal/infrastructure/templates/main.tpl.tf
@@ -139,6 +139,10 @@ output "{{ .outputKeys.routerID }}" {
   value = {{ .router.id }}
 }
 
+output "{{ .outputKeys.routerIP }}" {
+  value = openstack_networking_router_v2.router.external_fixed_ip[0].ip_address
+}
+
 output "{{ .outputKeys.networkID }}" {
   value = {{ template "network-id" $ }}
 }

--- a/pkg/internal/infrastructure/terraform.go
+++ b/pkg/internal/infrastructure/terraform.go
@@ -37,6 +37,8 @@ const (
 	TerraformOutputKeySSHKeyName = "key_name"
 	// TerraformOutputKeyRouterID is the id the router between provider network and the worker subnet.
 	TerraformOutputKeyRouterID = "router_id"
+	// TerraformOutputKeyRouterIP is the ip address of the router.
+	TerraformOutputKeyRouterIP = "router_ip"
 	// TerraformOutputKeyNetworkID is the private worker network.
 	TerraformOutputKeyNetworkID = "network_id"
 	// TerraformOutputKeyNetworkName is the private worker network name.
@@ -75,6 +77,7 @@ func ComputeTerraformerTemplateValues(
 		}
 		outputKeysConfig = map[string]interface{}{
 			"routerID":          TerraformOutputKeyRouterID,
+			"routerIP":          TerraformOutputKeyRouterIP,
 			"networkID":         TerraformOutputKeyNetworkID,
 			"networkName":       TerraformOutputKeyNetworkName,
 			"keyName":           TerraformOutputKeySSHKeyName,
@@ -196,6 +199,8 @@ type TerraformState struct {
 	SSHKeyName string
 	// RouterID is the id the router between provider network and the worker subnet.
 	RouterID string
+	// RouterIP is the ip address of the router.
+	RouterIP string
 	// NetworkID is the private worker network.
 	NetworkID string
 	// NetworkName is the private worker network name.
@@ -215,6 +220,7 @@ func ExtractTerraformState(ctx context.Context, tf terraformer.Terraformer) (*Te
 	outputKeys := []string{
 		TerraformOutputKeySSHKeyName,
 		TerraformOutputKeyRouterID,
+		TerraformOutputKeyRouterIP,
 		TerraformOutputKeyNetworkID,
 		TerraformOutputKeyNetworkName,
 		TerraformOutputKeySubnetID,
@@ -231,6 +237,7 @@ func ExtractTerraformState(ctx context.Context, tf terraformer.Terraformer) (*Te
 	return &TerraformState{
 		SSHKeyName:        vars[TerraformOutputKeySSHKeyName],
 		RouterID:          vars[TerraformOutputKeyRouterID],
+		RouterIP:          vars[TerraformOutputKeyRouterIP],
 		NetworkID:         vars[TerraformOutputKeyNetworkID],
 		NetworkName:       vars[TerraformOutputKeyNetworkName],
 		SubnetID:          vars[TerraformOutputKeySubnetID],
@@ -256,6 +263,7 @@ func StatusFromTerraformState(state *TerraformState) *apiv1alpha1.Infrastructure
 			},
 			Router: apiv1alpha1.RouterStatus{
 				ID: state.RouterID,
+				IP: state.RouterIP,
 			},
 			Subnets: []apiv1alpha1.Subnet{
 				{

--- a/pkg/internal/infrastructure/terraform_test.go
+++ b/pkg/internal/infrastructure/terraform_test.go
@@ -133,6 +133,7 @@ var _ = Describe("Terraform", func() {
 			}
 			expectedOutputKeysValues = map[string]interface{}{
 				"routerID":          TerraformOutputKeyRouterID,
+				"routerIP":          TerraformOutputKeyRouterIP,
 				"networkID":         TerraformOutputKeyNetworkID,
 				"networkName":       TerraformOutputKeyNetworkName,
 				"keyName":           TerraformOutputKeySSHKeyName,
@@ -233,6 +234,7 @@ var _ = Describe("Terraform", func() {
 		var (
 			SSHKeyName        string
 			RouterID          string
+			RouterIP          string
 			NetworkID         string
 			SubnetID          string
 			FloatingNetworkID string
@@ -246,6 +248,7 @@ var _ = Describe("Terraform", func() {
 		BeforeEach(func() {
 			SSHKeyName = "my-key"
 			RouterID = "111"
+			RouterIP = "1.1.1.1"
 			NetworkID = "222"
 			SubnetID = "333"
 			FloatingNetworkID = "444"
@@ -255,6 +258,7 @@ var _ = Describe("Terraform", func() {
 			state = TerraformState{
 				SSHKeyName:        SSHKeyName,
 				RouterID:          RouterID,
+				RouterIP:          RouterIP,
 				NetworkID:         NetworkID,
 				SubnetID:          SubnetID,
 				FloatingNetworkID: FloatingNetworkID,
@@ -271,6 +275,7 @@ var _ = Describe("Terraform", func() {
 					ID: state.NetworkID,
 					Router: apiv1alpha1.RouterStatus{
 						ID: state.RouterID,
+						IP: state.RouterIP,
 					},
 					FloatingPool: apiv1alpha1.FloatingPoolStatus{
 						ID: FloatingNetworkID,


### PR DESCRIPTION
**How to categorize this PR?**
/area useability
/kind api-change
/platform openstack

**What this PR does / why we need it**:
We recently developed the [Gardener ACL extension](https://github.com/stackitcloud/gardener-extension-acl) which can block external traffic to gardener via IP ranges.  
In order for gardener to function on openstack, we also need to add the Gateway routerIP to the list of allowed IP ranges. Otherwise gardener is not able to connect via reverse VPN to the cluster and we get internal error messages.

This PR exposes the IP to the RouterStatus so we are able to use it and feed it into our allowed list.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
Expose Router IP address to RouterStatus.IP
```
