### PR TITLE
fix typo public ip to floating ip

### DIFF
--- a/pkg/controller/bastion/actuator_reconcile.go
+++ b/pkg/controller/bastion/actuator_reconcile.go
@@ -300,7 +300,7 @@ func ensureAssociateFIPWithInstance(client openstackclient.Compute, instance *se
 	}
 
 	if floatingIP.Status != "ACTIVE" || instance.Status != "ACTIVE" {
-		return fmt.Errorf("instance or public ip address not ready yet")
+		return fmt.Errorf("instance or floating ip address not ready yet")
 	}
 
 	associateOpts := computefip.AssociateOpts{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind task
/platform openstack

**What this PR does / why we need it**:
after https://github.com/gardener/gardenctl-v2/pull/186 PR, the last error will be printed during the bastion creation 
fix typo in case misleading, fix public ip to floating ip 

`Still waiting: Error while waiting for Bastion shoot--abc-os/cli-urta3zkr to become ready: error during reconciliation: Error reconciling Bastion: instance or public ip address not ready yet`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
