### PR TITLE
mutating webhook respects shoot deletion, restore and migration

### DIFF
--- a/pkg/admission/mutator/mutator_suite_test.go
+++ b/pkg/admission/mutator/mutator_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mutator_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestMutator(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Shoot Mutator Suite")
+}

--- a/pkg/admission/mutator/shoot_test.go
+++ b/pkg/admission/mutator/shoot_test.go
@@ -1,0 +1,112 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mutator_test
+
+import (
+	"context"
+	"time"
+
+	"github.com/gardener/gardener-extension-provider-openstack/pkg/admission/mutator"
+	"github.com/gardener/gardener-extension-provider-openstack/pkg/openstack"
+	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
+)
+
+var _ = Describe("Shoot mutator", func() {
+
+	Describe("#Mutate", func() {
+		const namespace = "garden-dev"
+
+		var (
+			shootMutator extensionswebhook.Mutator
+			shoot        *gardencorev1beta1.Shoot
+			ctx          = context.TODO()
+			now          = metav1.Now()
+		)
+
+		BeforeEach(func() {
+			shootMutator = mutator.NewShootMutator()
+			scheme := runtime.NewScheme()
+			Expect(gardencorev1beta1.AddToScheme(scheme)).To(Succeed())
+			Expect(shootMutator.(inject.Scheme).InjectScheme(scheme)).To(Succeed())
+
+			shoot = &gardencorev1beta1.Shoot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: namespace,
+				},
+				Spec: gardencorev1beta1.ShootSpec{
+					SeedName: pointer.String("openstack"),
+					Provider: gardencorev1beta1.Provider{
+						Type: openstack.Type,
+					},
+					Region: "eu-nl-1",
+					Networking: gardencorev1beta1.Networking{
+						Nodes: pointer.String("10.250.0.0/16"),
+						Type:  "calico",
+					},
+				},
+			}
+		})
+
+		Context("Mutate shoot", func() {
+			It("should return nil when shoot is in scheduled to new seed phase", func() {
+				shoot.Status.LastOperation = &gardencorev1beta1.LastOperation{
+					Description:    "test",
+					LastUpdateTime: metav1.Time{Time: metav1.Now().Add(time.Second * -1000)},
+					Progress:       0,
+					Type:           gardencorev1beta1.LastOperationTypeReconcile,
+					State:          gardencorev1beta1.LastOperationStateProcessing,
+				}
+				shoot.Status.SeedName = pointer.String("aws")
+				shootExpected := shoot.DeepCopy()
+				err := shootMutator.Mutate(ctx, shoot, nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(shoot).To(DeepEqual(shootExpected))
+			})
+
+			It("should return nil when shoot is in migration or restore phase", func() {
+				shoot.Status.LastOperation = &gardencorev1beta1.LastOperation{
+					Description:    "test",
+					LastUpdateTime: metav1.Time{Time: metav1.Now().Add(time.Second * -1000)},
+					Progress:       0,
+					Type:           gardencorev1beta1.LastOperationTypeMigrate,
+					State:          gardencorev1beta1.LastOperationStateProcessing,
+				}
+				shoot.Status.SeedName = pointer.String("openstack")
+				shootExpected := shoot.DeepCopy()
+				err := shootMutator.Mutate(ctx, shoot, shoot)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(shoot).To(DeepEqual(shootExpected))
+			})
+
+			It("should return nil when shoot is in deletion phase", func() {
+				shoot.DeletionTimestamp = &now
+				shootExpected := shoot.DeepCopy()
+				err := shootMutator.Mutate(ctx, shoot, nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(shoot).To(DeepEqual(shootExpected))
+			})
+		})
+	})
+})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug
/platform openstack

**What this PR does / why we need it**:
Mutating webhook respects shoot deletion, restore and migration.Before those operations failed under certain conditions. E.g.: 
```
task "Waiting until shoot infrastructure has been reconciled" failed: shoots.core.gardener.cloud "tmn33-zb3-hs-mgr" is forbidden: cannot change shoot spec during Restore operation that is in state Processing
```

**Which issue(s) this PR fixes**:
Fixes issue similar to https://github.com/gardener/gardener-extension-provider-aws/issues/659 on openstack.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Mutating webhook respects shoot deletion, restore and migration. Before those operations failed under certain conditions.
```
