### PR TITLE
delete infrastructure routes in case ccm is not there

### DIFF
--- a/pkg/internal/infrastructure/infrastucture.go
+++ b/pkg/internal/infrastructure/infrastucture.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package infrastructure
+
+import (
+	"context"
+	"net"
+
+	openstackclient "github.com/gardener/gardener-extension-provider-openstack/pkg/openstack/client"
+
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers"
+)
+
+// CleanupKubernetesRoutes deletes all routes from the router which have a nextHop in the subnet.
+func CleanupKubernetesRoutes(ctx context.Context, client openstackclient.Networking, routerID, workers string) error {
+
+	router, err := client.GetRouterByID(routerID)
+	if err != nil {
+		return err
+	}
+
+	if len(router) == 0 {
+		return nil
+	}
+
+	routes := []routers.Route{}
+	_, workersNet, _ := net.ParseCIDR(workers)
+
+	for _, route := range router[0].Routes {
+		ipNode, _, err := net.ParseCIDR(route.NextHop + "/32")
+		if err != nil {
+			return err
+		}
+		if !workersNet.Contains(ipNode) {
+			routes = append(routes, route)
+		}
+	}
+
+	if _, err := client.UpdateRoutesForRouter(routes, routerID); err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/openstack/client/mocks/client_mocks.go
+++ b/pkg/openstack/client/mocks/client_mocks.go
@@ -16,6 +16,7 @@ import (
 	images "github.com/gophercloud/gophercloud/openstack/compute/v2/images"
 	servers "github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
 	floatingips0 "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/floatingips"
+	routers "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers"
 	groups "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups"
 	rules "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules"
 	networks "github.com/gophercloud/gophercloud/openstack/networking/v2/networks"
@@ -579,6 +580,21 @@ func (mr *MockNetworkingMockRecorder) GetNetworkByName(arg0 interface{}) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNetworkByName", reflect.TypeOf((*MockNetworking)(nil).GetNetworkByName), arg0)
 }
 
+// GetRouterByID mocks base method.
+func (m *MockNetworking) GetRouterByID(arg0 string) ([]routers.Router, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRouterByID", arg0)
+	ret0, _ := ret[0].([]routers.Router)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetRouterByID indicates an expected call of GetRouterByID.
+func (mr *MockNetworkingMockRecorder) GetRouterByID(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRouterByID", reflect.TypeOf((*MockNetworking)(nil).GetRouterByID), arg0)
+}
+
 // GetSecurityGroupByName mocks base method.
 func (m *MockNetworking) GetSecurityGroupByName(arg0 string) ([]groups.SecGroup, error) {
 	m.ctrl.T.Helper()
@@ -624,6 +640,21 @@ func (mr *MockNetworkingMockRecorder) ListNetwork(arg0 interface{}) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListNetwork", reflect.TypeOf((*MockNetworking)(nil).ListNetwork), arg0)
 }
 
+// ListRouters mocks base method.
+func (m *MockNetworking) ListRouters(arg0 routers.ListOpts) ([]routers.Router, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListRouters", arg0)
+	ret0, _ := ret[0].([]routers.Router)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListRouters indicates an expected call of ListRouters.
+func (mr *MockNetworkingMockRecorder) ListRouters(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRouters", reflect.TypeOf((*MockNetworking)(nil).ListRouters), arg0)
+}
+
 // ListRules mocks base method.
 func (m *MockNetworking) ListRules(arg0 rules.ListOpts) ([]rules.SecGroupRule, error) {
 	m.ctrl.T.Helper()
@@ -652,4 +683,19 @@ func (m *MockNetworking) ListSecurityGroup(arg0 groups.ListOpts) ([]groups.SecGr
 func (mr *MockNetworkingMockRecorder) ListSecurityGroup(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSecurityGroup", reflect.TypeOf((*MockNetworking)(nil).ListSecurityGroup), arg0)
+}
+
+// UpdateRoutesForRouter mocks base method.
+func (m *MockNetworking) UpdateRoutesForRouter(arg0 []routers.Route, arg1 string) (*routers.Router, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateRoutesForRouter", arg0, arg1)
+	ret0, _ := ret[0].(*routers.Router)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateRoutesForRouter indicates an expected call of UpdateRoutesForRouter.
+func (mr *MockNetworkingMockRecorder) UpdateRoutesForRouter(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateRoutesForRouter", reflect.TypeOf((*MockNetworking)(nil).UpdateRoutesForRouter), arg0, arg1)
 }

--- a/pkg/openstack/client/networking.go
+++ b/pkg/openstack/client/networking.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/external"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/floatingips"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/networks"
@@ -141,4 +142,30 @@ func (c *NetworkingClient) GetSecurityGroupByName(name string) ([]groups.SecGrou
 		Name: name,
 	}
 	return c.ListSecurityGroup(listOpts)
+}
+
+// GetRouterByID return a router info by name
+func (c *NetworkingClient) GetRouterByID(id string) ([]routers.Router, error) {
+	listOpts := routers.ListOpts{
+		ID: id,
+	}
+	return c.ListRouters(listOpts)
+}
+
+// ListRouters returns a list of routers
+func (c *NetworkingClient) ListRouters(listOpts routers.ListOpts) ([]routers.Router, error) {
+	allPages, err := routers.List(c.client, listOpts).AllPages()
+	if err != nil {
+		return nil, err
+	}
+	return routers.ExtractRouters(allPages)
+}
+
+// UpdateRoutesForRouter updates the route list for a router
+func (c *NetworkingClient) UpdateRoutesForRouter(routes []routers.Route, routerID string) (*routers.Router, error) {
+
+	updateOpts := routers.UpdateOpts{
+		Routes: routes,
+	}
+	return routers.Update(c.client, routerID, updateOpts).Extract()
 }

--- a/pkg/openstack/client/types.go
+++ b/pkg/openstack/client/types.go
@@ -25,6 +25,8 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/images"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/floatingips"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers"
+
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/networks"
@@ -119,6 +121,10 @@ type Networking interface {
 	CreateRule(createOpts rules.CreateOpts) (*rules.SecGroupRule, error)
 	ListRules(listOpts rules.ListOpts) ([]rules.SecGroupRule, error)
 	DeleteRule(ruleID string) error
+	// Routers
+	GetRouterByID(id string) ([]routers.Router, error)
+	ListRouters(listOpts routers.ListOpts) ([]routers.Router, error)
+	UpdateRoutesForRouter(routes []routers.Route, routerID string) (*routers.Router, error)
 }
 
 // FactoryFactory creates instances of Factory.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement
/platform openstack

**What this PR does / why we need it**:
All infrastructure routes within the workers node range are deleted during the deletion process. This lets the deletion still succeed when the cloud controller manager is not there anymore.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
All infrastructure routes within the workers node range are deleted during the deletion process. This lets the deletion still succeed when the cloud controller manager is not there anymore.
```
