### PR TITLE
Flow-based infrastructure reconciliation without Terraformer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,8 @@ require (
 	k8s.io/api v0.26.3
 	k8s.io/apiextensions-apiserver v0.26.3
 	k8s.io/apimachinery v0.26.3
+	go.uber.org/atomic v1.9.0
+	golang.org/x/tools v0.6.0
 	k8s.io/autoscaler/vertical-pod-autoscaler v0.13.0
 	k8s.io/client-go v11.0.1-0.20190409021438-1a26190bd76a+incompatible
 	k8s.io/code-generator v0.26.3
@@ -111,7 +113,6 @@ require (
 	github.com/subosito/gotenv v1.2.0 // indirect
 	github.com/ulikunitz/xz v0.5.10 // indirect
 	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
-	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.7.0 // indirect
 	go.uber.org/zap v1.24.0 // indirect
 	golang.org/x/crypto v0.6.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -21,12 +21,11 @@ require (
 	github.com/onsi/gomega v1.27.6
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/pflag v1.0.5
+	go.uber.org/atomic v1.9.0
 	golang.org/x/tools v0.7.0
 	k8s.io/api v0.26.3
 	k8s.io/apiextensions-apiserver v0.26.3
 	k8s.io/apimachinery v0.26.3
-	go.uber.org/atomic v1.9.0
-	golang.org/x/tools v0.6.0
 	k8s.io/autoscaler/vertical-pod-autoscaler v0.13.0
 	k8s.io/client-go v11.0.1-0.20190409021438-1a26190bd76a+incompatible
 	k8s.io/code-generator v0.26.3

--- a/pkg/apis/openstack/helper/error_codes.go
+++ b/pkg/apis/openstack/helper/error_codes.go
@@ -22,7 +22,7 @@ import (
 
 var (
 	unauthenticatedRegexp               = regexp.MustCompile(`(?i)(Authentication failed|invalid character|invalid_client|cannot fetch token|InvalidSecretAccessKey)`)
-	unauthorizedRegexp                  = regexp.MustCompile(`(?i)(Unauthorized|SignatureDoesNotMatch|invalid_grant|Authorization Profile was not found|no active subscriptions|not authorized|AccessDenied)`)
+	unauthorizedRegexp                  = regexp.MustCompile(`(?i)(Unauthorized|SignatureDoesNotMatch|invalid_grant|Authorization Profile was not found|no active subscriptions|not authorized|AccessDenied|PolicyNotAuthorized)`)
 	quotaExceededRegexp                 = regexp.MustCompile(`(?i)((?:^|[^t]|(?:[^s]|^)t|(?:[^e]|^)st|(?:[^u]|^)est|(?:[^q]|^)uest|(?:[^e]|^)quest|(?:[^r]|^)equest)LimitExceeded|Quotas|Quota.*exceeded|exceeded quota|Quota has been met|QUOTA_EXCEEDED|Maximum number of ports exceeded|VolumeSizeExceedsAvailableQuota)`)
 	rateLimitsExceededRegexp            = regexp.MustCompile(`(?i)(RequestLimitExceeded|Throttling|Too many requests)`)
 	dependenciesRegexp                  = regexp.MustCompile(`(?i)(PendingVerification|Access Not Configured|accessNotConfigured|DependencyViolation|OptInRequired|Conflict|inactive billing state|timeout while waiting for state to become|InvalidCidrBlock|already busy for|internal server error|A resource with the ID|There are not enough hosts available)`)

--- a/pkg/controller/bastion/actuator_reconcile.go
+++ b/pkg/controller/bastion/actuator_reconcile.go
@@ -184,16 +184,15 @@ func ensurePublicIPAddress(opt *Options, log logr.Logger, client openstackclient
 		return nil, errors.New("router must not be empty")
 	}
 
-	routerList, err := client.GetRouterByID(infraStatus.Networks.Router.ID)
+	router, err := client.GetRouterByID(infraStatus.Networks.Router.ID)
 	if err != nil {
 		return nil, err
 	}
 
-	if len(routerList) == 0 {
+	if router == nil {
 		return nil, fmt.Errorf("router with ID %s was not found", infraStatus.Networks.Router.ID)
 	}
 
-	router := routerList[0]
 	if len(router.GatewayInfo.ExternalFixedIPs) == 0 {
 		return nil, errors.New("no external fixed IPs detected on the router")
 	}

--- a/pkg/controller/infrastructure/actuator.go
+++ b/pkg/controller/infrastructure/actuator.go
@@ -18,18 +18,18 @@ import (
 	"context"
 	"strings"
 
-	api "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack"
-	openstackv1alpha1 "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack/v1alpha1"
-	infrainternal "github.com/gardener/gardener-extension-provider-openstack/pkg/internal/infrastructure"
-	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	"github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
-
 	"github.com/gardener/gardener/extensions/pkg/controller/common"
 	"github.com/gardener/gardener/extensions/pkg/controller/infrastructure"
 	"github.com/gardener/gardener/extensions/pkg/terraformer"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	"github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	api "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack"
+	openstackv1alpha1 "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack/v1alpha1"
+	infrainternal "github.com/gardener/gardener-extension-provider-openstack/pkg/internal/infrastructure"
 )
 
 const (

--- a/pkg/controller/infrastructure/actuator_delete.go
+++ b/pkg/controller/infrastructure/actuator_delete.go
@@ -41,9 +41,11 @@ func (a *actuator) Delete(ctx context.Context, log logr.Logger, infra *extension
 		return err
 	}
 	if state != nil {
-		return a.deleteWithFlow(ctx, log, infra, cluster, state)
+		err = a.deleteWithFlow(ctx, log, infra, cluster, state)
+	} else {
+		err = a.deleteWithTerraformer(ctx, log, infra, cluster)
 	}
-	return a.deleteWithTerraformer(ctx, log, infra, cluster)
+	return util.DetermineError(err, helper.KnownCodes)
 }
 
 func (a *actuator) deleteWithFlow(ctx context.Context, log logr.Logger, infra *extensionsv1alpha1.Infrastructure,
@@ -56,7 +58,7 @@ func (a *actuator) deleteWithFlow(ctx context.Context, log logr.Logger, infra *e
 	}
 	if err = flowContext.Delete(ctx); err != nil {
 		_ = flowContext.PersistState(ctx, true)
-		return a.addErrorCodes(err)
+		return err
 	}
 	return flowContext.PersistState(ctx, true)
 }

--- a/pkg/controller/infrastructure/actuator_delete.go
+++ b/pkg/controller/infrastructure/actuator_delete.go
@@ -28,6 +28,7 @@ import (
 
 	api "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack"
 	"github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack/helper"
+	"github.com/gardener/gardener-extension-provider-openstack/pkg/controller/infrastructure/infraflow"
 	"github.com/gardener/gardener-extension-provider-openstack/pkg/internal"
 	"github.com/gardener/gardener-extension-provider-openstack/pkg/internal/infrastructure"
 	"github.com/gardener/gardener-extension-provider-openstack/pkg/openstack"
@@ -35,6 +36,32 @@ import (
 )
 
 func (a *actuator) Delete(ctx context.Context, log logr.Logger, infra *extensionsv1alpha1.Infrastructure, cluster *extensionscontroller.Cluster) error {
+	state, err := a.getStateFromInfraStatus(ctx, infra)
+	if err != nil {
+		return err
+	}
+	if state != nil {
+		return a.deleteWithFlow(ctx, log, infra, cluster, state)
+	}
+	return a.deleteWithTerraformer(ctx, log, infra, cluster)
+}
+
+func (a *actuator) deleteWithFlow(ctx context.Context, log logr.Logger, infra *extensionsv1alpha1.Infrastructure,
+	cluster *extensionscontroller.Cluster, oldState *infraflow.PersistentState) error {
+	log.Info("deleteWithFlow")
+
+	flowContext, err := a.createFlowContext(ctx, log, infra, cluster, oldState)
+	if err != nil {
+		return err
+	}
+	if err = flowContext.Delete(ctx); err != nil {
+		_ = flowContext.PersistState(ctx, true)
+		return a.addErrorCodes(err)
+	}
+	return flowContext.PersistState(ctx, true)
+}
+
+func (a *actuator) deleteWithTerraformer(ctx context.Context, log logr.Logger, infra *extensionsv1alpha1.Infrastructure, cluster *extensionscontroller.Cluster) error {
 	tf, err := internal.NewTerraformer(log, a.RESTConfig(), infrastructure.TerraformerPurpose, infra, a.disableProjectedTokenMount)
 	if err != nil {
 		return util.DetermineError(fmt.Errorf("could not create the Terraformer: %+v", err), helper.KnownCodes)

--- a/pkg/controller/infrastructure/actuator_reconcile.go
+++ b/pkg/controller/infrastructure/actuator_reconcile.go
@@ -27,7 +27,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	api "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack"
 	"github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack/helper"
 	openstackv1alpha1 "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack/v1alpha1"
 	"github.com/gardener/gardener-extension-provider-openstack/pkg/controller/infrastructure/infraflow"
@@ -61,7 +60,7 @@ func (a *actuator) shouldUseFlow(infrastructure *extensionsv1alpha1.Infrastructu
 		(cluster.Shoot != nil && cluster.Shoot.Annotations != nil && strings.EqualFold(cluster.Shoot.Annotations[AnnotationKeyUseFlow], "true"))
 }
 
-func (a *actuator) getStateFromInfraStatus(ctx context.Context, infrastructure *extensionsv1alpha1.Infrastructure) (*infraflow.PersistentState, error) {
+func (a *actuator) getStateFromInfraStatus(_ context.Context, infrastructure *extensionsv1alpha1.Infrastructure) (*infraflow.PersistentState, error) {
 	if infrastructure.Status.State != nil {
 		return infraflow.NewPersistentStateFromJSON(infrastructure.Status.State.Raw)
 	}
@@ -157,12 +156,7 @@ func (a *actuator) createFlowContext(ctx context.Context, log logr.Logger,
 }
 
 func (a *actuator) updateStatusState(ctx context.Context, infra *extensionsv1alpha1.Infrastructure, state *infraflow.PersistentState) error {
-	config, err := helper.InfrastructureConfigFromInfrastructure(infra)
-	if err != nil {
-		return err
-	}
-
-	status, err := computeProviderStatusFromFlowState(config, state)
+	status, err := computeProviderStatusFromFlowState(state)
 	if err != nil {
 		return err
 	}
@@ -224,7 +218,7 @@ func (a *actuator) reconcileWithTerraformer(ctx context.Context, log logr.Logger
 	return a.updateProviderStatusWithTerraformer(ctx, tf, infra, config)
 }
 
-func computeProviderStatusFromFlowState(config *api.InfrastructureConfig, state *infraflow.PersistentState) (*openstackv1alpha1.InfrastructureStatus, error) {
+func computeProviderStatusFromFlowState(state *infraflow.PersistentState) (*openstackv1alpha1.InfrastructureStatus, error) {
 	if len(state.Data) == 0 {
 		return nil, nil
 	}

--- a/pkg/controller/infrastructure/actuator_reconcile.go
+++ b/pkg/controller/infrastructure/actuator_reconcile.go
@@ -17,24 +17,182 @@ package infrastructure
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
 	"github.com/gardener/gardener/extensions/pkg/terraformer"
 	"github.com/gardener/gardener/extensions/pkg/util"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/go-logr/logr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	api "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack"
 	"github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack/helper"
+	openstackv1alpha1 "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack/v1alpha1"
+	"github.com/gardener/gardener-extension-provider-openstack/pkg/controller/infrastructure/infraflow"
+	"github.com/gardener/gardener-extension-provider-openstack/pkg/controller/infrastructure/infraflow/shared"
 	"github.com/gardener/gardener-extension-provider-openstack/pkg/internal"
 	"github.com/gardener/gardener-extension-provider-openstack/pkg/internal/infrastructure"
 	"github.com/gardener/gardener-extension-provider-openstack/pkg/openstack"
+	openstackclient "github.com/gardener/gardener-extension-provider-openstack/pkg/openstack/client"
 )
 
 func (a *actuator) Reconcile(ctx context.Context, log logr.Logger, infra *extensionsv1alpha1.Infrastructure, cluster *extensionscontroller.Cluster) error {
-	return a.reconcile(ctx, log, infra, cluster, terraformer.StateConfigMapInitializerFunc(terraformer.CreateState))
+	flowState, err := a.getStateFromInfraStatus(ctx, infra)
+	if err != nil {
+		return err
+	}
+	if flowState != nil {
+		return a.reconcileWithFlow(ctx, log, infra, cluster, flowState)
+	}
+	if a.shouldUseFlow(infra, cluster) {
+		flowState, err = a.migrateFromTerraformerState(ctx, log, infra)
+		if err != nil {
+			return err
+		}
+		return a.reconcileWithFlow(ctx, log, infra, cluster, flowState)
+	}
+	return a.reconcileWithTerraformer(ctx, log, infra, cluster, terraformer.StateConfigMapInitializerFunc(terraformer.CreateState))
 }
 
-func (a *actuator) reconcile(ctx context.Context, log logr.Logger, infra *extensionsv1alpha1.Infrastructure, cluster *extensionscontroller.Cluster, stateInitializer terraformer.StateConfigMapInitializer) error {
+func (a *actuator) shouldUseFlow(infrastructure *extensionsv1alpha1.Infrastructure, cluster *extensionscontroller.Cluster) bool {
+	return (infrastructure.Annotations != nil && strings.EqualFold(infrastructure.Annotations[AnnotationKeyUseFlow], "true")) ||
+		(cluster.Shoot != nil && cluster.Shoot.Annotations != nil && strings.EqualFold(cluster.Shoot.Annotations[AnnotationKeyUseFlow], "true"))
+}
+
+func (a *actuator) getStateFromInfraStatus(ctx context.Context, infrastructure *extensionsv1alpha1.Infrastructure) (*infraflow.PersistentState, error) {
+	if infrastructure.Status.State != nil {
+		return infraflow.NewPersistentStateFromJSON(infrastructure.Status.State.Raw)
+	}
+	return nil, nil
+}
+
+func (a *actuator) migrateFromTerraformerState(ctx context.Context, log logr.Logger, infra *extensionsv1alpha1.Infrastructure) (*infraflow.PersistentState, error) {
+	log.Info("starting terraform state migration")
+
+	// just explore the infrastructure objects by starting with an empty state
+	state := infraflow.NewPersistentState()
+
+	if err := a.updateStatusState(ctx, infra, state); err != nil {
+		return nil, fmt.Errorf("updating status state failed: %w", err)
+	}
+	log.Info("terraform state migrated successfully")
+
+	return state, nil
+}
+
+func (a *actuator) reconcileWithFlow(ctx context.Context, log logr.Logger, infra *extensionsv1alpha1.Infrastructure,
+	cluster *extensionscontroller.Cluster, oldState *infraflow.PersistentState) error {
+
+	log.Info("reconcileWithFlow")
+
+	flowContext, err := a.createFlowContext(ctx, log, infra, cluster, oldState)
+	if err != nil {
+		return err
+	}
+	if err = flowContext.Reconcile(ctx); err != nil {
+		_ = flowContext.PersistState(ctx, true)
+		return a.addErrorCodes(err)
+	}
+	return flowContext.PersistState(ctx, true)
+}
+
+func (a *actuator) createFlowContext(ctx context.Context, log logr.Logger,
+	infra *extensionsv1alpha1.Infrastructure, cluster *extensionscontroller.Cluster,
+	oldState *infraflow.PersistentState) (*infraflow.FlowContext, error) {
+
+	cloudProfileConfig, err := helper.CloudProfileConfigFromCluster(cluster)
+	if err != nil {
+		return nil, err
+	}
+
+	if oldState.MigratedFromTerraform() && !oldState.TerraformCleanedUp() {
+		err := a.cleanupTerraformerResources(ctx, log, infra)
+		if err != nil {
+			return nil, fmt.Errorf("cleaning up terraformer resources failed: %w", err)
+		}
+		oldState.SetTerraformCleanedUp()
+		if err := a.updateStatusState(ctx, infra, oldState); err != nil {
+			return nil, fmt.Errorf("updating status state failed: %w", err)
+		}
+	}
+
+	config, err := helper.InfrastructureConfigFromInfrastructure(infra)
+	if err != nil {
+		return nil, err
+	}
+
+	credentials, err := openstack.GetCredentials(ctx, a.Client(), infra.Spec.SecretRef, false)
+	if err != nil {
+		return nil, fmt.Errorf("could not get Openstack credentials: %w", err)
+	}
+	clientFactory, err := openstackclient.NewOpenstackClientFromCredentials(credentials)
+	if err != nil {
+		return nil, err
+	}
+
+	infraObjectKey := client.ObjectKey{
+		Namespace: infra.Namespace,
+		Name:      infra.Name,
+	}
+	persistor := func(ctx context.Context, flatState shared.FlatMap) error {
+		state := infraflow.NewPersistentStateFromFlatMap(flatState)
+		infra := &extensionsv1alpha1.Infrastructure{}
+		if err := a.Client().Get(ctx, infraObjectKey, infra); err != nil {
+			return err
+		}
+		return a.updateStatusState(ctx, infra, state)
+	}
+
+	if oldState != nil && !oldState.HasValidVersion() {
+		return nil, fmt.Errorf("unknown flow state version %s", oldState.FlowVersion)
+	}
+	var oldFlatState shared.FlatMap
+	if oldState != nil {
+		oldFlatState = oldState.ToFlatMap()
+	}
+
+	return infraflow.NewFlowContext(log, clientFactory, infra, config, cloudProfileConfig, oldFlatState, persistor)
+}
+
+func (a *actuator) updateStatusState(ctx context.Context, infra *extensionsv1alpha1.Infrastructure, state *infraflow.PersistentState) error {
+	config, err := helper.InfrastructureConfigFromInfrastructure(infra)
+	if err != nil {
+		return err
+	}
+
+	status, err := computeProviderStatusFromFlowState(config, state)
+	if err != nil {
+		return err
+	}
+
+	stateBytes, err := state.ToJSON()
+	if err != nil {
+		return err
+	}
+
+	return a.updateProviderStatus(ctx, infra, status, stateBytes)
+}
+
+func (a *actuator) cleanupTerraformerResources(ctx context.Context, log logr.Logger, infra *extensionsv1alpha1.Infrastructure) error {
+	credentials, err := openstack.GetCredentials(ctx, a.Client(), infra.Spec.SecretRef, false)
+	if err != nil {
+		return err
+	}
+
+	tf, err := internal.NewTerraformerWithAuth(log, a.RESTConfig(), infrastructure.TerraformerPurpose, infra, credentials, a.disableProjectedTokenMount)
+	if err != nil {
+		return fmt.Errorf("could not create terraformer object: %w", err)
+	}
+
+	if err := tf.CleanupConfiguration(ctx); err != nil {
+		return err
+	}
+	return tf.RemoveTerraformerFinalizerFromConfig(ctx)
+}
+
+func (a *actuator) reconcileWithTerraformer(ctx context.Context, log logr.Logger, infra *extensionsv1alpha1.Infrastructure, cluster *extensionscontroller.Cluster, stateInitializer terraformer.StateConfigMapInitializer) error {
 	config, err := helper.InfrastructureConfigFromInfrastructure(infra)
 	if err != nil {
 		return err
@@ -63,5 +221,49 @@ func (a *actuator) reconcile(ctx context.Context, log logr.Logger, infra *extens
 		return util.DetermineError(fmt.Errorf("failed to apply the terraform config: %w", err), helper.KnownCodes)
 	}
 
-	return a.updateProviderStatus(ctx, tf, infra, config)
+	return a.updateProviderStatusWithTerraformer(ctx, tf, infra, config)
+}
+
+func computeProviderStatusFromFlowState(config *api.InfrastructureConfig, state *infraflow.PersistentState) (*openstackv1alpha1.InfrastructureStatus, error) {
+	if len(state.Data) == 0 {
+		return nil, nil
+	}
+	status := &openstackv1alpha1.InfrastructureStatus{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: openstackv1alpha1.SchemeGroupVersion.String(),
+			Kind:       "InfrastructureStatus",
+		},
+	}
+
+	status.Networks.ID = shared.ValidValue(state.Data[infraflow.IdentifierNetwork])
+	status.Networks.Name = shared.ValidValue(state.Data[infraflow.NameNetwork])
+	status.Networks.Router.ID = shared.ValidValue(state.Data[infraflow.IdentifierRouter])
+	status.Networks.Router.IP = shared.ValidValue(state.Data[infraflow.RouterIP])
+	status.Networks.FloatingPool.ID = shared.ValidValue(state.Data[infraflow.IdentifierFloatingNetwork])
+	status.Networks.FloatingPool.Name = shared.ValidValue(state.Data[infraflow.NameFloatingNetwork])
+
+	subnetID := shared.ValidValue(state.Data[infraflow.IdentifierSubnet])
+	if subnetID != "" {
+		status.Networks.Subnets = []openstackv1alpha1.Subnet{
+			{
+				Purpose: openstackv1alpha1.PurposeNodes,
+				ID:      subnetID,
+			},
+		}
+	}
+
+	secGroupID := shared.ValidValue(state.Data[infraflow.IdentifierSecGroup])
+	if secGroupID != "" {
+		status.SecurityGroups = []openstackv1alpha1.SecurityGroup{
+			{
+				Purpose: openstackv1alpha1.PurposeNodes,
+				ID:      secGroupID,
+				Name:    shared.ValidValue(state.Data[infraflow.NameSecGroup]),
+			},
+		}
+	}
+
+	status.Node.KeyName = shared.ValidValue(state.Data[infraflow.NameKeyPair])
+
+	return status, nil
 }

--- a/pkg/controller/infrastructure/actuator_restore.go
+++ b/pkg/controller/infrastructure/actuator_restore.go
@@ -19,8 +19,11 @@ import (
 
 	"github.com/gardener/gardener/extensions/pkg/controller"
 	"github.com/gardener/gardener/extensions/pkg/terraformer"
+	"github.com/gardener/gardener/extensions/pkg/util"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/go-logr/logr"
+
+	"github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack/helper"
 )
 
 // Restore implements infrastructure.Actuator.
@@ -35,7 +38,7 @@ func (a *actuator) Restore(ctx context.Context, log logr.Logger, infra *extensio
 	if a.shouldUseFlow(infra, cluster) {
 		flowState, err = a.migrateFromTerraformerState(ctx, log, infra)
 		if err != nil {
-			return a.addErrorCodes(err)
+			return util.DetermineError(err, helper.KnownCodes)
 		}
 		return a.reconcileWithFlow(ctx, log, infra, cluster, flowState)
 	}

--- a/pkg/controller/infrastructure/infraflow/access/networking_access.go
+++ b/pkg/controller/infrastructure/infraflow/access/networking_access.go
@@ -1,0 +1,524 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package access
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"regexp"
+	"time"
+
+	"github.com/gardener/gardener-extension-provider-openstack/pkg/openstack/client"
+	"github.com/go-logr/logr"
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/networks"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/subnets"
+)
+
+// NetworkingAccess provides methods for managing routers and networks
+type NetworkingAccess interface {
+	// Routers
+	CreateRouter(desired *Router) (*Router, error)
+	GetRouterByID(id string) (*Router, error)
+	GetRouterByName(name string) ([]*Router, error)
+	UpdateRouter(desired, current *Router) (modified bool, err error)
+	LookupFloatingPoolSubnetIDs(networkID, floatingPoolSubnetNameRegex string) ([]string, error)
+	AddRouterInterfaceAndWait(ctx context.Context, routerID, subnetID string) error
+	GetRouterInterfacePortID(routerID string) (portID, subnetID *string, err error)
+	RemoveRouterInterfaceAndWait(ctx context.Context, routerID, subnetID, portID string) error
+
+	// Networks
+	CreateNetwork(desired *Network) (*Network, error)
+	GetNetworkByID(id string) (*Network, error)
+	GetNetworkByName(name string) ([]*Network, error)
+	UpdateNetwork(desired, current *Network) (modified bool, err error)
+
+	// Subnets
+	CreateSubnet(desired *subnets.Subnet) (*subnets.Subnet, error)
+	GetSubnetByID(id string) (*subnets.Subnet, error)
+	GetSubnetByName(networkID, name string) ([]*subnets.Subnet, error)
+	UpdateSubnet(desired, current *subnets.Subnet) (modified bool, err error)
+
+	// SecurityGroups
+	CreateSecurityGroup(desired *groups.SecGroup) (*groups.SecGroup, error)
+	GetSecurityGroupByID(id string) (*groups.SecGroup, error)
+	GetSecurityGroupByName(name string) ([]*groups.SecGroup, error)
+	UpdateSecurityGroup(desired, current *groups.SecGroup) (modified bool, err error)
+}
+
+// Router is a simplified router resource
+type Router struct {
+	ID                string
+	Name              string
+	ExternalNetworkID string
+	EnableSNAT        *bool
+	ExternalSubnetIDs []string
+
+	Status           string                    // only output
+	ExternalFixedIPs []routers.ExternalFixedIP // only output
+}
+
+// Network is a simplified network resource
+type Network struct {
+	ID           string
+	Name         string
+	AdminStateUp bool
+
+	Status string
+}
+
+const (
+	// SecurityGroupIDSelf special placeholder for self secgroup ID
+	SecurityGroupIDSelf = "self"
+)
+
+type networkingAccess struct {
+	networking client.Networking
+	log        logr.Logger
+}
+
+var _ NetworkingAccess = &networkingAccess{}
+
+// NewNetworkingAccess creates a new access object
+func NewNetworkingAccess(networking client.Networking, log logr.Logger) (NetworkingAccess, error) {
+	return &networkingAccess{
+		networking: networking,
+		log:        log,
+	}, nil
+}
+
+// CreateRouter creates a router.
+// If the input router object specifies external subnet ids, the router is created in the
+// first available subnet.
+func (a *networkingAccess) CreateRouter(desired *Router) (router *Router, err error) {
+	if len(desired.ExternalSubnetIDs) == 0 {
+		return a.tryCreateRouter(desired, nil)
+	}
+	// create router in first available subnet
+	for _, subnetID := range desired.ExternalSubnetIDs {
+		router, err = a.tryCreateRouter(desired, &subnetID)
+		if err != nil && !retryOn409(a.log, err) {
+			return
+		}
+		if err == nil {
+			break
+		}
+	}
+	return
+}
+
+func (a *networkingAccess) tryCreateRouter(desired *Router, subnetID *string) (*Router, error) {
+	options := routers.CreateOpts{
+		Name: desired.Name,
+		GatewayInfo: &routers.GatewayInfo{
+			NetworkID:  desired.ExternalNetworkID,
+			EnableSNAT: desired.EnableSNAT,
+		},
+	}
+	if subnetID != nil {
+		options.GatewayInfo.ExternalFixedIPs = []routers.ExternalFixedIP{{SubnetID: *subnetID}}
+	}
+	raw, err := a.networking.CreateRouter(options)
+	if err != nil {
+		return nil, err
+	}
+	return a.toRouter(raw), nil
+}
+
+// GetRouterByID retrieves router by identifier
+func (a *networkingAccess) GetRouterByID(id string) (*Router, error) {
+	routers, err := a.networking.ListRouters(routers.ListOpts{ID: id})
+	if err != nil {
+		return nil, err
+	}
+	if len(routers) == 0 {
+		return nil, nil
+	}
+	return a.toRouter(&routers[0]), nil
+}
+
+// GetRouterByName retrieves routers by name
+func (a *networkingAccess) GetRouterByName(name string) ([]*Router, error) {
+	routers, err := a.networking.ListRouters(routers.ListOpts{Name: name})
+	if err != nil {
+		return nil, err
+	}
+	var result []*Router
+	for _, raw := range routers {
+		result = append(result, a.toRouter(&raw))
+	}
+	return result, nil
+}
+
+func (a *networkingAccess) toRouter(raw *routers.Router) *Router {
+	router := &Router{
+		ID:                raw.ID,
+		Name:              raw.Name,
+		ExternalNetworkID: raw.GatewayInfo.NetworkID,
+		EnableSNAT:        raw.GatewayInfo.EnableSNAT,
+		Status:            raw.Status,
+		ExternalFixedIPs:  raw.GatewayInfo.ExternalFixedIPs,
+	}
+	return router
+}
+
+// UpdateRouter updates the router if important fields have changed
+func (a *networkingAccess) UpdateRouter(desired, current *Router) (modified bool, err error) {
+	updateOpts := routers.UpdateOpts{}
+	if desired.Name != current.Name {
+		modified = true
+		updateOpts.Name = desired.Name
+	}
+	if desired.ExternalNetworkID != current.ExternalNetworkID ||
+		(desired.EnableSNAT != nil && !reflect.DeepEqual(desired.EnableSNAT, current.EnableSNAT)) {
+		modified = true
+		updateOpts.GatewayInfo = &routers.GatewayInfo{
+			NetworkID:        desired.ExternalNetworkID,
+			EnableSNAT:       desired.EnableSNAT,
+			ExternalFixedIPs: current.ExternalFixedIPs, // unchanged
+		}
+	}
+	if modified {
+		_, err = a.networking.UpdateRouter(current.ID, updateOpts)
+	}
+	return
+}
+
+// AddRouterInterfaceAndWait adds router interface and waits up to
+func (a *networkingAccess) AddRouterInterfaceAndWait(ctx context.Context, routerID, subnetID string) error {
+	info, err := a.networking.AddRouterInterface(routerID, routers.AddInterfaceOpts{SubnetID: subnetID})
+	if err != nil {
+		return err
+	}
+	for {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		time.Sleep(1 * time.Second)
+		port, err := a.networking.GetPort(info.PortID)
+		if err != nil {
+			return err
+		}
+		switch port.Status {
+		case "BUILD", "PENDING_CREATE", "PENDING_UPDATE", "DOWN":
+			time.Sleep(3 * time.Second)
+			continue
+		case "ACTIVE":
+			return nil
+		default:
+			return fmt.Errorf("router interface has unexpected status: %s", port.Status)
+		}
+	}
+}
+
+func (a *networkingAccess) GetRouterInterfacePortID(routerID string) (portID, subnetID *string, err error) {
+	port, err := a.networking.GetRouterInterfacePort(routerID)
+	if err != nil {
+		return
+	}
+	if port == nil {
+		return
+	}
+	portID = &port.ID
+	if len(port.FixedIPs) == 1 {
+		subnetID = &port.FixedIPs[0].SubnetID
+	}
+	return
+}
+
+// RemoveRouterInterfaceAndWait removes the router interface. Either subnetID or portID must be specified
+func (a *networkingAccess) RemoveRouterInterfaceAndWait(ctx context.Context, routerID, subnetID, portID string) error {
+	for {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		_, err := a.networking.RemoveRouterInterface(routerID, routers.RemoveInterfaceOpts{SubnetID: subnetID, PortID: portID})
+		if err != nil {
+			if _, ok := err.(gophercloud.ErrDefault404); ok {
+				return nil
+			}
+			if _, ok := err.(gophercloud.ErrDefault409); !ok {
+				return err
+			}
+		}
+		if err == nil {
+			return nil
+		}
+		time.Sleep(3 * time.Second)
+	}
+}
+
+// LookupFloatingPoolSubnetIDs returns a list of subnet ids matching the given regex of the subnet name
+func (a *networkingAccess) LookupFloatingPoolSubnetIDs(networkID, floatingPoolSubnetNameRegex string) ([]string, error) {
+	allSubnets, err := a.networking.ListSubnets(subnets.ListOpts{
+		NetworkID: networkID,
+	})
+	if err != nil {
+		return nil, err
+	}
+	var subnetIDs []string
+	if floatingPoolSubnetNameRegex == "" {
+		for _, subnet := range allSubnets {
+			subnetIDs = append(subnetIDs, subnet.ID)
+		}
+		return subnetIDs, nil
+	}
+
+	r, err := regexp.Compile(floatingPoolSubnetNameRegex)
+	if err != nil {
+		return nil, err
+	}
+	for _, subnet := range allSubnets {
+		// Check for a very rare case where the response would include no
+		// subnet name. No name means nothing to attempt a match against,
+		// therefore we are skipping such subnet.
+		if subnet.Name == "" {
+			a.log.Info("[WARN] Unable to find subnet name to match against for subnet ID, nothing to do.",
+				"subnetID", subnet.ID)
+			continue
+		}
+		if r.MatchString(subnet.Name) {
+			subnetIDs = append(subnetIDs, subnet.ID)
+		}
+	}
+	return subnetIDs, nil
+}
+
+// CreateNetwork creates a private network
+func (a *networkingAccess) CreateNetwork(desired *Network) (*Network, error) {
+	raw, err := a.networking.CreateNetwork(networks.CreateOpts{
+		AdminStateUp: &desired.AdminStateUp,
+		Name:         desired.Name,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return a.toNetwork(raw), nil
+}
+
+// GetNetworkByID retrieves a network by identifer
+func (a *networkingAccess) GetNetworkByID(id string) (*Network, error) {
+	networks, err := a.networking.ListNetwork(networks.ListOpts{ID: id})
+	if err != nil {
+		return nil, err
+	}
+	if len(networks) == 0 {
+		return nil, nil
+	}
+	return a.toNetwork(&networks[0]), nil
+}
+
+// GetNetworkByName retrieves networks by name
+func (a *networkingAccess) GetNetworkByName(name string) ([]*Network, error) {
+	networks, err := a.networking.GetNetworkByName(name)
+	if err != nil {
+		return nil, err
+	}
+	var result []*Network
+	for _, raw := range networks {
+		result = append(result, a.toNetwork(&raw))
+	}
+	return result, nil
+}
+
+// UpdateNetwork updates a network
+func (a *networkingAccess) UpdateNetwork(desired, current *Network) (modified bool, err error) {
+	updateOpts := networks.UpdateOpts{}
+	if desired.Name != current.Name {
+		modified = true
+		updateOpts.Name = &desired.Name
+	}
+	if desired.AdminStateUp != current.AdminStateUp {
+		modified = true
+		updateOpts.AdminStateUp = &desired.AdminStateUp
+	}
+	if modified {
+		_, err = a.networking.UpdateNetwork(current.ID, updateOpts)
+	}
+	return
+}
+
+func (a *networkingAccess) toNetwork(raw *networks.Network) *Network {
+	return &Network{
+		ID:           raw.ID,
+		Name:         raw.Name,
+		AdminStateUp: raw.AdminStateUp,
+		Status:       raw.Status,
+	}
+}
+
+func (a *networkingAccess) CreateSubnet(desired *subnets.Subnet) (*subnets.Subnet, error) {
+	raw, err := a.networking.CreateSubnet(subnets.CreateOpts{
+		NetworkID:      desired.NetworkID,
+		CIDR:           desired.CIDR,
+		Name:           desired.Name,
+		IPVersion:      gophercloud.IPVersion(desired.IPVersion),
+		DNSNameservers: desired.DNSNameservers,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return raw, nil
+}
+
+func (a *networkingAccess) GetSubnetByID(id string) (*subnets.Subnet, error) {
+	list, err := a.networking.ListSubnets(subnets.ListOpts{ID: id})
+	if err != nil {
+		return nil, err
+	}
+	if len(list) == 0 {
+		return nil, nil
+	}
+	return &list[0], nil
+}
+
+func (a *networkingAccess) GetSubnetByName(networkID, name string) ([]*subnets.Subnet, error) {
+	list, err := a.networking.ListSubnets(subnets.ListOpts{NetworkID: networkID, Name: name})
+	if err != nil {
+		return nil, err
+	}
+	var result []*subnets.Subnet
+	for _, raw := range list {
+		copy := raw
+		result = append(result, &copy)
+	}
+	return result, nil
+}
+
+func (a *networkingAccess) UpdateSubnet(desired, current *subnets.Subnet) (modified bool, err error) {
+	updateOpts := subnets.UpdateOpts{}
+	if desired.Name != current.Name {
+		modified = true
+		updateOpts.Name = &desired.Name
+	}
+	if !reflect.DeepEqual(desired.DNSNameservers, current.DNSNameservers) {
+		modified = true
+		updateOpts.DNSNameservers = &desired.DNSNameservers
+	}
+	if modified {
+		_, err = a.networking.UpdateSubnet(current.ID, updateOpts)
+	}
+	return
+}
+
+func (a *networkingAccess) CreateSecurityGroup(desired *groups.SecGroup) (*groups.SecGroup, error) {
+	opts := groups.CreateOpts{
+		Name:        desired.Name,
+		Description: desired.Description,
+	}
+	sg, err := a.networking.CreateSecurityGroup(opts)
+	if err != nil {
+		return nil, err
+	}
+	if _, err = a.UpdateSecurityGroup(desired, sg); err != nil {
+		return nil, err
+	}
+	return a.GetSecurityGroupByID(sg.ID)
+}
+
+func (a *networkingAccess) GetSecurityGroupByID(id string) (*groups.SecGroup, error) {
+	sg, err := a.networking.GetSecurityGroup(id)
+	return sg, client.IgnoreNotFoundError(err)
+}
+
+func (a *networkingAccess) GetSecurityGroupByName(name string) ([]*groups.SecGroup, error) {
+	list, err := a.networking.ListSecurityGroup(groups.ListOpts{Name: name})
+	if err != nil {
+		return nil, err
+	}
+	var result []*groups.SecGroup
+	for _, raw := range list {
+		copy := raw
+		result = append(result, &copy)
+	}
+	return result, nil
+}
+
+func (a *networkingAccess) UpdateSecurityGroup(desired, current *groups.SecGroup) (modified bool, err error) {
+	for i := range desired.Rules {
+		rule := &desired.Rules[i]
+		rule.SecGroupID = current.ID
+		rule.ProjectID = current.ProjectID
+		rule.TenantID = current.TenantID
+		if rule.RemoteGroupID == SecurityGroupIDSelf {
+			rule.RemoteGroupID = current.ID
+		}
+	}
+
+	for i := range current.Rules {
+		rule := &current.Rules[i]
+		if desiredRule := a.findMatchingRule(rule, desired.Rules); desiredRule == nil {
+			if err = a.networking.DeleteRule(rule.ID); err != nil {
+				err = fmt.Errorf("Error deleting rule for security group %s: %s", rule.ID, err)
+				return
+			}
+			modified = true
+		} else {
+			desiredRule.ID = rule.ID // mark as found
+		}
+	}
+	for i := range desired.Rules {
+		rule := &desired.Rules[i]
+		if rule.ID != "" {
+			// ignore found rules
+			continue
+		}
+		createOpts := rules.CreateOpts{
+			Direction:      rules.RuleDirection(rule.Direction),
+			Description:    rule.Description,
+			EtherType:      rules.RuleEtherType(rule.EtherType),
+			SecGroupID:     rule.SecGroupID,
+			PortRangeMax:   rule.PortRangeMax,
+			PortRangeMin:   rule.PortRangeMin,
+			Protocol:       rules.RuleProtocol(rule.Protocol),
+			RemoteGroupID:  rule.RemoteGroupID,
+			RemoteIPPrefix: rule.RemoteIPPrefix,
+			ProjectID:      rule.ProjectID,
+		}
+		if _, err = a.networking.CreateRule(createOpts); err != nil {
+			err = fmt.Errorf("Error creating rule %d for security group: %s", i, err)
+			return
+		}
+		modified = true
+	}
+	return
+}
+
+func (a *networkingAccess) findMatchingRule(rule *rules.SecGroupRule, desiredRules []rules.SecGroupRule) *rules.SecGroupRule {
+	for i := range desiredRules {
+		desired := &desiredRules[i]
+		if desired.ID != "" {
+			// ignore already found rules
+			continue
+		}
+		if rule.Direction == desired.Direction &&
+			rule.EtherType == desired.EtherType &&
+			rule.Protocol == desired.Protocol &&
+			rule.RemoteIPPrefix == desired.RemoteIPPrefix &&
+			rule.RemoteGroupID == desired.RemoteGroupID &&
+			rule.PortRangeMin == desired.PortRangeMin &&
+			rule.PortRangeMax == desired.PortRangeMax &&
+			rule.Description == desired.Description &&
+			rule.ProjectID == desired.ProjectID &&
+			rule.TenantID == desired.TenantID {
+			return desired
+		}
+	}
+	return nil
+}

--- a/pkg/controller/infrastructure/infraflow/access/networking_access.go
+++ b/pkg/controller/infrastructure/infraflow/access/networking_access.go
@@ -21,7 +21,6 @@ import (
 	"regexp"
 	"time"
 
-	"github.com/gardener/gardener-extension-provider-openstack/pkg/openstack/client"
 	"github.com/go-logr/logr"
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers"
@@ -29,6 +28,8 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/networks"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/subnets"
+
+	"github.com/gardener/gardener-extension-provider-openstack/pkg/openstack/client"
 )
 
 // NetworkingAccess provides methods for managing routers and networks

--- a/pkg/controller/infrastructure/infraflow/access/networking_access.go
+++ b/pkg/controller/infrastructure/infraflow/access/networking_access.go
@@ -396,8 +396,8 @@ func (a *networkingAccess) GetSubnetByName(networkID, name string) ([]*subnets.S
 	}
 	var result []*subnets.Subnet
 	for _, raw := range list {
-		copy := raw
-		result = append(result, &copy)
+		tmp := raw
+		result = append(result, &tmp)
 	}
 	return result, nil
 }
@@ -445,8 +445,8 @@ func (a *networkingAccess) GetSecurityGroupByName(name string) ([]*groups.SecGro
 	}
 	var result []*groups.SecGroup
 	for _, raw := range list {
-		copy := raw
-		result = append(result, &copy)
+		tmp := raw
+		result = append(result, &tmp)
 	}
 	return result, nil
 }

--- a/pkg/controller/infrastructure/infraflow/access/retry.go
+++ b/pkg/controller/infrastructure/infraflow/access/retry.go
@@ -33,13 +33,13 @@ type neutronError struct {
 	Detail  string `json:"detail"`
 }
 
-func retryOn409(log logr.Logger, err error) bool {
+func retryOnError(log logr.Logger, err error) bool {
 	switch err := err.(type) {
 	case gophercloud.ErrDefault409:
 		neutronError, e := decodeNeutronError(err.ErrUnexpectedResponseCode.Body)
 		if e != nil {
 			// retry, when error type cannot be detected
-			log.Info("[DEBUG] failed to decode a neutron error", "error", e)
+			log.V(4).Info("[DEBUG] failed to decode a neutron error", "error", e)
 			return true
 		}
 		if neutronError.Type == "IpAddressGenerationFailure" {
@@ -52,7 +52,7 @@ func retryOn409(log logr.Logger, err error) bool {
 		neutronError, e := decodeNeutronError(err.ErrUnexpectedResponseCode.Body)
 		if e != nil {
 			// retry, when error type cannot be detected
-			log.Info("[DEBUG] failed to decode a neutron error", "error", e)
+			log.V(4).Info("[DEBUG] failed to decode a neutron error", "error", e)
 			return true
 		}
 		if neutronError.Type == "ExternalIpAddressExhausted" {

--- a/pkg/controller/infrastructure/infraflow/access/retry.go
+++ b/pkg/controller/infrastructure/infraflow/access/retry.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package access
+
+import (
+	"encoding/json"
+
+	"github.com/go-logr/logr"
+	"github.com/gophercloud/gophercloud"
+)
+
+// following https://github.com/terraform-provider-openstack/terraform-provider-openstack/blob/cec35ae29769b4de7d84980b1335a2b723ffb15f/openstack/networking_v2_shared.go
+
+type neutronErrorWrap struct {
+	NeutronError neutronError
+}
+
+type neutronError struct {
+	Message string `json:"message"`
+	Type    string `json:"type"`
+	Detail  string `json:"detail"`
+}
+
+func retryOn409(log logr.Logger, err error) bool {
+	switch err := err.(type) {
+	case gophercloud.ErrDefault409:
+		neutronError, e := decodeNeutronError(err.ErrUnexpectedResponseCode.Body)
+		if e != nil {
+			// retry, when error type cannot be detected
+			log.Info("[DEBUG] failed to decode a neutron error", "error", e)
+			return true
+		}
+		if neutronError.Type == "IpAddressGenerationFailure" {
+			return true
+		}
+
+		// don't retry on quota or other errors
+		return false
+	case gophercloud.ErrDefault400:
+		neutronError, e := decodeNeutronError(err.ErrUnexpectedResponseCode.Body)
+		if e != nil {
+			// retry, when error type cannot be detected
+			log.Info("[DEBUG] failed to decode a neutron error", "error", e)
+			return true
+		}
+		if neutronError.Type == "ExternalIpAddressExhausted" {
+			return true
+		}
+
+		// don't retry on quota or other errors
+		return false
+	case gophercloud.ErrDefault404: // this case is handled mostly for functional tests
+		return true
+	}
+
+	return false
+}
+
+func decodeNeutronError(body []byte) (*neutronError, error) {
+	e := &neutronErrorWrap{}
+	if err := json.Unmarshal(body, e); err != nil {
+		return nil, err
+	}
+
+	return &e.NeutronError, nil
+}

--- a/pkg/controller/infrastructure/infraflow/context.go
+++ b/pkg/controller/infrastructure/infraflow/context.go
@@ -53,6 +53,9 @@ const (
 	// RouterIP is the key for the router IP address
 	RouterIP = "RouterIP"
 
+	// ObjectSecGroup is the key for the cached security group
+	ObjectSecGroup = "SecurityGroup"
+
 	// MarkerMigratedFromTerraform is the key for marking the state for successful state migration from Terraformer
 	MarkerMigratedFromTerraform = "MigratedFromTerraform"
 	// MarkerTerraformCleanedUp is the key for marking the state for successful cleanup of Terraformer resources.

--- a/pkg/controller/infrastructure/infraflow/context.go
+++ b/pkg/controller/infrastructure/infraflow/context.go
@@ -1,0 +1,115 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package infraflow
+
+import (
+	"fmt"
+
+	openstackapi "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack"
+	"github.com/gardener/gardener-extension-provider-openstack/pkg/controller/infrastructure/infraflow/access"
+	"github.com/gardener/gardener-extension-provider-openstack/pkg/controller/infrastructure/infraflow/shared"
+	osclient "github.com/gardener/gardener-extension-provider-openstack/pkg/openstack/client"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/go-logr/logr"
+)
+
+const (
+
+	// IdentifierRouter is the key for the router id
+	IdentifierRouter = "Router"
+	// IdentifierNetwork is the key for the network id
+	IdentifierNetwork = "Network"
+	// IdentifierSubnet is the key for the subnet id
+	IdentifierSubnet = "Subnet"
+	// IdentifierFloatingNetwork is the key for the floating network id
+	IdentifierFloatingNetwork = "FloatingNetwork"
+	// IdentifierSecGroup is the key for the security group id
+	IdentifierSecGroup = "SecurityGroup"
+
+	// NameFloatingNetwork is the key for the floating network name
+	NameFloatingNetwork = "FloatingNetworkName"
+	// NameFloatingPoolSubnet is the name/regex for the floating pool subnets
+	NameFloatingPoolSubnet = "FloatingPoolSubnetName"
+	// NameNetwork is the name of the network
+	NameNetwork = "NetworkName"
+	// NameKeyPair is the key for the name of the EC2 key pair resource
+	NameKeyPair = "KeyPair"
+	// NameSecGroup is the name of the security group
+	NameSecGroup = "SecurityGroupName"
+
+	// RouterIP is the key for the router IP address
+	RouterIP = "RouterIP"
+
+	// MarkerMigratedFromTerraform is the key for marking the state for successful state migration from Terraformer
+	MarkerMigratedFromTerraform = "MigratedFromTerraform"
+	// MarkerTerraformCleanedUp is the key for marking the state for successful cleanup of Terraformer resources.
+	MarkerTerraformCleanedUp = "TerraformCleanedUp"
+)
+
+// FlowContext contains the logic to reconcile or delete the AWS infrastructure.
+type FlowContext struct {
+	shared.BasicFlowContext
+	state              shared.Whiteboard
+	namespace          string
+	infraSpec          extensionsv1alpha1.InfrastructureSpec
+	config             *openstackapi.InfrastructureConfig
+	cloudProfileConfig *openstackapi.CloudProfileConfig
+	networking         osclient.Networking
+	access             access.NetworkingAccess
+	compute            osclient.Compute
+}
+
+// NewFlowContext creates a new FlowContext object
+func NewFlowContext(log logr.Logger, clientFactory osclient.Factory,
+	infra *extensionsv1alpha1.Infrastructure, config *openstackapi.InfrastructureConfig,
+	cloudProfileConfig *openstackapi.CloudProfileConfig,
+	oldState shared.FlatMap, persistor shared.FlowStatePersistor) (*FlowContext, error) {
+
+	whiteboard := shared.NewWhiteboard()
+	if oldState != nil {
+		whiteboard.ImportFromFlatMap(oldState)
+	}
+
+	networking, err := clientFactory.Networking(osclient.WithRegion(infra.Spec.Region))
+	if err != nil {
+		return nil, fmt.Errorf("creating networking client failed: %w", err)
+	}
+	access, err := access.NewNetworkingAccess(networking, log)
+	if err != nil {
+		return nil, fmt.Errorf("creating networking access failed: %w", err)
+	}
+	compute, err := clientFactory.Compute(osclient.WithRegion(infra.Spec.Region))
+	if err != nil {
+		return nil, fmt.Errorf("creating compute client failed: %w", err)
+	}
+
+	flowContext := &FlowContext{
+		BasicFlowContext:   *shared.NewBasicFlowContext(log, whiteboard, persistor),
+		state:              whiteboard,
+		namespace:          infra.Namespace,
+		infraSpec:          infra.Spec,
+		config:             config,
+		cloudProfileConfig: cloudProfileConfig,
+		networking:         networking,
+		access:             access,
+		compute:            compute,
+	}
+	return flowContext, nil
+}
+
+// GetInfrastructureConfig returns the InfrastructureConfig object
+func (c *FlowContext) GetInfrastructureConfig() *openstackapi.InfrastructureConfig {
+	return c.config
+}

--- a/pkg/controller/infrastructure/infraflow/context.go
+++ b/pkg/controller/infrastructure/infraflow/context.go
@@ -17,12 +17,13 @@ package infraflow
 import (
 	"fmt"
 
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/go-logr/logr"
+
 	openstackapi "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack"
 	"github.com/gardener/gardener-extension-provider-openstack/pkg/controller/infrastructure/infraflow/access"
 	"github.com/gardener/gardener-extension-provider-openstack/pkg/controller/infrastructure/infraflow/shared"
 	osclient "github.com/gardener/gardener-extension-provider-openstack/pkg/openstack/client"
-	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
-	"github.com/go-logr/logr"
 )
 
 const (

--- a/pkg/controller/infrastructure/infraflow/delete.go
+++ b/pkg/controller/infrastructure/infraflow/delete.go
@@ -1,0 +1,197 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package infraflow
+
+import (
+	"context"
+
+	. "github.com/gardener/gardener-extension-provider-openstack/pkg/controller/infrastructure/infraflow/shared"
+	"github.com/gardener/gardener/pkg/utils/flow"
+)
+
+// Delete creates and runs the flow to delete the AWS infrastructure.
+func (c *FlowContext) Delete(ctx context.Context) error {
+	if c.state.IsEmpty() {
+		// nothing to do, e.g. if cluster was created with wrong credentials
+		return nil
+	}
+	g := c.buildDeleteGraph()
+	f := g.Compile()
+	if err := f.Run(ctx, flow.Opts{Log: c.Log}); err != nil {
+		return flow.Causes(err)
+	}
+	return nil
+}
+
+func (c *FlowContext) buildDeleteGraph() *flow.Graph {
+	g := flow.NewGraph("Openstack infrastructure destruction")
+
+	needToDeleteNetwork := c.config.Networks.ID == nil
+	needToDeleteRouter := c.config.Networks.Router == nil
+
+	_ = c.AddTask(g, "delete ssh key pair",
+		c.deleteSSHKeyPair,
+		Timeout(defaultTimeout))
+	_ = c.AddTask(g, "delete security group",
+		c.deleteSecGroup,
+		Timeout(defaultTimeout))
+	deleteRouterInterface := c.AddTask(g, "delete router interface",
+		c.deleteRouterInterface,
+		Timeout(defaultTimeout))
+	// subnet deletion only needed if network is given by spec
+	_ = c.AddTask(g, "delete subnet",
+		c.deleteSubnet,
+		DoIf(!needToDeleteNetwork), Timeout(defaultTimeout), Dependencies(deleteRouterInterface))
+	_ = c.AddTask(g, "delete network",
+		c.deleteNetwork,
+		DoIf(needToDeleteNetwork), Timeout(defaultTimeout), Dependencies(deleteRouterInterface))
+	_ = c.AddTask(g, "delete router",
+		c.deleteRouter,
+		DoIf(needToDeleteRouter), Timeout(defaultTimeout), Dependencies(deleteRouterInterface))
+
+	return g
+}
+
+func (c *FlowContext) hasRouter() bool {
+	return !c.state.IsAlreadyDeleted(IdentifierRouter)
+}
+
+func (c *FlowContext) deleteRouter(ctx context.Context) error {
+	if c.state.IsAlreadyDeleted(IdentifierRouter) {
+		return nil
+	}
+	log := c.LogFromContext(ctx)
+	current, err := c.findExistingRouter()
+	if err != nil {
+		return err
+	}
+	if current != nil {
+		log.Info("deleting...", "router", current.ID)
+		if err := c.networking.DeleteRouter(current.ID); err != nil {
+			return err
+		}
+	}
+	c.state.SetAsDeleted(IdentifierRouter)
+	c.state.SetAsDeleted(RouterIP)
+	return nil
+}
+
+func (c *FlowContext) deleteNetwork(ctx context.Context) error {
+	if c.state.IsAlreadyDeleted(IdentifierNetwork) {
+		return nil
+	}
+	log := c.LogFromContext(ctx)
+	current, err := c.findExistingNetwork()
+	if err != nil {
+		return err
+	}
+	if current != nil {
+		log.Info("deleting...", "network", current.ID)
+		if err := c.networking.DeleteNetwork(current.ID); err != nil {
+			return err
+		}
+	}
+	c.state.SetAsDeleted(IdentifierNetwork)
+	c.state.SetAsDeleted(IdentifierSubnet)
+	c.state.Set(NameNetwork, "")
+	return nil
+}
+
+func (c *FlowContext) deleteSubnet(ctx context.Context) error {
+	if c.state.IsAlreadyDeleted(IdentifierSubnet) {
+		return nil
+	}
+	log := c.LogFromContext(ctx)
+	current, err := c.findExistingSubnet()
+	if err != nil {
+		return err
+	}
+	if current != nil {
+		log.Info("deleting...", "subnet", current.ID)
+		if err := c.networking.DeleteSubnet(current.ID); err != nil {
+			return err
+		}
+	}
+	c.state.SetAsDeleted(IdentifierSubnet)
+	return nil
+}
+
+func (c *FlowContext) deleteRouterInterface(ctx context.Context) error {
+	if c.state.IsAlreadyDeleted(IdentifierNetwork) && c.state.IsAlreadyDeleted(IdentifierRouter) {
+		return nil
+	}
+
+	routerID, subnetID, err := c.getExistingRouterAndSubnetIDs()
+	if err != nil {
+		return ignoreNotFound(err)
+	}
+
+	portID, _, err := c.access.GetRouterInterfacePortID(routerID)
+	if err != nil {
+		return err
+	}
+	if portID == nil {
+		return nil
+	}
+
+	log := c.LogFromContext(ctx)
+	log.Info("deleting...")
+	err = c.access.RemoveRouterInterfaceAndWait(ctx, routerID, subnetID, *portID)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *FlowContext) deleteSecGroup(ctx context.Context) error {
+	if c.state.IsAlreadyDeleted(IdentifierSecGroup) {
+		return nil
+	}
+
+	log := c.LogFromContext(ctx)
+	current, err := findExisting(c.state.Get(IdentifierSecGroup), c.namespace, c.access.GetSecurityGroupByID, c.access.GetSecurityGroupByName)
+	if err != nil {
+		return err
+	}
+	if current != nil {
+		log.Info("deleting...", "securityGroup", current.ID)
+		if err := c.networking.DeleteSecurityGroup(current.ID); err != nil {
+			return err
+		}
+	}
+	c.state.SetAsDeleted(IdentifierSecGroup)
+	c.state.Set(NameSecGroup, "")
+	return nil
+}
+
+func (c *FlowContext) deleteSSHKeyPair(ctx context.Context) error {
+	if c.state.IsAlreadyDeleted(NameKeyPair) {
+		return nil
+	}
+
+	log := c.LogFromContext(ctx)
+	current, err := c.compute.GetKeyPair(c.namespace)
+	if err != nil {
+		return err
+	}
+	if current != nil {
+		log.Info("deleting...")
+		if err := c.compute.DeleteKeyPair(current.Name); err != nil {
+			return err
+		}
+	}
+	c.state.SetAsDeleted(NameKeyPair)
+	return nil
+}

--- a/pkg/controller/infrastructure/infraflow/delete.go
+++ b/pkg/controller/infrastructure/infraflow/delete.go
@@ -17,8 +17,9 @@ package infraflow
 import (
 	"context"
 
-	. "github.com/gardener/gardener-extension-provider-openstack/pkg/controller/infrastructure/infraflow/shared"
 	"github.com/gardener/gardener/pkg/utils/flow"
+
+	. "github.com/gardener/gardener-extension-provider-openstack/pkg/controller/infrastructure/infraflow/shared"
 )
 
 // Delete creates and runs the flow to delete the AWS infrastructure.

--- a/pkg/controller/infrastructure/infraflow/persistent_state.go
+++ b/pkg/controller/infrastructure/infraflow/persistent_state.go
@@ -1,0 +1,116 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package infraflow
+
+import (
+	"fmt"
+
+	"github.com/gardener/gardener-extension-provider-openstack/pkg/controller/infrastructure/infraflow/shared"
+	"k8s.io/apimachinery/pkg/util/json"
+)
+
+const (
+	// PersistentStateVersion is the current version used for persisting the state.
+	PersistentStateVersion = "1.0"
+)
+
+type persistentStateMarker struct {
+	FlowVersion string `json:"flowVersion"`
+}
+
+// PersistentState is the state which is persisted as part of the infrastructure status.
+type PersistentState struct {
+	FlowVersion string `json:"flowVersion"`
+
+	Data map[string]string `json:"data"`
+}
+
+// NewPersistentState creates empty PersistentState
+func NewPersistentState() *PersistentState {
+	return &PersistentState{
+		FlowVersion: PersistentStateVersion,
+		Data:        map[string]string{},
+	}
+}
+
+// NewPersistentStateFromJSON unmarshals PersistentState from JSON or YAML.
+// Returns nil if input contains no "flowVersion" field.
+func NewPersistentStateFromJSON(raw []byte) (*PersistentState, error) {
+	// first check if state is from flow or Terraformer
+	marker := &persistentStateMarker{}
+	if err := json.Unmarshal(raw, marker); err != nil {
+		return nil, err
+	}
+	if marker.FlowVersion == "" {
+		// no flow state
+		return nil, nil
+	}
+
+	state := &PersistentState{}
+	if err := json.Unmarshal(raw, state); err != nil {
+		return nil, err
+	}
+	if !state.HasValidVersion() {
+		return nil, fmt.Errorf("unsupported flowVersion %s", state.FlowVersion)
+	}
+
+	if state.Data == nil {
+		state.Data = map[string]string{}
+	}
+	return state, nil
+}
+
+// NewPersistentStateFromFlatMap create new PersistentState and initialises data from input.
+func NewPersistentStateFromFlatMap(flatState shared.FlatMap) *PersistentState {
+	state := NewPersistentState()
+
+	state.Data = copyMap(flatState)
+	return state
+}
+
+// HasValidVersion checks if flow version is supported.
+func (s *PersistentState) HasValidVersion() bool {
+	return s != nil && s.FlowVersion == PersistentStateVersion
+}
+
+// ToFlatMap returns a copy of state as FlatMap
+func (s *PersistentState) ToFlatMap() shared.FlatMap {
+	return copyMap(s.Data)
+}
+
+// ToJSON marshals state as JSON
+func (s *PersistentState) ToJSON() ([]byte, error) {
+	return json.Marshal(s)
+}
+
+// MigratedFromTerraform returns trus if marker MarkerMigratedFromTerraform is set.
+func (s *PersistentState) MigratedFromTerraform() bool {
+	return s.Data[MarkerMigratedFromTerraform] == "true"
+}
+
+// SetMigratedFromTerraform sets the marker MarkerMigratedFromTerraform
+func (s *PersistentState) SetMigratedFromTerraform() {
+	s.Data[MarkerMigratedFromTerraform] = "true"
+}
+
+// TerraformCleanedUp returns trus if marker MarkerTerraformCleanedUp is set.
+func (s *PersistentState) TerraformCleanedUp() bool {
+	return s.Data[MarkerTerraformCleanedUp] == "true"
+}
+
+// SetTerraformCleanedUp sets the marker MarkerTerraformCleanedUp
+func (s *PersistentState) SetTerraformCleanedUp() {
+	s.Data[MarkerTerraformCleanedUp] = "true"
+}

--- a/pkg/controller/infrastructure/infraflow/persistent_state.go
+++ b/pkg/controller/infrastructure/infraflow/persistent_state.go
@@ -16,23 +16,27 @@ package infraflow
 
 import (
 	"fmt"
+	"strings"
 
-	"github.com/gardener/gardener-extension-provider-openstack/pkg/controller/infrastructure/infraflow/shared"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/json"
+
+	"github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack"
+	"github.com/gardener/gardener-extension-provider-openstack/pkg/controller/infrastructure/infraflow/shared"
 )
 
 const (
 	// PersistentStateVersion is the current version used for persisting the state.
-	PersistentStateVersion = "1.0"
+	PersistentStateVersion = "v1alpha1"
+	// PersistentStateAPIVersion is the APIVersion used for the persistent state
+	PersistentStateAPIVersion = openstack.GroupName + "/" + PersistentStateVersion
+	// PersistentStateKind is the kind name for the persistent state
+	PersistentStateKind = "FlowState"
 )
-
-type persistentStateMarker struct {
-	FlowVersion string `json:"flowVersion"`
-}
 
 // PersistentState is the state which is persisted as part of the infrastructure status.
 type PersistentState struct {
-	FlowVersion string `json:"flowVersion"`
+	metav1.TypeMeta
 
 	Data map[string]string `json:"data"`
 }
@@ -40,30 +44,36 @@ type PersistentState struct {
 // NewPersistentState creates empty PersistentState
 func NewPersistentState() *PersistentState {
 	return &PersistentState{
-		FlowVersion: PersistentStateVersion,
-		Data:        map[string]string{},
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: PersistentStateAPIVersion,
+			Kind:       PersistentStateKind,
+		},
+		Data: map[string]string{},
 	}
 }
 
 // NewPersistentStateFromJSON unmarshals PersistentState from JSON or YAML.
-// Returns nil if input contains no "flowVersion" field.
+// Returns nil if input contains no kind field with value "FlowState".
 func NewPersistentStateFromJSON(raw []byte) (*PersistentState, error) {
 	// first check if state is from flow or Terraformer
-	marker := &persistentStateMarker{}
+	marker := &metav1.TypeMeta{}
 	if err := json.Unmarshal(raw, marker); err != nil {
 		return nil, err
 	}
-	if marker.FlowVersion == "" {
+	if marker.Kind == "" {
 		// no flow state
 		return nil, nil
+	}
+	if marker.Kind != PersistentStateKind || !strings.HasPrefix(marker.APIVersion, openstack.GroupName) {
+		return nil, fmt.Errorf("unknown kind or group: kind=%s, apiVersion=%s", marker.Kind, marker.APIVersion)
 	}
 
 	state := &PersistentState{}
 	if err := json.Unmarshal(raw, state); err != nil {
 		return nil, err
 	}
-	if !state.HasValidVersion() {
-		return nil, fmt.Errorf("unsupported flowVersion %s", state.FlowVersion)
+	if valid, err := state.HasValidVersion(); !valid {
+		return nil, err
 	}
 
 	if state.Data == nil {
@@ -81,8 +91,12 @@ func NewPersistentStateFromFlatMap(flatState shared.FlatMap) *PersistentState {
 }
 
 // HasValidVersion checks if flow version is supported.
-func (s *PersistentState) HasValidVersion() bool {
-	return s != nil && s.FlowVersion == PersistentStateVersion
+func (s *PersistentState) HasValidVersion() (valid bool, err error) {
+	valid = s != nil && s.Kind == PersistentStateKind && s.APIVersion == PersistentStateAPIVersion
+	if !valid {
+		err = fmt.Errorf("unsupported APIVersion %s for kind %s", s.APIVersion, s.Kind)
+	}
+	return
 }
 
 // ToFlatMap returns a copy of state as FlatMap

--- a/pkg/controller/infrastructure/infraflow/reconcile.go
+++ b/pkg/controller/infrastructure/infraflow/reconcile.go
@@ -1,0 +1,468 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package infraflow
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack/helper"
+	"github.com/gardener/gardener-extension-provider-openstack/pkg/controller/infrastructure/infraflow/access"
+	. "github.com/gardener/gardener-extension-provider-openstack/pkg/controller/infrastructure/infraflow/shared"
+	"github.com/gardener/gardener/pkg/utils/flow"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/subnets"
+)
+
+const (
+	defaultTimeout     = 90 * time.Second
+	defaultLongTimeout = 3 * time.Minute
+)
+
+// Reconcile creates and runs the flow to reconcile the AWS infrastructure.
+func (c *FlowContext) Reconcile(ctx context.Context) error {
+	g := c.buildReconcileGraph()
+	f := g.Compile()
+	if err := f.Run(ctx, flow.Opts{Log: c.Log}); err != nil {
+		return flow.Causes(err)
+	}
+	return nil
+}
+
+func (c *FlowContext) buildReconcileGraph() *flow.Graph {
+	//createNetwork := c.config.Networks.ID == nil
+	g := flow.NewGraph("Openstack infrastructure reconcilation")
+
+	ensureRouter := c.AddTask(g, "ensure router",
+		c.ensureRouter,
+		Timeout(defaultTimeout))
+
+	ensureNetwork := c.AddTask(g, "ensure network",
+		c.ensureNetwork,
+		Timeout(defaultTimeout))
+
+	ensureSubnet := c.AddTask(g, "ensure subnet",
+		c.ensureSubnet,
+		Timeout(defaultTimeout), Dependencies(ensureNetwork))
+
+	_ = c.AddTask(g, "ensure router interface",
+		c.ensureRouterInterface,
+		Timeout(defaultTimeout), Dependencies(ensureRouter, ensureSubnet))
+
+	_ = c.AddTask(g, "ensure security group",
+		c.ensureSecGroup,
+		Timeout(defaultTimeout), Dependencies(ensureRouter))
+
+	_ = c.AddTask(g, "ensure ssh key pair",
+		c.ensureSSHKeyPair,
+		Timeout(defaultTimeout), Dependencies(ensureRouter))
+
+	return g
+}
+
+func unused(_ any) {}
+
+func (c *FlowContext) ensureRouter(ctx context.Context) error {
+	externalNetwork, err := c.networking.GetExternalNetworkByName(c.config.FloatingPoolName)
+	if err != nil {
+		return err
+	}
+	if externalNetwork == nil {
+		return fmt.Errorf("external network for floating pool name %s not found", c.config.FloatingPoolName)
+	}
+	c.state.Set(IdentifierFloatingNetwork, externalNetwork.ID)
+	c.state.Set(NameFloatingNetwork, externalNetwork.Name)
+
+	if c.config.Networks.Router != nil {
+		return c.ensureConfiguredRouter(ctx)
+	}
+	return c.ensureNewRouter(ctx, externalNetwork.ID)
+}
+
+func (c *FlowContext) ensureConfiguredRouter(_ context.Context) error {
+	router, err := c.access.GetRouterByID(c.config.Networks.Router.ID)
+	if err != nil {
+		c.state.Set(IdentifierRouter, "")
+		return err
+	}
+	c.state.Set(IdentifierRouter, c.config.Networks.Router.ID)
+	c.state.Set(RouterIP, router.ExternalFixedIPs[0].IPAddress)
+	return nil
+}
+
+func (c *FlowContext) ensureNewRouter(ctx context.Context, externalNetworkID string) error {
+	log := c.LogFromContext(ctx)
+
+	desired := &access.Router{
+		Name:              c.namespace,
+		ExternalNetworkID: externalNetworkID,
+		EnableSNAT:        c.cloudProfileConfig.UseSNAT,
+	}
+	current, err := c.findExistingRouter()
+	if err != nil {
+		return err
+	}
+	if current != nil {
+		c.state.Set(IdentifierRouter, current.ID)
+		c.state.Set(RouterIP, current.ExternalFixedIPs[0].IPAddress)
+		if _, err := c.access.UpdateRouter(desired, current); err != nil {
+			return err
+		}
+	} else {
+		floatingPoolSubnetName := c.findFloatingPoolSubnetName()
+		c.state.SetPtr(NameFloatingPoolSubnet, floatingPoolSubnetName)
+		if floatingPoolSubnetName != nil {
+			log.Info("looking up floating pool subnets...")
+			desired.ExternalSubnetIDs, err = c.access.LookupFloatingPoolSubnetIDs(externalNetworkID, *floatingPoolSubnetName)
+			if err != nil {
+				return err
+			}
+		}
+		log.Info("creating...")
+		created, err := c.access.CreateRouter(desired)
+		if err != nil {
+			return err
+		}
+		c.state.Set(IdentifierRouter, created.ID)
+		c.state.Set(RouterIP, created.ExternalFixedIPs[0].IPAddress)
+	}
+
+	return nil
+}
+
+func (c *FlowContext) findExistingRouter() (*access.Router, error) {
+	return findExisting(c.state.Get(IdentifierRouter), c.namespace, c.access.GetRouterByID, c.access.GetRouterByName)
+}
+
+func (c *FlowContext) getRouterID() (*string, error) {
+	if c.config.Networks.Router != nil {
+		return &c.config.Networks.Router.ID, nil
+	}
+	routerID := c.state.Get(IdentifierRouter)
+	if routerID != nil {
+		return routerID, nil
+	}
+	router, err := c.findExistingRouter()
+	if err != nil {
+		return nil, err
+	}
+	if router != nil {
+		c.state.Set(IdentifierRouter, router.ID)
+		c.state.Set(RouterIP, router.ExternalFixedIPs[0].IPAddress)
+		return &router.ID, nil
+	}
+	return nil, nil
+}
+
+func (c *FlowContext) findFloatingPoolSubnetName() *string {
+	if c.config.FloatingPoolSubnetName != nil {
+		return c.config.FloatingPoolSubnetName
+	}
+
+	// Second: Check if the CloudProfile contains a default floating subnet and use it.
+	if floatingPool, err := helper.FindFloatingPool(c.cloudProfileConfig.Constraints.FloatingPools, c.config.FloatingPoolName, c.infraSpec.Region, nil); err == nil && floatingPool.DefaultFloatingSubnet != nil {
+		return floatingPool.DefaultFloatingSubnet
+	}
+
+	return nil
+}
+
+func (c *FlowContext) ensureNetwork(ctx context.Context) error {
+	if c.config.Networks.ID != nil {
+		return c.ensureConfiguredNetwork(ctx)
+	}
+	return c.ensureNewNetwork(ctx)
+}
+
+func (c *FlowContext) ensureConfiguredNetwork(_ context.Context) error {
+	network, err := c.access.GetNetworkByID(*c.config.Networks.ID)
+	if err != nil {
+		c.state.Set(IdentifierNetwork, "")
+		c.state.Set(NameNetwork, "")
+		return err
+	}
+	c.state.Set(IdentifierNetwork, *c.config.Networks.ID)
+	c.state.Set(NameNetwork, network.Name)
+	return nil
+}
+
+func (c *FlowContext) ensureNewNetwork(ctx context.Context) error {
+	log := c.LogFromContext(ctx)
+
+	desired := &access.Network{
+		Name:         c.namespace,
+		AdminStateUp: true,
+	}
+	current, err := c.findExistingNetwork()
+	if err != nil {
+		return err
+	}
+	if current != nil {
+		c.state.Set(IdentifierNetwork, current.ID)
+		c.state.Set(NameNetwork, current.Name)
+		if _, err := c.access.UpdateNetwork(desired, current); err != nil {
+			return err
+		}
+	} else {
+		log.Info("creating...")
+		created, err := c.access.CreateNetwork(desired)
+		if err != nil {
+			return err
+		}
+		c.state.Set(IdentifierNetwork, created.ID)
+		c.state.Set(NameNetwork, created.Name)
+	}
+
+	return nil
+}
+
+func (c *FlowContext) findExistingNetwork() (*access.Network, error) {
+	return findExisting(c.state.Get(IdentifierNetwork), c.namespace, c.access.GetNetworkByID, c.access.GetNetworkByName)
+}
+
+func (c *FlowContext) getNetworkID() (*string, error) {
+	if c.config.Networks.ID != nil {
+		return c.config.Networks.ID, nil
+	}
+	networkID := c.state.Get(IdentifierNetwork)
+	if networkID != nil {
+		return networkID, nil
+	}
+	network, err := c.findExistingNetwork()
+	if err != nil {
+		return nil, err
+	}
+	if network != nil {
+		c.state.Set(IdentifierNetwork, network.ID)
+		return &network.ID, nil
+	}
+	return nil, nil
+}
+
+func (c *FlowContext) ensureSubnet(ctx context.Context) error {
+	log := c.LogFromContext(ctx)
+
+	networkID := *c.state.Get(IdentifierNetwork)
+	workersCIDR := c.config.Networks.Workers
+	// Backwards compatibility - remove this code in a future version.
+	if workersCIDR == "" {
+		workersCIDR = c.config.Networks.Worker
+	}
+	desired := &subnets.Subnet{
+		Name:           c.namespace,
+		NetworkID:      networkID,
+		CIDR:           workersCIDR,
+		IPVersion:      4,
+		DNSNameservers: c.cloudProfileConfig.DNSServers,
+	}
+	current, err := c.findExistingSubnet()
+	if err != nil {
+		return err
+	}
+	if current != nil {
+		c.state.Set(IdentifierSubnet, current.ID)
+		if _, err := c.access.UpdateSubnet(desired, current); err != nil {
+			return err
+		}
+	} else {
+		log.Info("creating...")
+		created, err := c.access.CreateSubnet(desired)
+		if err != nil {
+			return err
+		}
+		c.state.Set(IdentifierSubnet, created.ID)
+	}
+	return nil
+}
+
+func (c *FlowContext) findExistingSubnet() (*subnets.Subnet, error) {
+	networkID, err := c.getNetworkID()
+	if err != nil {
+		return nil, err
+	}
+	if networkID == nil {
+		return nil, fmt.Errorf("network not found")
+	}
+	getByName := func(name string) ([]*subnets.Subnet, error) {
+		return c.access.GetSubnetByName(*networkID, name)
+	}
+	return findExisting(c.state.Get(IdentifierSubnet), c.namespace, c.access.GetSubnetByID, getByName)
+}
+
+func (c *FlowContext) getSubnetID() (*string, error) {
+	subnetID := c.state.Get(IdentifierSubnet)
+	if subnetID != nil {
+		return subnetID, nil
+	}
+	subnet, err := c.findExistingSubnet()
+	if err != nil {
+		return nil, err
+	}
+	if subnet != nil {
+		c.state.Set(IdentifierSubnet, subnet.ID)
+		return &subnet.ID, nil
+	}
+	return nil, nil
+}
+
+type notFoundError struct {
+	msg string
+}
+
+var _ error = &notFoundError{}
+
+func (e *notFoundError) Error() string {
+	return e.msg
+}
+
+func ignoreNotFound(err error) error {
+	if _, ok := err.(*notFoundError); ok {
+		return nil
+	}
+	return err
+}
+
+func (c *FlowContext) getExistingRouterAndSubnetIDs() (routerID, subnetID string, err error) {
+	prouter, err := c.getRouterID()
+	if err != nil {
+		return
+	}
+	if prouter == nil {
+		err = &notFoundError{msg: "router not found"}
+		return
+	}
+	routerID = *prouter
+	psubnet, err := c.getSubnetID()
+	if err != nil {
+		return
+	}
+	if psubnet == nil {
+		err = &notFoundError{msg: "subnet not found"}
+		return
+	}
+	subnetID = *psubnet
+	return
+}
+
+func (c *FlowContext) ensureRouterInterface(ctx context.Context) error {
+	log := c.LogFromContext(ctx)
+
+	routerID, subnetID, err := c.getExistingRouterAndSubnetIDs()
+	if err != nil {
+		return err
+	}
+	portID, actualSubnetID, err := c.access.GetRouterInterfacePortID(routerID)
+	if err != nil {
+		return err
+	}
+	if portID != nil {
+		if actualSubnetID != nil && *actualSubnetID == subnetID {
+			return nil
+		}
+		log.Info("router interface mismatch, deleting...", "port", *portID)
+		err = c.access.RemoveRouterInterfaceAndWait(ctx, routerID, "", *portID)
+		if err != nil {
+			return err
+		}
+	}
+	log.Info("creating...")
+	return c.access.AddRouterInterfaceAndWait(ctx, routerID, subnetID)
+}
+
+func (c *FlowContext) ensureSecGroup(ctx context.Context) error {
+	log := c.LogFromContext(ctx)
+
+	desired := &groups.SecGroup{
+		Name:        c.namespace,
+		Description: "Cluster Nodes",
+		Rules: []rules.SecGroupRule{
+			{
+				Direction:     string(rules.DirIngress),
+				EtherType:     string(rules.EtherType4),
+				RemoteGroupID: access.SecurityGroupIDSelf,
+			},
+			{
+				Direction: string(rules.DirEgress),
+				EtherType: string(rules.EtherType4),
+			},
+			{
+				Direction:      string(rules.DirIngress),
+				EtherType:      string(rules.EtherType4),
+				Protocol:       string(rules.ProtocolTCP),
+				RemoteIPPrefix: "0.0.0.0/0",
+			},
+			{
+				Direction:      string(rules.DirIngress),
+				EtherType:      string(rules.EtherType4),
+				Protocol:       string(rules.ProtocolUDP),
+				RemoteIPPrefix: "0.0.0.0/0",
+			},
+		},
+	}
+	current, err := findExisting(c.state.Get(IdentifierSecGroup), c.namespace, c.access.GetSecurityGroupByID, c.access.GetSecurityGroupByName)
+	if err != nil {
+		return err
+	}
+	if current != nil {
+		c.state.Set(IdentifierSecGroup, current.ID)
+		c.state.Set(NameSecGroup, current.Name)
+		if modified, err := c.access.UpdateSecurityGroup(desired, current); err != nil {
+			return err
+		} else if modified {
+			log.Info("updated rules")
+		}
+	} else {
+		log.Info("creating...")
+		created, err := c.access.CreateSecurityGroup(desired)
+		if err != nil {
+			return err
+		}
+		c.state.Set(IdentifierSecGroup, created.ID)
+		c.state.Set(NameSecGroup, created.Name)
+	}
+	return nil
+}
+
+func (c *FlowContext) ensureSSHKeyPair(ctx context.Context) error {
+	log := c.LogFromContext(ctx)
+
+	keyPair, err := c.compute.GetKeyPair(c.namespace)
+	if err != nil {
+		return err
+	}
+	if keyPair != nil {
+		if keyPair.PublicKey == string(c.infraSpec.SSHPublicKey) {
+			c.state.Set(NameKeyPair, keyPair.Name)
+			return nil
+		}
+		log.Info("replacing SSH key pair")
+		if err := c.compute.DeleteKeyPair(c.namespace); err != nil {
+			return err
+		}
+		keyPair = nil
+	}
+
+	if keyPair == nil {
+		c.state.Set(NameKeyPair, "")
+		log.Info("creating SSH key pair")
+		if keyPair, err = c.compute.CreateKeyPair(c.namespace, string(c.infraSpec.SSHPublicKey)); err != nil {
+			return err
+		}
+	}
+	c.state.Set(NameKeyPair, keyPair.Name)
+	return nil
+}

--- a/pkg/controller/infrastructure/infraflow/reconcile.go
+++ b/pkg/controller/infrastructure/infraflow/reconcile.go
@@ -45,7 +45,6 @@ func (c *FlowContext) Reconcile(ctx context.Context) error {
 }
 
 func (c *FlowContext) buildReconcileGraph() *flow.Graph {
-	//createNetwork := c.config.Networks.ID == nil
 	g := flow.NewGraph("Openstack infrastructure reconciliation")
 
 	ensureExternalNetwork := c.AddTask(g, "ensure external network",

--- a/pkg/controller/infrastructure/infraflow/reconcile.go
+++ b/pkg/controller/infrastructure/infraflow/reconcile.go
@@ -19,13 +19,14 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack/helper"
-	"github.com/gardener/gardener-extension-provider-openstack/pkg/controller/infrastructure/infraflow/access"
-	. "github.com/gardener/gardener-extension-provider-openstack/pkg/controller/infrastructure/infraflow/shared"
 	"github.com/gardener/gardener/pkg/utils/flow"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/subnets"
+
+	"github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack/helper"
+	"github.com/gardener/gardener-extension-provider-openstack/pkg/controller/infrastructure/infraflow/access"
+	. "github.com/gardener/gardener-extension-provider-openstack/pkg/controller/infrastructure/infraflow/shared"
 )
 
 const (
@@ -73,8 +74,6 @@ func (c *FlowContext) buildReconcileGraph() *flow.Graph {
 
 	return g
 }
-
-func unused(_ any) {}
 
 func (c *FlowContext) ensureRouter(ctx context.Context) error {
 	externalNetwork, err := c.networking.GetExternalNetworkByName(c.config.FloatingPoolName)

--- a/pkg/controller/infrastructure/infraflow/shared/basic_context.go
+++ b/pkg/controller/infrastructure/infraflow/shared/basic_context.go
@@ -1,0 +1,177 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shared
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/gardener/gardener/pkg/utils/flow"
+	"github.com/go-logr/logr"
+	"k8s.io/utils/pointer"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// TaskOption contains options for created flow tasks
+type TaskOption struct {
+	Dependencies []flow.TaskIDer
+	Timeout      time.Duration
+	DoIf         *bool
+}
+
+// Dependencies creates a TaskOption for dependencies
+func Dependencies(dependencies ...flow.TaskIDer) TaskOption {
+	return TaskOption{Dependencies: dependencies}
+}
+
+// Timeout creates a TaskOption for Timeout
+func Timeout(timeout time.Duration) TaskOption {
+	return TaskOption{Timeout: timeout}
+}
+
+// DoIf creates a TaskOption for DoIf
+func DoIf(condition bool) TaskOption {
+	return TaskOption{DoIf: pointer.Bool(condition)}
+}
+
+// FlowStatePersistor persists the flat map to the provider status
+type FlowStatePersistor func(ctx context.Context, flatMap FlatMap) error
+
+// BasicFlowContext provides logic for persisting the state and add tasks to the flow graph.
+type BasicFlowContext struct {
+	Log logr.Logger
+
+	exporter                StateExporter
+	persistorLock           sync.Mutex
+	flowStatePersistor      FlowStatePersistor
+	lastPersistedGeneration int64
+	lastPersistedAt         time.Time
+	PersistInterval         time.Duration
+}
+
+// StateExporter knows how to export the internal state to a flat string map.
+type StateExporter interface {
+	// CurrentGeneration is a counter which increments on changes of the internal state.
+	CurrentGeneration() int64
+	// Exports all or parts of the internal state to a flat string map.
+	ExportAsFlatMap() FlatMap
+}
+
+// NewBasicFlowContext creates a new `BasicFlowContext`.
+func NewBasicFlowContext(log logr.Logger, exporter StateExporter, persistor FlowStatePersistor) *BasicFlowContext {
+	flowContext := &BasicFlowContext{
+		Log:                log,
+		exporter:           exporter,
+		flowStatePersistor: persistor,
+		PersistInterval:    10 * time.Second,
+	}
+	return flowContext
+}
+
+// PersistState persists the internal state to the provider status if it has changed and force is true
+// or it has not been persisted during the `PersistInterval`.
+func (c *BasicFlowContext) PersistState(ctx context.Context, force bool) error {
+	c.persistorLock.Lock()
+	defer c.persistorLock.Unlock()
+
+	if !force && c.lastPersistedAt.Add(c.PersistInterval).After(time.Now()) {
+		return nil
+	}
+	currentGeneration := c.exporter.CurrentGeneration()
+	if c.lastPersistedGeneration == currentGeneration {
+		return nil
+	}
+	if c.flowStatePersistor != nil {
+		newState := c.exporter.ExportAsFlatMap()
+		if err := c.flowStatePersistor(ctx, newState); err != nil {
+			return err
+		}
+	}
+	c.lastPersistedGeneration = currentGeneration
+	c.lastPersistedAt = time.Now()
+	return nil
+}
+
+// LogFromContext returns the log from the context when called within a task function added with the `AddTask` method.
+func (c *BasicFlowContext) LogFromContext(ctx context.Context) logr.Logger {
+	if log, err := logr.FromContext(ctx); err != nil {
+		return c.Log
+	} else {
+		return log
+	}
+}
+
+// AddTask adds a wrapped task for the given task function and options.
+func (c *BasicFlowContext) AddTask(g *flow.Graph, name string, fn flow.TaskFn, options ...TaskOption) flow.TaskIDer {
+	allOptions := TaskOption{}
+	for _, opt := range options {
+		if len(opt.Dependencies) > 0 {
+			allOptions.Dependencies = append(allOptions.Dependencies, opt.Dependencies...)
+		}
+		if opt.Timeout > 0 {
+			allOptions.Timeout = opt.Timeout
+		}
+		if opt.DoIf != nil {
+			condition := true
+			if allOptions.DoIf != nil {
+				condition = *allOptions.DoIf
+			}
+			condition = condition && *opt.DoIf
+			allOptions.DoIf = pointer.Bool(condition)
+		}
+	}
+
+	tunedFn := fn
+	if allOptions.DoIf != nil {
+		tunedFn = tunedFn.DoIf(*allOptions.DoIf)
+		if !*allOptions.DoIf {
+			name = "[Skipped] " + name
+		}
+	}
+	if allOptions.Timeout > 0 {
+		tunedFn = tunedFn.Timeout(allOptions.Timeout)
+	}
+	task := flow.Task{
+		Name: name,
+		Fn:   c.wrapTaskFn(g.Name(), name, tunedFn),
+	}
+
+	if len(allOptions.Dependencies) > 0 {
+		task.Dependencies = flow.NewTaskIDs(allOptions.Dependencies...)
+	}
+
+	return g.Add(task)
+}
+
+func (c *BasicFlowContext) wrapTaskFn(flowName, taskName string, fn flow.TaskFn) flow.TaskFn {
+	return func(ctx context.Context) error {
+		taskCtx := logf.IntoContext(ctx, c.Log.WithValues("flow", flowName, "task", taskName))
+		err := fn(taskCtx)
+		if err != nil {
+			// don't wrap error with '%w', as otherwise the error context get lost
+			err = fmt.Errorf("failed to %s: %s", taskName, err)
+		}
+		if perr := c.PersistState(taskCtx, false); perr != nil {
+			if err != nil {
+				c.Log.Error(perr, "persisting state failed")
+			} else {
+				err = perr
+			}
+		}
+		return err
+	}
+}

--- a/pkg/controller/infrastructure/infraflow/shared/basic_context_test.go
+++ b/pkg/controller/infrastructure/infraflow/shared/basic_context_test.go
@@ -22,13 +22,12 @@ import (
 
 	"github.com/gardener/gardener/pkg/utils/flow"
 	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/gardener/gardener-extension-provider-openstack/pkg/controller/infrastructure/infraflow/shared"
-
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 )
 
 type testFlowContext struct {

--- a/pkg/controller/infrastructure/infraflow/shared/basic_context_test.go
+++ b/pkg/controller/infrastructure/infraflow/shared/basic_context_test.go
@@ -1,0 +1,167 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shared_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/gardener/gardener/pkg/utils/flow"
+	"github.com/go-logr/logr"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	"github.com/gardener/gardener-extension-provider-openstack/pkg/controller/infrastructure/infraflow/shared"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+type testFlowContext struct {
+	shared.BasicFlowContext
+	state shared.Whiteboard
+}
+
+func newTestFlowContext(log logr.Logger, state shared.Whiteboard, persistor shared.FlowStatePersistor) *testFlowContext {
+	return &testFlowContext{
+		BasicFlowContext: *shared.NewBasicFlowContext(log, state, persistor),
+		state:            state,
+	}
+}
+
+var _ = Describe("BasicFlowContext", func() {
+	It("should create and run a graph flow", func() {
+		var (
+			logBuffer           bytes.Buffer
+			log                 = zap.New(zap.WriteTo(&logBuffer))
+			state               = shared.NewWhiteboard()
+			forcePersistorError = false
+			forceTask3Error     = false
+			persistedData       shared.FlatMap
+			persistCallCount    = 0
+			persistor           = func(ctx context.Context, data shared.FlatMap) error {
+				if forcePersistorError {
+					return fmt.Errorf("forced persistor error")
+				}
+				persistedData = shared.FlatMap{}
+				for k, v := range data {
+					persistedData[k] = v
+				}
+				persistCallCount++
+				return nil
+			}
+			ctx           = context.Background()
+			err           error
+			expectedData1 = shared.FlatMap{
+				"key1": "id1",
+				"key2": "id2b",
+			}
+		)
+
+		c := newTestFlowContext(log, state, persistor)
+		c.PersistInterval = 10 * time.Millisecond
+
+		By("persists only if needed", func() {
+			c.state.Set("key1", "id1")
+			err = c.PersistState(ctx, false)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(persistCallCount).To(Equal(1))
+
+			// no immediate persistence with force = false
+			c.state.Set("key2", "id2")
+			err = c.PersistState(ctx, false)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(persistCallCount).To(Equal(1))
+
+			// persist after interval
+			time.Sleep(c.PersistInterval)
+			err = c.PersistState(ctx, false)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(persistCallCount).To(Equal(2))
+
+			// immediate persistence with force = true
+			c.state.Set("key2", "id2b")
+			err = c.PersistState(ctx, true)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(persistCallCount).To(Equal(3))
+			Expect(persistedData).To(Equal(expectedData1))
+
+			// no change, no persist call in backend
+			err = c.PersistState(ctx, true)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(persistCallCount).To(Equal(3))
+		})
+
+		By("logs with context", func() {
+			g := flow.NewGraph("test")
+			task1 := c.AddTask(g, "task1",
+				func(ctx context.Context) error {
+					c.state.Set("task1", "done")
+					return nil
+				},
+				shared.DoIf(false), shared.DoIf(true))
+			task2 := c.AddTask(g, "task2",
+				func(ctx context.Context) error {
+					c.state.Set("task2", "done")
+					task1Log := c.LogFromContext(ctx)
+					task1Log.Info("message from task2")
+					return nil
+				},
+				shared.Dependencies(task1))
+			_ = c.AddTask(g, "task3",
+				func(ctx context.Context) error {
+					c.state.SetPtr("afterTask2", c.state.Get("task2"))
+					time.Sleep(c.PersistInterval)
+					c.state.Set("task3", "done")
+					if forceTask3Error {
+						return fmt.Errorf("forceTask3Error")
+					}
+					return nil
+				},
+				shared.DoIf(true), shared.Dependencies(task2), shared.DoIf(true))
+
+			f := g.Compile()
+			Expect(f.Len()).To(Equal(3))
+
+			forcePersistorError = true
+			forceTask3Error = false
+			err = f.Run(ctx, flow.Opts{Log: log})
+			Expect(err.Error()).To(ContainSubstring(`flow "test" encountered task errors: [task "task3" failed: forced persistor error]`))
+
+			Expect(c.state.Get("task1")).To(BeNil())
+			Expect(c.state.Get("task2")).To(Equal(pointer.String("done")))
+			Expect(c.state.Get("afterTask2")).To(Equal(c.state.Get("task2")))
+			Expect(c.state.Get("task3")).To(Equal(pointer.String("done")))
+			Expect(logBuffer.String()).To(ContainSubstring(`"task":"[Skipped] task1"`))
+			Expect(logBuffer.String()).To(ContainSubstring(`"task":"task2"`))
+			Expect(logBuffer.String()).To(ContainSubstring(`"msg":"message from task2"`))
+			Expect(logBuffer.String()).To(ContainSubstring(`"task":"task3"`))
+
+			forcePersistorError = false
+			forceTask3Error = true
+			c.state.Set("task1", "")
+			err = f.Run(ctx, flow.Opts{Log: log})
+			Expect(err.Error()).To(ContainSubstring(`flow "test" encountered task errors: [task "task3" failed: failed to task3: forceTask3Error]`))
+
+			forcePersistorError = false
+			forceTask3Error = false
+			c.state.Set("task1", "")
+			err = f.Run(ctx, flow.Opts{Log: log})
+			Expect(err).To(BeNil())
+		})
+	})
+})

--- a/pkg/controller/infrastructure/infraflow/shared/shared_suite_test.go
+++ b/pkg/controller/infrastructure/infraflow/shared/shared_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shared_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestAws(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Infraflow Shared Test Suite")
+}

--- a/pkg/controller/infrastructure/infraflow/shared/tf_state.go
+++ b/pkg/controller/infrastructure/infraflow/shared/tf_state.go
@@ -1,0 +1,187 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shared
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+
+	"github.com/gardener/gardener/extensions/pkg/terraformer"
+)
+
+const (
+	// ModeManaged is mode value for managed resources.
+	ModeManaged = "managed"
+	// AttributeKeyId is the key for the id attribute
+	AttributeKeyId = "id"
+	// AttributeKeyName is the key for the name attribute
+	AttributeKeyName = "name"
+)
+
+// TerraformState holds the unmarshalled terraformer state.
+type TerraformState struct {
+	Version          int                 `json:"version"`
+	TerraformVersion string              `json:"terraform_version"`
+	Serial           int                 `json:"serial"`
+	Lineage          string              `json:"lineage"`
+	Outputs          map[string]TFOutput `json:"outputs,omitempty"`
+	Resources        []TFResource        `json:"resources,omitempty"`
+}
+
+// TFOutput holds the value and type for a terraformer state output variable.
+type TFOutput struct {
+	Value string `json:"value"`
+	Type  string `json:"type"`
+}
+
+// TFResource holds the attributes of a terraformer state resource.
+type TFResource struct {
+	Mode      string `json:"mode"`
+	Type      string `json:"type"`
+	Name      string `json:"name"`
+	Provider  string `json:"provider"`
+	Instances []TFInstance
+}
+
+// TFInstance holds the attributes of a terraformer state resource instance.
+type TFInstance struct {
+	SchemaVersion       int                    `json:"schema_version"`
+	Attributes          map[string]interface{} `json:"attributes,omitempty"`
+	SensitiveAttributes []string               `json:"sensitive_attributes,omitempty"`
+	Private             string                 `json:"private,omitempty"`
+	Dependencies        []string               `json:"dependencies"`
+}
+
+// LoadTerraformStateFromConfigMapData loads and unmarshalls the state from a config map data.
+func LoadTerraformStateFromConfigMapData(data map[string]string) (*TerraformState, error) {
+	content := data["terraform.tfstate"]
+	if content == "" {
+		return nil, fmt.Errorf("key 'terraform.tfstate' not found")
+	}
+
+	return UnmarshalTerraformState([]byte(content))
+}
+
+// UnmarshalTerraformStateFromTerraformer unmarshalls the Terraformer state from the raw state.
+func UnmarshalTerraformStateFromTerraformer(state *terraformer.RawState) (*TerraformState, error) {
+	var (
+		tfState *TerraformState
+		err     error
+		data    []byte
+	)
+
+	switch state.Encoding {
+	case "base64":
+		data, err = base64.StdEncoding.DecodeString(state.Data)
+		if err != nil {
+			return nil, fmt.Errorf("could not decode terraform raw state data: %w", err)
+		}
+	case "none":
+		data = []byte(state.Data)
+	default:
+		return nil, fmt.Errorf("unknown encoding of Terraformer raw state: %s", state.Encoding)
+	}
+	if tfState, err = UnmarshalTerraformState(data); err != nil {
+		return nil, fmt.Errorf("could not decode terraform state: %w", err)
+	}
+	return tfState, nil
+}
+
+// UnmarshalTerraformState unmarshalls the terraformer state from a byte array.
+func UnmarshalTerraformState(data []byte) (*TerraformState, error) {
+	state := &TerraformState{}
+	if err := json.Unmarshal(data, state); err != nil {
+		return nil, err
+	}
+	return state, nil
+}
+
+// FindManagedResourceInstances finds all instances for a resource identified by type and name.
+func (ts *TerraformState) FindManagedResourceInstances(tfType, resourceName string) []TFInstance {
+	for i := range ts.Resources {
+		resource := &ts.Resources[i]
+		if resource.Mode == ModeManaged && resource.Type == tfType && resource.Name == resourceName {
+			return resource.Instances
+		}
+	}
+	return nil
+}
+
+// FindManagedResourcesByType finds all instances for all resources of the given type.
+func (ts *TerraformState) FindManagedResourcesByType(tfType string) []*TFResource {
+	var result []*TFResource
+	for i := range ts.Resources {
+		resource := &ts.Resources[i]
+		if resource.Mode == ModeManaged && resource.Type == tfType {
+			result = append(result, resource)
+		}
+	}
+	return result
+}
+
+// GetManagedResourceInstanceID returns the value of the id attribute of the only instance of a resource identified by type and name.
+// It returns nil if either the resource is not found or the resource has not exactly one instance.
+func (ts *TerraformState) GetManagedResourceInstanceID(tfType, resourceName string) *string {
+	return ts.GetManagedResourceInstanceAttribute(tfType, resourceName, AttributeKeyId)
+}
+
+// GetManagedResourceInstanceName returns the value of the name attribute of the only instance of a resource identified by type and name.
+// It returns nil if either the resource is not found or the resource has not exactly one instance.
+func (ts *TerraformState) GetManagedResourceInstanceName(tfType, resourceName string) *string {
+	return ts.GetManagedResourceInstanceAttribute(tfType, resourceName, AttributeKeyName)
+}
+
+// GetManagedResourceInstanceAttribute returns the value of the given attribute keys of the only instance of a resource identified by type and name.
+// It returns nil if either the resource is not found or the resource has not exactly one instance or the attribute key is not existing.
+func (ts *TerraformState) GetManagedResourceInstanceAttribute(tfType, resourceName, attributeKey string) *string {
+	instances := ts.FindManagedResourceInstances(tfType, resourceName)
+	if len(instances) == 1 {
+		if value, ok := AttributeAsString(instances[0].Attributes, attributeKey); ok {
+			return &value
+		}
+	}
+	return nil
+}
+
+// GetManagedResourceInstances returns a map resource name to instance id for all resources of the given type.
+// Only resources are included which have exactly one instance.
+func (ts *TerraformState) GetManagedResourceInstances(tfType string) map[string]string {
+	result := map[string]string{}
+	for _, item := range ts.FindManagedResourcesByType(tfType) {
+		if len(item.Instances) == 1 {
+			if value, ok := AttributeAsString(item.Instances[0].Attributes, AttributeKeyId); ok {
+				result[item.Name] = value
+			}
+		}
+	}
+	return result
+}
+
+// AttributeAsString returns the string value for the given key. `found` is only true if the map contains the key and the value is a string.
+func AttributeAsString(attributes map[string]interface{}, key string) (svalue string, found bool) {
+	if attributes == nil {
+		return
+	}
+	value, ok := attributes[key]
+	if !ok {
+		return
+	}
+	if s, ok := value.(string); ok {
+		svalue = s
+		found = true
+	}
+	return
+}

--- a/pkg/controller/infrastructure/infraflow/shared/tf_state_test.go
+++ b/pkg/controller/infrastructure/infraflow/shared/tf_state_test.go
@@ -1,0 +1,244 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shared_test
+
+import (
+	"github.com/gardener/gardener-extension-provider-openstack/pkg/controller/infrastructure/infraflow/shared"
+	"github.com/gardener/gardener/extensions/pkg/terraformer"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/utils/pointer"
+)
+
+var _ = Describe("TerraformState", func() {
+	It("should unmarshall terraformer state", func() {
+		var ()
+
+		rawState := &terraformer.RawState{
+			Data:     tfstate,
+			Encoding: "none",
+		}
+
+		tf, err := shared.UnmarshalTerraformStateFromTerraformer(rawState)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(tf.Outputs["vpc_id"]).To(Equal(shared.TFOutput{Type: "string", Value: "vpc-0123456"}))
+
+		tables := tf.FindManagedResourcesByType("aws_route_table")
+		Expect(len(tables)).To(Equal(2))
+
+		Expect(tf.GetManagedResourceInstanceID("aws_route_table", "routetable_private_utility_z0")).
+			To(Equal(pointer.String("rtb-77777")))
+
+		Expect(tf.GetManagedResourceInstanceName("aws_iam_role", "nodes")).
+			To(Equal(pointer.String("shoot--foo--bar-nodes")))
+
+		Expect(tf.GetManagedResourceInstanceAttribute("aws_nat_gateway", "natgw_z0", "private_ip")).
+			To(Equal(pointer.String("10.180.46.81")))
+
+		Expect(tf.GetManagedResourceInstanceAttribute("aws_nat_gateway", "natgw_z0", "foobar")).
+			To(BeNil())
+
+		Expect(tf.GetManagedResourceInstances("aws_route_table")).
+			To(Equal(map[string]string{
+				"routetable_main":               "rtb-66666",
+				"routetable_private_utility_z0": "rtb-77777",
+			}))
+	})
+})
+
+const tfstate = `{
+  "version": 4,
+  "terraform_version": "0.15.5",
+  "serial": 83,
+  "lineage": "674a5a9a-d0e5-eee1-ce57-d820c4313bf0",
+  "outputs": {
+    "vpc_id": {
+      "value": "vpc-0123456",
+      "type": "string"
+    }
+  },
+  "resources": [
+    {
+      "mode": "managed",
+      "type": "aws_iam_role",
+      "name": "nodes",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "shoot--foo--bar-nodes-id",
+            "max_session_duration": 3600,
+            "name": "shoot--foo--bar-nodes"
+          }
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "aws_nat_gateway",
+      "name": "natgw_z0",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "allocation_id": "eipalloc-07aaaaa",
+            "connectivity_type": "public",
+            "id": "nat-22222",
+            "network_interface_id": "eni-33333",
+            "private_ip": "10.180.46.81",
+            "public_ip": "1.2.3.4",
+            "subnet_id": "subnet-44444",
+            "tags": {
+              "Name": "shoot--foo--bar-natgw-z0",
+              "kubernetes.io/cluster/shoot--foo--bar": "1"
+            },
+            "tags_all": {
+              "Name": "shoot--foo--bar-natgw-z0",
+              "kubernetes.io/cluster/shoot--foo--bar": "1"
+            }
+          },
+          "sensitive_attributes": [],
+          "private": "xxx",
+          "dependencies": [
+            "aws_eip.eip_natgw_z0",
+            "aws_subnet.public_utility_z0",
+            "aws_vpc.vpc"
+          ]
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "aws_route_table",
+      "name": "routetable_main",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "rtb-66666",
+            "owner_id": "999999",
+            "propagating_vgws": [],
+            "route": [
+              {
+                "cidr_block": "0.0.0.0/0"
+              }
+            ],
+            "tags": {
+              "Name": "shoot--foo--bar",
+              "kubernetes.io/cluster/shoot--foo--bar": "1"
+            },
+            "tags_all": {
+              "Name": "shoot--foo--bar",
+              "kubernetes.io/cluster/shoot--foo--bar": "1"
+            },
+            "timeouts": {
+              "create": "5m",
+              "delete": null,
+              "update": null
+            },
+            "vpc_id": "vpc-0123456"
+          },
+          "sensitive_attributes": [],
+          "private": "xxx",
+          "dependencies": [
+            "aws_vpc.vpc"
+          ]
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "aws_route_table",
+      "name": "routetable_private_utility_z0",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "rtb-77777",
+            "owner_id": "999999",
+            "route": [
+              {
+                "cidr_block": "0.0.0.0/0",
+                "nat_gateway_id": "nat-22222"
+              }
+            ],
+            "tags": {
+              "Name": "shoot--foo--bar-private-eu-west-1a",
+              "kubernetes.io/cluster/shoot--foo--bar": "1"
+            },
+            "tags_all": {
+              "Name": "shoot--foo--bar-private-eu-west-1a",
+              "kubernetes.io/cluster/shoot--foo--bar": "1"
+            },
+            "timeouts": {
+              "create": "5m",
+              "delete": null,
+              "update": null
+            },
+            "vpc_id": "vpc-0123456"
+          },
+          "sensitive_attributes": [],
+          "private": "xxx",
+          "dependencies": [
+            "aws_vpc.vpc"
+          ]
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "aws_vpc",
+      "name": "vpc",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 1,
+          "attributes": {
+            "arn": "arn:aws:ec2:eu-west-1:999999:vpc/vpc-0123456",
+            "assign_generated_ipv6_cidr_block": false,
+            "cidr_block": "10.180.0.0/16",
+            "default_security_group_id": "sg-11111",
+            "enable_classiclink": false,
+            "enable_classiclink_dns_support": false,
+            "enable_dns_hostnames": true,
+            "enable_dns_support": true,
+            "id": "vpc-0123456",
+            "instance_tenancy": "default",
+            "ipv6_association_id": "",
+            "ipv6_cidr_block": "",
+            "main_route_table_id": "rtb-77888",
+            "owner_id": "999999",
+            "tags": {
+              "Name": "shoot--foo--bar",
+              "kubernetes.io/cluster/shoot--foo--bar": "1"
+            },
+            "tags_all": {
+              "Name": "shoot--foo--bar",
+              "kubernetes.io/cluster/shoot--foo--bar": "1"
+            }
+          },
+          "sensitive_attributes": [],
+          "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
+        }
+      ]
+    }
+  ]
+}
+`

--- a/pkg/controller/infrastructure/infraflow/shared/tf_state_test.go
+++ b/pkg/controller/infrastructure/infraflow/shared/tf_state_test.go
@@ -15,11 +15,12 @@
 package shared_test
 
 import (
-	"github.com/gardener/gardener-extension-provider-openstack/pkg/controller/infrastructure/infraflow/shared"
 	"github.com/gardener/gardener/extensions/pkg/terraformer"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/utils/pointer"
+
+	"github.com/gardener/gardener-extension-provider-openstack/pkg/controller/infrastructure/infraflow/shared"
 )
 
 var _ = Describe("TerraformState", func() {

--- a/pkg/controller/infrastructure/infraflow/shared/whiteboard.go
+++ b/pkg/controller/infrastructure/infraflow/shared/whiteboard.go
@@ -1,0 +1,277 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shared
+
+import (
+	"sort"
+	"strings"
+	"sync"
+	"sync/atomic"
+
+	"k8s.io/utils/pointer"
+)
+
+const (
+	// Separator is used to on translating keys to/from flat maps
+	Separator = "/"
+	// deleted is a special value to mark a resource id as deleted
+	deleted = "<deleted>"
+)
+
+// FlatMap is a semantic name for string map used for importing and exporting
+type FlatMap map[string]string
+
+// Whiteboard is a hierarchical key/value store for the internal state.
+// It is safe to be used concurrently.
+// Additionally, it can cache objects for use in subsequent flow task.
+type Whiteboard interface {
+	IsEmpty() bool
+
+	// GetChild returns a sub-whiteboard for the given key. If no child exists with this name, it is created automatically.
+	// Each child has its own lock.
+	GetChild(key string) Whiteboard
+	// HasChild returns true if there is a non-empty child for that key
+	HasChild(key string) bool
+	// GetChildrenKeys returns all children keys
+	GetChildrenKeys() []string
+
+	// Get returns a valid value or nil (never "" or special deleted value)
+	Get(key string) *string
+	Set(key, id string)
+	SetPtr(key string, id *string)
+	IsAlreadyDeleted(key string) bool
+	SetAsDeleted(key string)
+	// Keys returns all stored keys, even for deleted ones
+	Keys() []string
+	// AsMap returns a map with all valid key/values
+	AsMap() map[string]string
+
+	GetObject(key string) any
+	SetObject(key string, obj any)
+
+	// ImportFromFlatMap reconstructs the hierarchical structure from a flat map containing path-like keys
+	ImportFromFlatMap(data FlatMap)
+	// ExportAsFlatMap exports the hierarchical structure to a flat map with path-like keys. Objects are ignored.
+	ExportAsFlatMap() FlatMap
+
+	// CurrentGeneration returns current generation, which increments with any change
+	CurrentGeneration() int64
+}
+
+type whiteboard struct {
+	sync.Mutex
+
+	children   map[string]*whiteboard
+	data       map[string]string
+	objects    map[string]any
+	generation *atomic.Int64
+}
+
+var _ Whiteboard = &whiteboard{}
+
+// NewWhiteboard creates an empty whiteboard.
+func NewWhiteboard() Whiteboard {
+	return newWhiteboard(&atomic.Int64{})
+}
+
+func newWhiteboard(generation *atomic.Int64) *whiteboard {
+	return &whiteboard{
+		children:   map[string]*whiteboard{},
+		data:       map[string]string{},
+		objects:    map[string]any{},
+		generation: generation,
+	}
+}
+
+func (w *whiteboard) CurrentGeneration() int64 {
+	return w.generation.Load()
+}
+
+func (w *whiteboard) IsEmpty() bool {
+	w.Lock()
+	defer w.Unlock()
+
+	if len(w.data) != 0 || len(w.objects) != 0 {
+		return false
+	}
+	for _, child := range w.children {
+		if !child.IsEmpty() {
+			return false
+		}
+	}
+	return true
+}
+
+func (w *whiteboard) GetChild(key string) Whiteboard {
+	return w.getChild(key)
+}
+
+func (w *whiteboard) getChild(key string) *whiteboard {
+	w.Lock()
+	defer w.Unlock()
+
+	child := w.children[key]
+	if child == nil {
+		child = newWhiteboard(w.generation)
+		w.children[key] = child
+	}
+	return child
+}
+
+func (w *whiteboard) HasChild(key string) bool {
+	w.Lock()
+	defer w.Unlock()
+
+	child := w.children[key]
+	return child != nil && !child.IsEmpty()
+}
+
+func (w *whiteboard) GetChildrenKeys() []string {
+	w.Lock()
+	defer w.Unlock()
+
+	return sortedKeys(w.children)
+}
+
+func (w *whiteboard) GetObject(key string) any {
+	w.Lock()
+	defer w.Unlock()
+	return w.objects[key]
+}
+
+func (w *whiteboard) SetObject(key string, obj any) {
+	w.Lock()
+	defer w.Unlock()
+	w.objects[key] = obj
+}
+
+func (w *whiteboard) Keys() []string {
+	w.Lock()
+	defer w.Unlock()
+
+	return sortedKeys(w.data)
+}
+
+func (w *whiteboard) AsMap() map[string]string {
+	w.Lock()
+	defer w.Unlock()
+
+	m := map[string]string{}
+	for key, value := range w.data {
+		if IsValidValue(value) {
+			m[key] = value
+		}
+	}
+	return m
+}
+
+func (w *whiteboard) Get(key string) *string {
+	w.Lock()
+	defer w.Unlock()
+	id := w.data[key]
+	if !IsValidValue(id) {
+		return nil
+	}
+	return &id
+}
+
+func (w *whiteboard) Set(key, id string) {
+	w.Lock()
+	defer w.Unlock()
+	oldId := w.data[key]
+	if id != "" {
+		w.data[key] = id
+	} else {
+		delete(w.data, key)
+	}
+	if oldId != id {
+		w.modified()
+	}
+}
+
+func (w *whiteboard) SetPtr(key string, id *string) {
+	w.Set(key, pointer.StringDeref(id, ""))
+}
+
+func (w *whiteboard) IsAlreadyDeleted(key string) bool {
+	w.Lock()
+	defer w.Unlock()
+	return w.data[key] == deleted
+}
+
+func (w *whiteboard) SetAsDeleted(key string) {
+	w.Set(key, deleted)
+}
+
+func (w *whiteboard) ImportFromFlatMap(data FlatMap) {
+	for key, value := range data {
+		parts := strings.Split(key, Separator)
+		level := w
+		for i := 0; i < len(parts)-1; i++ {
+			level = level.getChild(parts[i])
+		}
+		level.Set(parts[len(parts)-1], value)
+	}
+}
+
+func (w *whiteboard) ExportAsFlatMap() FlatMap {
+	data := map[string]string{}
+	w.copyMap(data, "")
+	fillDataFromChildren(data, "", w)
+	return data
+}
+
+func (w *whiteboard) copyMap(data map[string]string, prefix string) {
+	w.Lock()
+	defer w.Unlock()
+	for k, v := range w.data {
+		data[prefix+k] = v
+	}
+}
+
+func fillDataFromChildren(data map[string]string, parentPrefix string, parent *whiteboard) {
+	for _, childKey := range parent.GetChildrenKeys() {
+		child := parent.getChild(childKey)
+		childPrefix := parentPrefix + childKey + Separator
+		child.copyMap(data, childPrefix)
+		fillDataFromChildren(data, childPrefix, child)
+	}
+}
+
+func (w *whiteboard) modified() {
+	w.generation.Add(1)
+}
+
+func sortedKeys[V any](m map[string]V) []string {
+	var keys []string
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// IsValidValue returns true if an exported value is valid, i.e. not empty and not special value for deleted.
+func IsValidValue(value string) bool {
+	return value != "" && value != deleted
+}
+
+// ValidValue returns the value if the exported value is valid, otherwise an empty string.
+func ValidValue(value string) string {
+	if !IsValidValue(value) {
+		return ""
+	}
+	return value
+}

--- a/pkg/controller/infrastructure/infraflow/shared/whiteboard_test.go
+++ b/pkg/controller/infrastructure/infraflow/shared/whiteboard_test.go
@@ -1,0 +1,104 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shared_test
+
+import (
+	"k8s.io/utils/pointer"
+
+	"github.com/gardener/gardener-extension-provider-openstack/pkg/controller/infrastructure/infraflow/shared"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Whiteboard", func() {
+	It("should create hierarchical whiteboard from flat map", func() {
+		var (
+			data = shared.FlatMap{
+				"key1":                  "id1",
+				"key2":                  "id2",
+				"child1/subchild1/key1": "id111",
+				"child1/subchild2/key1": "id121",
+				"child2/key2":           "id22",
+			}
+			expectedData = shared.FlatMap{
+				"key1":                  "<deleted>",
+				"key2":                  "id2a",
+				"key3":                  "id3",
+				"child1/subchild1/key1": "id111b",
+				"child2/key2":           "id22",
+			}
+			expectedMap = map[string]string{
+				"key2": "id2a",
+				"key3": "id3",
+			}
+			expectedKeys = []string{"key1", "key2", "key3"}
+		)
+
+		w := shared.NewWhiteboard()
+		w.IsEmpty()
+		w.ImportFromFlatMap(data)
+		Expect(w.Get("key1")).NotTo(BeNil())
+		Expect(*w.Get("key1")).To(Equal("id1"))
+		Expect(w.Get("key2")).NotTo(BeNil())
+		Expect(*w.Get("key2")).To(Equal("id2"))
+		Expect(w.Get("child1")).To(BeNil())
+		Expect(w.GetChild("child1").IsEmpty()).To(BeFalse())
+		Expect(w.GetChild("child1").GetChild("subchild1").Get("key1")).To(Equal(pointer.String("id111")))
+		Expect(w.GetChild("child1").GetChild("subchild2").Get("key1")).To(Equal(pointer.String("id121")))
+		Expect(w.GetChild("child2").IsEmpty()).To(BeFalse())
+		Expect(w.GetChild("child2").Get("key2")).To(Equal(pointer.String("id22")))
+		Expect(w.GetChild("child3").IsEmpty()).To(BeTrue())
+		generation1 := w.CurrentGeneration()
+		w.Set("key2", "id2")
+		Expect(w.CurrentGeneration()).To(Equal(generation1))
+		w.GetChild("child1").GetChild("subchild1").Set("key1", "id111")
+		Expect(w.CurrentGeneration()).To(Equal(generation1))
+		w.Set("key2", "id2a")
+		generation2 := w.CurrentGeneration()
+		Expect(generation2 > generation1).To(BeTrue())
+		w.GetChild("child1").GetChild("subchild1").Set("key1", "id111b")
+		Expect(w.CurrentGeneration() > generation2).To(BeTrue())
+
+		Expect(w.GetChild("child1").GetChild("subchild2").IsAlreadyDeleted("key1")).To(BeFalse())
+		w.GetChild("child1").GetChild("subchild2").Set("key1", "")
+		Expect(w.GetChild("child1").GetChild("subchild2").IsAlreadyDeleted("key1")).To(BeFalse())
+
+		Expect(w.Get("key1")).NotTo(BeNil())
+		Expect(w.IsAlreadyDeleted("key1")).To(BeFalse())
+		w.SetAsDeleted("key1")
+		Expect(w.Get("key1")).To(BeNil())
+		Expect(w.IsAlreadyDeleted("key1")).To(BeTrue())
+
+		Expect(w.Get("key3")).To(BeNil())
+		w.SetPtr("key3", pointer.String("id3"))
+		Expect(w.Get("key3")).NotTo(BeNil())
+
+		Expect(w.HasChild("child1")).To(BeTrue())
+		Expect(w.HasChild("child3")).To(BeFalse())
+
+		Expect(w.AsMap()).To(Equal(expectedMap))
+
+		Expect(w.Keys()).To(Equal(expectedKeys))
+
+		generation3 := w.CurrentGeneration()
+		w.SetObject("obj1", expectedKeys)
+		Expect(w.GetObject("obj1")).To(Equal(expectedKeys))
+		Expect(w.CurrentGeneration()).To(Equal(generation3))
+
+		exported := w.ExportAsFlatMap()
+		Expect(exported).To(Equal(expectedData))
+	})
+})

--- a/pkg/controller/infrastructure/infraflow/shared/whiteboard_test.go
+++ b/pkg/controller/infrastructure/infraflow/shared/whiteboard_test.go
@@ -15,12 +15,11 @@
 package shared_test
 
 import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"k8s.io/utils/pointer"
 
 	"github.com/gardener/gardener-extension-provider-openstack/pkg/controller/infrastructure/infraflow/shared"
-
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Whiteboard", func() {

--- a/pkg/controller/infrastructure/infraflow/utils.go
+++ b/pkg/controller/infrastructure/infraflow/utils.go
@@ -1,0 +1,116 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package infraflow
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/go-logr/logr"
+	"go.uber.org/atomic"
+)
+
+func findExisting[T any](id *string, name string,
+	getter func(id string) (*T, error),
+	finder func(name string) ([]*T, error),
+	selector ...func(item *T) bool) (*T, error) {
+
+	if id != nil {
+		found, err := getter(*id)
+		if err != nil {
+			return nil, err
+		}
+		if found != nil && (len(selector) == 0 || selector[0](found)) {
+			return found, nil
+		}
+	}
+
+	found, err := finder(name)
+	if err != nil {
+		return nil, err
+	}
+	if len(found) == 0 {
+		return nil, nil
+	}
+	if len(selector) > 0 {
+		for _, item := range found {
+			if selector[0](item) {
+				return item, nil
+			}
+		}
+		return nil, nil
+	}
+	return found[0], nil
+}
+
+type waiter struct {
+	log           logr.Logger
+	start         time.Time
+	period        time.Duration
+	message       atomic.String
+	keysAndValues []any
+	done          chan struct{}
+}
+
+func informOnWaiting(log logr.Logger, period time.Duration, message string, keysAndValues ...any) *waiter {
+	w := &waiter{
+		log:           log,
+		start:         time.Now(),
+		period:        period,
+		keysAndValues: keysAndValues,
+		done:          make(chan struct{}),
+	}
+	w.message.Store(message)
+	go w.run()
+	return w
+}
+
+func (w *waiter) UpdateMessage(message string) {
+	w.message.Store(message)
+}
+
+func (w *waiter) run() {
+	ticker := time.NewTicker(w.period)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-w.done:
+			return
+		case <-ticker.C:
+			delta := int(time.Since(w.start).Seconds())
+			w.log.Info(fmt.Sprintf("%s [%ds]", w.message.Load(), delta), w.keysAndValues...)
+		}
+	}
+}
+
+func (w *waiter) Done(err error) {
+	w.done <- struct{}{}
+	if err != nil {
+		w.log.Info("failed: " + err.Error())
+	} else {
+		w.log.Info("succeeded")
+	}
+}
+
+func copyMap(src map[string]string) map[string]string {
+	if src == nil {
+		return nil
+	}
+	dst := map[string]string{}
+	for k, v := range src {
+		dst[k] = v
+	}
+	return dst
+}

--- a/pkg/internal/infrastructure/infrastucture.go
+++ b/pkg/internal/infrastructure/infrastucture.go
@@ -31,7 +31,7 @@ func CleanupKubernetesRoutes(_ context.Context, client openstackclient.Networkin
 		return err
 	}
 
-	if len(router) == 0 {
+	if router == nil {
 		return nil
 	}
 
@@ -41,7 +41,7 @@ func CleanupKubernetesRoutes(_ context.Context, client openstackclient.Networkin
 		return err
 	}
 
-	for _, route := range router[0].Routes {
+	for _, route := range router.Routes {
 		ipNode, _, err := net.ParseCIDR(route.NextHop + "/32")
 		if err != nil {
 			return err
@@ -52,7 +52,7 @@ func CleanupKubernetesRoutes(_ context.Context, client openstackclient.Networkin
 	}
 
 	// return early if no changes were made
-	if len(router[0].Routes) == len(routes) {
+	if len(router.Routes) == len(routes) {
 		return nil
 	}
 

--- a/pkg/internal/infrastructure/infrastucture_test.go
+++ b/pkg/internal/infrastructure/infrastucture_test.go
@@ -38,7 +38,7 @@ var _ = Describe("Infrastructure", func() {
 
 	prepRoutes := func(routes ...routers.Route) {
 		router.Routes = routes
-		nw.EXPECT().GetRouterByID(routerID).Return([]routers.Router{*router}, nil)
+		nw.EXPECT().GetRouterByID(routerID).Return(router, nil)
 	}
 
 	DescribeTable("#RouteCleanup", func(a args, expErr error) {

--- a/pkg/openstack/client/compute.go
+++ b/pkg/openstack/client/compute.go
@@ -18,6 +18,7 @@ package client
 
 import (
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/floatingips"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/keypairs"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/servergroups"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/images"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
@@ -151,4 +152,24 @@ func (c *ComputeClient) ListImages(listOpts images.ListOpts) ([]images.Image, er
 		return nil, err
 	}
 	return images.ExtractImages(allPages)
+}
+
+// CreateKeyPair creates an SSH key pair
+func (c *ComputeClient) CreateKeyPair(name, publicKey string) (*keypairs.KeyPair, error) {
+	opts := keypairs.CreateOpts{
+		Name:      name,
+		PublicKey: publicKey,
+	}
+	return keypairs.Create(c.client, opts).Extract()
+}
+
+// GetKeyPair gets an SSH key pair by name
+func (c *ComputeClient) GetKeyPair(name string) (*keypairs.KeyPair, error) {
+	keypair, err := keypairs.Get(c.client, name).Extract()
+	return keypair, IgnoreNotFoundError(err)
+}
+
+// DeleteKeyPair deletes an SSH key pair by name
+func (c *ComputeClient) DeleteKeyPair(name string) error {
+	return keypairs.Delete(c.client, name).ExtractErr()
 }

--- a/pkg/openstack/client/compute.go
+++ b/pkg/openstack/client/compute.go
@@ -165,11 +165,11 @@ func (c *ComputeClient) CreateKeyPair(name, publicKey string) (*keypairs.KeyPair
 
 // GetKeyPair gets an SSH key pair by name
 func (c *ComputeClient) GetKeyPair(name string) (*keypairs.KeyPair, error) {
-	keypair, err := keypairs.Get(c.client, name).Extract()
+	keypair, err := keypairs.Get(c.client, name, nil).Extract()
 	return keypair, IgnoreNotFoundError(err)
 }
 
 // DeleteKeyPair deletes an SSH key pair by name
 func (c *ComputeClient) DeleteKeyPair(name string) error {
-	return keypairs.Delete(c.client, name).ExtractErr()
+	return keypairs.Delete(c.client, name, nil).ExtractErr()
 }

--- a/pkg/openstack/client/mocks/client_mocks.go
+++ b/pkg/openstack/client/mocks/client_mocks.go
@@ -12,6 +12,7 @@ import (
 	client "github.com/gardener/gardener-extension-provider-openstack/pkg/openstack/client"
 	gomock "github.com/golang/mock/gomock"
 	floatingips "github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/floatingips"
+	keypairs "github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/keypairs"
 	servergroups "github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/servergroups"
 	images "github.com/gophercloud/gophercloud/openstack/compute/v2/images"
 	servers "github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
@@ -20,6 +21,8 @@ import (
 	groups "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups"
 	rules "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules"
 	networks "github.com/gophercloud/gophercloud/openstack/networking/v2/networks"
+	ports "github.com/gophercloud/gophercloud/openstack/networking/v2/ports"
+	subnets "github.com/gophercloud/gophercloud/openstack/networking/v2/subnets"
 )
 
 // MockFactory is a mock of Factory interface.
@@ -196,6 +199,21 @@ func (mr *MockComputeMockRecorder) AssociateFIPWithInstance(arg0, arg1 interface
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssociateFIPWithInstance", reflect.TypeOf((*MockCompute)(nil).AssociateFIPWithInstance), arg0, arg1)
 }
 
+// CreateKeyPair mocks base method.
+func (m *MockCompute) CreateKeyPair(arg0, arg1 string) (*keypairs.KeyPair, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateKeyPair", arg0, arg1)
+	ret0, _ := ret[0].(*keypairs.KeyPair)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateKeyPair indicates an expected call of CreateKeyPair.
+func (mr *MockComputeMockRecorder) CreateKeyPair(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateKeyPair", reflect.TypeOf((*MockCompute)(nil).CreateKeyPair), arg0, arg1)
+}
+
 // CreateServer mocks base method.
 func (m *MockCompute) CreateServer(arg0 servers.CreateOpts) (*servers.Server, error) {
 	m.ctrl.T.Helper()
@@ -224,6 +242,20 @@ func (m *MockCompute) CreateServerGroup(arg0, arg1 string) (*servergroups.Server
 func (mr *MockComputeMockRecorder) CreateServerGroup(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateServerGroup", reflect.TypeOf((*MockCompute)(nil).CreateServerGroup), arg0, arg1)
+}
+
+// DeleteKeyPair mocks base method.
+func (m *MockCompute) DeleteKeyPair(arg0 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteKeyPair", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteKeyPair indicates an expected call of DeleteKeyPair.
+func (mr *MockComputeMockRecorder) DeleteKeyPair(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteKeyPair", reflect.TypeOf((*MockCompute)(nil).DeleteKeyPair), arg0)
 }
 
 // DeleteServer mocks base method.
@@ -312,6 +344,21 @@ func (m *MockCompute) FindServersByName(arg0 string) ([]servers.Server, error) {
 func (mr *MockComputeMockRecorder) FindServersByName(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindServersByName", reflect.TypeOf((*MockCompute)(nil).FindServersByName), arg0)
+}
+
+// GetKeyPair mocks base method.
+func (m *MockCompute) GetKeyPair(arg0 string) (*keypairs.KeyPair, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetKeyPair", arg0)
+	ret0, _ := ret[0].(*keypairs.KeyPair)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetKeyPair indicates an expected call of GetKeyPair.
+func (mr *MockComputeMockRecorder) GetKeyPair(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetKeyPair", reflect.TypeOf((*MockCompute)(nil).GetKeyPair), arg0)
 }
 
 // GetServerGroup mocks base method.
@@ -448,6 +495,21 @@ func (m *MockNetworking) EXPECT() *MockNetworkingMockRecorder {
 	return m.recorder
 }
 
+// AddRouterInterface mocks base method.
+func (m *MockNetworking) AddRouterInterface(arg0 string, arg1 routers.AddInterfaceOpts) (*routers.InterfaceInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AddRouterInterface", arg0, arg1)
+	ret0, _ := ret[0].(*routers.InterfaceInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AddRouterInterface indicates an expected call of AddRouterInterface.
+func (mr *MockNetworkingMockRecorder) AddRouterInterface(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddRouterInterface", reflect.TypeOf((*MockNetworking)(nil).AddRouterInterface), arg0, arg1)
+}
+
 // CreateFloatingIP mocks base method.
 func (m *MockNetworking) CreateFloatingIP(arg0 floatingips0.CreateOpts) (*floatingips0.FloatingIP, error) {
 	m.ctrl.T.Helper()
@@ -461,6 +523,36 @@ func (m *MockNetworking) CreateFloatingIP(arg0 floatingips0.CreateOpts) (*floati
 func (mr *MockNetworkingMockRecorder) CreateFloatingIP(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateFloatingIP", reflect.TypeOf((*MockNetworking)(nil).CreateFloatingIP), arg0)
+}
+
+// CreateNetwork mocks base method.
+func (m *MockNetworking) CreateNetwork(arg0 networks.CreateOpts) (*networks.Network, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateNetwork", arg0)
+	ret0, _ := ret[0].(*networks.Network)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateNetwork indicates an expected call of CreateNetwork.
+func (mr *MockNetworkingMockRecorder) CreateNetwork(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateNetwork", reflect.TypeOf((*MockNetworking)(nil).CreateNetwork), arg0)
+}
+
+// CreateRouter mocks base method.
+func (m *MockNetworking) CreateRouter(arg0 routers.CreateOpts) (*routers.Router, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateRouter", arg0)
+	ret0, _ := ret[0].(*routers.Router)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateRouter indicates an expected call of CreateRouter.
+func (mr *MockNetworkingMockRecorder) CreateRouter(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateRouter", reflect.TypeOf((*MockNetworking)(nil).CreateRouter), arg0)
 }
 
 // CreateRule mocks base method.
@@ -493,6 +585,21 @@ func (mr *MockNetworkingMockRecorder) CreateSecurityGroup(arg0 interface{}) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSecurityGroup", reflect.TypeOf((*MockNetworking)(nil).CreateSecurityGroup), arg0)
 }
 
+// CreateSubnet mocks base method.
+func (m *MockNetworking) CreateSubnet(arg0 subnets.CreateOpts) (*subnets.Subnet, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateSubnet", arg0)
+	ret0, _ := ret[0].(*subnets.Subnet)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateSubnet indicates an expected call of CreateSubnet.
+func (mr *MockNetworkingMockRecorder) CreateSubnet(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSubnet", reflect.TypeOf((*MockNetworking)(nil).CreateSubnet), arg0)
+}
+
 // DeleteFloatingIP mocks base method.
 func (m *MockNetworking) DeleteFloatingIP(arg0 string) error {
 	m.ctrl.T.Helper()
@@ -505,6 +612,34 @@ func (m *MockNetworking) DeleteFloatingIP(arg0 string) error {
 func (mr *MockNetworkingMockRecorder) DeleteFloatingIP(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteFloatingIP", reflect.TypeOf((*MockNetworking)(nil).DeleteFloatingIP), arg0)
+}
+
+// DeleteNetwork mocks base method.
+func (m *MockNetworking) DeleteNetwork(arg0 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteNetwork", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteNetwork indicates an expected call of DeleteNetwork.
+func (mr *MockNetworkingMockRecorder) DeleteNetwork(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNetwork", reflect.TypeOf((*MockNetworking)(nil).DeleteNetwork), arg0)
+}
+
+// DeleteRouter mocks base method.
+func (m *MockNetworking) DeleteRouter(arg0 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteRouter", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteRouter indicates an expected call of DeleteRouter.
+func (mr *MockNetworkingMockRecorder) DeleteRouter(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRouter", reflect.TypeOf((*MockNetworking)(nil).DeleteRouter), arg0)
 }
 
 // DeleteRule mocks base method.
@@ -533,6 +668,35 @@ func (m *MockNetworking) DeleteSecurityGroup(arg0 string) error {
 func (mr *MockNetworkingMockRecorder) DeleteSecurityGroup(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSecurityGroup", reflect.TypeOf((*MockNetworking)(nil).DeleteSecurityGroup), arg0)
+}
+
+// DeleteSubnet mocks base method.
+func (m *MockNetworking) DeleteSubnet(arg0 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteSubnet", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteSubnet indicates an expected call of DeleteSubnet.
+func (mr *MockNetworkingMockRecorder) DeleteSubnet(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSubnet", reflect.TypeOf((*MockNetworking)(nil).DeleteSubnet), arg0)
+}
+
+// GetExternalNetworkByName mocks base method.
+func (m *MockNetworking) GetExternalNetworkByName(arg0 string) (*networks.Network, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetExternalNetworkByName", arg0)
+	ret0, _ := ret[0].(*networks.Network)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetExternalNetworkByName indicates an expected call of GetExternalNetworkByName.
+func (mr *MockNetworkingMockRecorder) GetExternalNetworkByName(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetExternalNetworkByName", reflect.TypeOf((*MockNetworking)(nil).GetExternalNetworkByName), arg0)
 }
 
 // GetExternalNetworkNames mocks base method.
@@ -580,11 +744,26 @@ func (mr *MockNetworkingMockRecorder) GetNetworkByName(arg0 interface{}) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNetworkByName", reflect.TypeOf((*MockNetworking)(nil).GetNetworkByName), arg0)
 }
 
+// GetPort mocks base method.
+func (m *MockNetworking) GetPort(arg0 string) (*ports.Port, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPort", arg0)
+	ret0, _ := ret[0].(*ports.Port)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetPort indicates an expected call of GetPort.
+func (mr *MockNetworkingMockRecorder) GetPort(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPort", reflect.TypeOf((*MockNetworking)(nil).GetPort), arg0)
+}
+
 // GetRouterByID mocks base method.
-func (m *MockNetworking) GetRouterByID(arg0 string) ([]routers.Router, error) {
+func (m *MockNetworking) GetRouterByID(arg0 string) (*routers.Router, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetRouterByID", arg0)
-	ret0, _ := ret[0].([]routers.Router)
+	ret0, _ := ret[0].(*routers.Router)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -593,6 +772,36 @@ func (m *MockNetworking) GetRouterByID(arg0 string) ([]routers.Router, error) {
 func (mr *MockNetworkingMockRecorder) GetRouterByID(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRouterByID", reflect.TypeOf((*MockNetworking)(nil).GetRouterByID), arg0)
+}
+
+// GetRouterInterfacePort mocks base method.
+func (m *MockNetworking) GetRouterInterfacePort(arg0 string) (*ports.Port, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRouterInterfacePort", arg0)
+	ret0, _ := ret[0].(*ports.Port)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetRouterInterfacePort indicates an expected call of GetRouterInterfacePort.
+func (mr *MockNetworkingMockRecorder) GetRouterInterfacePort(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRouterInterfacePort", reflect.TypeOf((*MockNetworking)(nil).GetRouterInterfacePort), arg0)
+}
+
+// GetSecurityGroup mocks base method.
+func (m *MockNetworking) GetSecurityGroup(arg0 string) (*groups.SecGroup, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSecurityGroup", arg0)
+	ret0, _ := ret[0].(*groups.SecGroup)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetSecurityGroup indicates an expected call of GetSecurityGroup.
+func (mr *MockNetworkingMockRecorder) GetSecurityGroup(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSecurityGroup", reflect.TypeOf((*MockNetworking)(nil).GetSecurityGroup), arg0)
 }
 
 // GetSecurityGroupByName mocks base method.
@@ -685,6 +894,66 @@ func (mr *MockNetworkingMockRecorder) ListSecurityGroup(arg0 interface{}) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSecurityGroup", reflect.TypeOf((*MockNetworking)(nil).ListSecurityGroup), arg0)
 }
 
+// ListSubnets mocks base method.
+func (m *MockNetworking) ListSubnets(arg0 subnets.ListOpts) ([]subnets.Subnet, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListSubnets", arg0)
+	ret0, _ := ret[0].([]subnets.Subnet)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListSubnets indicates an expected call of ListSubnets.
+func (mr *MockNetworkingMockRecorder) ListSubnets(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSubnets", reflect.TypeOf((*MockNetworking)(nil).ListSubnets), arg0)
+}
+
+// RemoveRouterInterface mocks base method.
+func (m *MockNetworking) RemoveRouterInterface(arg0 string, arg1 routers.RemoveInterfaceOpts) (*routers.InterfaceInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemoveRouterInterface", arg0, arg1)
+	ret0, _ := ret[0].(*routers.InterfaceInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RemoveRouterInterface indicates an expected call of RemoveRouterInterface.
+func (mr *MockNetworkingMockRecorder) RemoveRouterInterface(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveRouterInterface", reflect.TypeOf((*MockNetworking)(nil).RemoveRouterInterface), arg0, arg1)
+}
+
+// UpdateNetwork mocks base method.
+func (m *MockNetworking) UpdateNetwork(arg0 string, arg1 networks.UpdateOpts) (*networks.Network, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateNetwork", arg0, arg1)
+	ret0, _ := ret[0].(*networks.Network)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateNetwork indicates an expected call of UpdateNetwork.
+func (mr *MockNetworkingMockRecorder) UpdateNetwork(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateNetwork", reflect.TypeOf((*MockNetworking)(nil).UpdateNetwork), arg0, arg1)
+}
+
+// UpdateRouter mocks base method.
+func (m *MockNetworking) UpdateRouter(arg0 string, arg1 routers.UpdateOpts) (*routers.Router, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateRouter", arg0, arg1)
+	ret0, _ := ret[0].(*routers.Router)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateRouter indicates an expected call of UpdateRouter.
+func (mr *MockNetworkingMockRecorder) UpdateRouter(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateRouter", reflect.TypeOf((*MockNetworking)(nil).UpdateRouter), arg0, arg1)
+}
+
 // UpdateRoutesForRouter mocks base method.
 func (m *MockNetworking) UpdateRoutesForRouter(arg0 []routers.Route, arg1 string) (*routers.Router, error) {
 	m.ctrl.T.Helper()
@@ -698,4 +967,19 @@ func (m *MockNetworking) UpdateRoutesForRouter(arg0 []routers.Route, arg1 string
 func (mr *MockNetworkingMockRecorder) UpdateRoutesForRouter(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateRoutesForRouter", reflect.TypeOf((*MockNetworking)(nil).UpdateRoutesForRouter), arg0, arg1)
+}
+
+// UpdateSubnet mocks base method.
+func (m *MockNetworking) UpdateSubnet(arg0 string, arg1 subnets.UpdateOpts) (*subnets.Subnet, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateSubnet", arg0, arg1)
+	ret0, _ := ret[0].(*subnets.Subnet)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateSubnet indicates an expected call of UpdateSubnet.
+func (mr *MockNetworkingMockRecorder) UpdateSubnet(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSubnet", reflect.TypeOf((*MockNetworking)(nil).UpdateSubnet), arg0, arg1)
 }

--- a/pkg/openstack/client/mocks/client_mocks.go
+++ b/pkg/openstack/client/mocks/client_mocks.go
@@ -775,18 +775,18 @@ func (mr *MockNetworkingMockRecorder) GetRouterByID(arg0 interface{}) *gomock.Ca
 }
 
 // GetRouterInterfacePort mocks base method.
-func (m *MockNetworking) GetRouterInterfacePort(arg0 string) (*ports.Port, error) {
+func (m *MockNetworking) GetRouterInterfacePort(arg0, arg1 string) (*ports.Port, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetRouterInterfacePort", arg0)
+	ret := m.ctrl.Call(m, "GetRouterInterfacePort", arg0, arg1)
 	ret0, _ := ret[0].(*ports.Port)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetRouterInterfacePort indicates an expected call of GetRouterInterfacePort.
-func (mr *MockNetworkingMockRecorder) GetRouterInterfacePort(arg0 interface{}) *gomock.Call {
+func (mr *MockNetworkingMockRecorder) GetRouterInterfacePort(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRouterInterfacePort", reflect.TypeOf((*MockNetworking)(nil).GetRouterInterfacePort), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRouterInterfacePort", reflect.TypeOf((*MockNetworking)(nil).GetRouterInterfacePort), arg0, arg1)
 }
 
 // GetSecurityGroup mocks base method.

--- a/pkg/openstack/client/networking.go
+++ b/pkg/openstack/client/networking.go
@@ -16,6 +16,7 @@ package client
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/external"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/floatingips"
@@ -23,6 +24,8 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/networks"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/ports"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/subnets"
 	"k8s.io/utils/pointer"
 )
 
@@ -33,8 +36,21 @@ type networkWithExternalExt struct {
 
 // GetExternalNetworkNames returns a list of all external network names.
 func (c *NetworkingClient) GetExternalNetworkNames(_ context.Context) ([]string, error) {
+	externalNetworks, err := c.listExternalNetworks(networks.ListOpts{})
+	if err != nil {
+		return nil, err
+	}
+	var externalNetworkNames []string
+	for _, externalNetwork := range externalNetworks {
+		externalNetworkNames = append(externalNetworkNames, externalNetwork.Name)
+	}
+	return externalNetworkNames, nil
+}
+
+// GetExternalNetworkNames returns a list of all external network names.
+func (c *NetworkingClient) listExternalNetworks(listOpts networks.ListOptsBuilder) ([]networkWithExternalExt, error) {
 	allPages, err := networks.List(c.client, external.ListOptsExt{
-		ListOptsBuilder: networks.ListOpts{},
+		ListOptsBuilder: listOpts,
 		External:        pointer.Bool(true),
 	}).AllPages()
 	if err != nil {
@@ -46,12 +62,22 @@ func (c *NetworkingClient) GetExternalNetworkNames(_ context.Context) ([]string,
 	if err != nil {
 		return nil, err
 	}
+	return externalNetworks, nil
+}
 
-	var externalNetworkNames []string
-	for _, externalNetwork := range externalNetworks {
-		externalNetworkNames = append(externalNetworkNames, externalNetwork.Name)
+// GetExternalNetworkByName returns an external network by name
+func (c *NetworkingClient) GetExternalNetworkByName(name string) (*networks.Network, error) {
+	externalNetworks, err := c.listExternalNetworks(networks.ListOpts{Name: name})
+	if err != nil {
+		return nil, err
 	}
-	return externalNetworkNames, nil
+	if len(externalNetworks) == 0 {
+		return nil, nil
+	}
+	if len(externalNetworks) > 1 {
+		return nil, fmt.Errorf("duplicate external network name: %s (%d)", name, len(externalNetworks))
+	}
+	return &externalNetworks[0].Network, nil
 }
 
 // ListNetwork returns a list of all network info by listOpts
@@ -63,12 +89,27 @@ func (c *NetworkingClient) ListNetwork(listOpts networks.ListOpts) ([]networks.N
 	return networks.ExtractNetworks(pages)
 }
 
+// UpdateNetwork updates settings of a network resource
+func (c *NetworkingClient) UpdateNetwork(networkID string, opts networks.UpdateOpts) (*networks.Network, error) {
+	return networks.Update(c.client, networkID, opts).Extract()
+}
+
 // GetNetworkByName return a network info by name
 func (c *NetworkingClient) GetNetworkByName(name string) ([]networks.Network, error) {
 	listOpts := networks.ListOpts{
 		Name: name,
 	}
 	return c.ListNetwork(listOpts)
+}
+
+// CreateNetwork creates a network
+func (c *NetworkingClient) CreateNetwork(opts networks.CreateOpts) (*networks.Network, error) {
+	return networks.Create(c.client, opts).Extract()
+}
+
+// DeleteNetwork deletes a network
+func (c *NetworkingClient) DeleteNetwork(networkID string) error {
+	return networks.Delete(c.client, networkID).ExtractErr()
 }
 
 // CreateFloatingIP create floating ip
@@ -145,11 +186,19 @@ func (c *NetworkingClient) GetSecurityGroupByName(name string) ([]groups.SecGrou
 }
 
 // GetRouterByID return a router info by name
-func (c *NetworkingClient) GetRouterByID(id string) ([]routers.Router, error) {
-	listOpts := routers.ListOpts{
-		ID: id,
-	}
-	return c.ListRouters(listOpts)
+func (c *NetworkingClient) GetRouterByID(id string) (*routers.Router, error) {
+	router, err := routers.Get(c.client, id).Extract()
+	return router, IgnoreNotFoundError(err)
+}
+
+// GetSecurityGroup returns a security group info by id
+func (c *NetworkingClient) GetSecurityGroup(groupID string) (*groups.SecGroup, error) {
+	return groups.Get(c.client, groupID).Extract()
+}
+
+// CreateRouter creates a router
+func (c *NetworkingClient) CreateRouter(createOpts routers.CreateOpts) (*routers.Router, error) {
+	return routers.Create(c.client, createOpts).Extract()
 }
 
 // ListRouters returns a list of routers
@@ -168,4 +217,72 @@ func (c *NetworkingClient) UpdateRoutesForRouter(routes []routers.Route, routerI
 		Routes: &routes,
 	}
 	return routers.Update(c.client, routerID, updateOpts).Extract()
+}
+
+// UpdateRouter updates router settings
+func (c *NetworkingClient) UpdateRouter(routerID string, updateOpts routers.UpdateOpts) (*routers.Router, error) {
+	return routers.Update(c.client, routerID, updateOpts).Extract()
+}
+
+// DeleteRouter deletes a router by identifier
+func (c *NetworkingClient) DeleteRouter(routerID string) error {
+	return routers.Delete(c.client, routerID).ExtractErr()
+}
+
+// AddRouterInterface adds a router interface
+func (c *NetworkingClient) AddRouterInterface(routerID string, addOpts routers.AddInterfaceOpts) (*routers.InterfaceInfo, error) {
+	return routers.AddInterface(c.client, routerID, addOpts).Extract()
+}
+
+// RemoveRouterInterface removes a router interface
+func (c *NetworkingClient) RemoveRouterInterface(routerID string, removeOpts routers.RemoveInterfaceOpts) (*routers.InterfaceInfo, error) {
+	return routers.RemoveInterface(c.client, routerID, removeOpts).Extract()
+}
+
+// CreateSubnet creates a subnet
+func (c *NetworkingClient) CreateSubnet(createOpts subnets.CreateOpts) (*subnets.Subnet, error) {
+	return subnets.Create(c.client, createOpts).Extract()
+}
+
+// ListSubnets returns a list of subnets
+func (c *NetworkingClient) ListSubnets(listOpts subnets.ListOpts) ([]subnets.Subnet, error) {
+	page, err := subnets.List(c.client, listOpts).AllPages()
+	if err != nil {
+		return nil, err
+	}
+	return subnets.ExtractSubnets(page)
+}
+
+// UpdateSubnet updates a subnet
+func (c *NetworkingClient) UpdateSubnet(id string, updateOpts subnets.UpdateOpts) (*subnets.Subnet, error) {
+	return subnets.Update(c.client, id, updateOpts).Extract()
+}
+
+// DeleteSubnet deletes a subnet by identifier
+func (c *NetworkingClient) DeleteSubnet(subnetID string) error {
+	return subnets.Delete(c.client, subnetID).ExtractErr()
+}
+
+// GetPort gets a port by identifier
+func (c *NetworkingClient) GetPort(portID string) (*ports.Port, error) {
+	return ports.Get(c.client, portID).Extract()
+}
+
+// GetRouterInterfacePort gets a port for a router interface
+func (c *NetworkingClient) GetRouterInterfacePort(routerID string) (*ports.Port, error) {
+	page, err := ports.List(c.client, ports.ListOpts{
+		DeviceOwner: "network:router_interface",
+		DeviceID:    routerID,
+	}).AllPages()
+	if err != nil {
+		return nil, err
+	}
+	list, err := ports.ExtractPorts(page)
+	if err != nil {
+		return nil, err
+	}
+	if len(list) == 0 {
+		return nil, nil
+	}
+	return &list[0], nil
 }

--- a/pkg/openstack/client/networking.go
+++ b/pkg/openstack/client/networking.go
@@ -269,10 +269,13 @@ func (c *NetworkingClient) GetPort(portID string) (*ports.Port, error) {
 }
 
 // GetRouterInterfacePort gets a port for a router interface
-func (c *NetworkingClient) GetRouterInterfacePort(routerID string) (*ports.Port, error) {
+func (c *NetworkingClient) GetRouterInterfacePort(routerID, subnetID string) (*ports.Port, error) {
 	page, err := ports.List(c.client, ports.ListOpts{
 		DeviceOwner: "network:router_interface",
 		DeviceID:    routerID,
+		FixedIPs: []ports.FixedIPOpts{
+			{SubnetID: subnetID},
+		},
 	}).AllPages()
 	if err != nil {
 		return nil, err

--- a/pkg/openstack/client/types.go
+++ b/pkg/openstack/client/types.go
@@ -151,7 +151,7 @@ type Networking interface {
 	DeleteSubnet(subnetID string) error
 	// Ports
 	GetPort(portID string) (*ports.Port, error)
-	GetRouterInterfacePort(routerID string) (*ports.Port, error)
+	GetRouterInterfacePort(routerID, subnetID string) (*ports.Port, error)
 }
 
 // FactoryFactory creates instances of Factory.

--- a/pkg/openstack/client/types.go
+++ b/pkg/openstack/client/types.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/gophercloud/gophercloud"
 	computefip "github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/floatingips"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/keypairs"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/servergroups"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/images"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
@@ -28,6 +29,8 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/networks"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/ports"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/subnets"
 
 	"github.com/gardener/gardener-extension-provider-openstack/pkg/openstack"
 )
@@ -92,6 +95,11 @@ type Compute interface {
 	FindFlavorID(name string) (string, error)
 	FindImages(name string) ([]images.Image, error)
 	ListImages(listOpts images.ListOpts) ([]images.Image, error)
+
+	// KeyPairs
+	CreateKeyPair(name, publicKey string) (*keypairs.KeyPair, error)
+	GetKeyPair(name string) (*keypairs.KeyPair, error)
+	DeleteKeyPair(name string) error
 }
 
 // DNS describes the operations of a client interacting with OpenStack's DNS service.
@@ -105,8 +113,13 @@ type DNS interface {
 type Networking interface {
 	// External Network
 	GetExternalNetworkNames(ctx context.Context) ([]string, error)
+	GetExternalNetworkByName(name string) (*networks.Network, error)
+	// Network
+	CreateNetwork(opts networks.CreateOpts) (*networks.Network, error)
 	ListNetwork(listOpts networks.ListOpts) ([]networks.Network, error)
+	UpdateNetwork(networkID string, opts networks.UpdateOpts) (*networks.Network, error)
 	GetNetworkByName(name string) ([]networks.Network, error)
+	DeleteNetwork(networkID string) error
 	// FloatingIP
 	CreateFloatingIP(createOpts floatingips.CreateOpts) (*floatingips.FloatingIP, error)
 	DeleteFloatingIP(id string) error
@@ -116,15 +129,29 @@ type Networking interface {
 	CreateSecurityGroup(listOpts groups.CreateOpts) (*groups.SecGroup, error)
 	DeleteSecurityGroup(groupID string) error
 	ListSecurityGroup(listOpts groups.ListOpts) ([]groups.SecGroup, error)
+	GetSecurityGroup(groupID string) (*groups.SecGroup, error)
 	GetSecurityGroupByName(name string) ([]groups.SecGroup, error)
 	// Security Group rules
 	CreateRule(createOpts rules.CreateOpts) (*rules.SecGroupRule, error)
 	ListRules(listOpts rules.ListOpts) ([]rules.SecGroupRule, error)
 	DeleteRule(ruleID string) error
 	// Routers
-	GetRouterByID(id string) ([]routers.Router, error)
+	GetRouterByID(id string) (*routers.Router, error)
 	ListRouters(listOpts routers.ListOpts) ([]routers.Router, error)
 	UpdateRoutesForRouter(routes []routers.Route, routerID string) (*routers.Router, error)
+	UpdateRouter(routerID string, updateOpts routers.UpdateOpts) (*routers.Router, error)
+	CreateRouter(createOpts routers.CreateOpts) (*routers.Router, error)
+	DeleteRouter(routerID string) error
+	AddRouterInterface(routerID string, addOpts routers.AddInterfaceOpts) (*routers.InterfaceInfo, error)
+	RemoveRouterInterface(routerID string, removeOpts routers.RemoveInterfaceOpts) (*routers.InterfaceInfo, error)
+	// Subnets
+	CreateSubnet(createOpts subnets.CreateOpts) (*subnets.Subnet, error)
+	ListSubnets(listOpts subnets.ListOpts) ([]subnets.Subnet, error)
+	UpdateSubnet(subnetID string, updateOpts subnets.UpdateOpts) (*subnets.Subnet, error)
+	DeleteSubnet(subnetID string) error
+	// Ports
+	GetPort(portID string) (*ports.Port, error)
+	GetRouterInterfacePort(routerID string) (*ports.Port, error)
 }
 
 // FactoryFactory creates instances of Factory.

--- a/test/integration/infrastructure/infrastructure_test.go
+++ b/test/integration/infrastructure/infrastructure_test.go
@@ -287,12 +287,12 @@ var _ = Describe("Infrastructure tests", func() {
 
 			cloudRouterName := namespace + "-cloud-router"
 
-			routerID, err := prepareNewRouter(ctx, log, cloudRouterName, openstackClient)
+			routerID, err := prepareNewRouter(log, cloudRouterName, openstackClient)
 			Expect(err).NotTo(HaveOccurred())
 
 			var cleanupHandle framework.CleanupActionHandle
 			cleanupHandle = framework.AddCleanupAction(func() {
-				err := teardownRouter(ctx, log, *routerID, openstackClient)
+				err := teardownRouter(log, *routerID, openstackClient)
 				Expect(err).NotTo(HaveOccurred())
 
 				framework.RemoveCleanupAction(cleanupHandle)
@@ -342,12 +342,12 @@ var _ = Describe("Infrastructure tests", func() {
 
 			networkName := namespace + "-network"
 
-			networkID, err := prepareNewNetwork(ctx, log, networkName, openstackClient)
+			networkID, err := prepareNewNetwork(log, networkName, openstackClient)
 			Expect(err).NotTo(HaveOccurred())
 
 			var cleanupHandle framework.CleanupActionHandle
 			cleanupHandle = framework.AddCleanupAction(func() {
-				err := teardownNetwork(ctx, log, *networkID, openstackClient)
+				err := teardownNetwork(log, *networkID, openstackClient)
 				Expect(err).NotTo(HaveOccurred())
 
 				framework.RemoveCleanupAction(cleanupHandle)
@@ -408,19 +408,19 @@ var _ = Describe("Infrastructure tests", func() {
 			networkName := namespace + "-network"
 			cloudRouterName := namespace + "-cloud-router"
 
-			networkID, err := prepareNewNetwork(ctx, log, networkName, openstackClient)
+			networkID, err := prepareNewNetwork(log, networkName, openstackClient)
 			Expect(err).NotTo(HaveOccurred())
-			routerID, err := prepareNewRouter(ctx, log, cloudRouterName, openstackClient)
+			routerID, err := prepareNewRouter(log, cloudRouterName, openstackClient)
 			Expect(err).NotTo(HaveOccurred())
 
 			var cleanupHandle framework.CleanupActionHandle
 			cleanupHandle = framework.AddCleanupAction(func() {
 				By("Tearing down network")
-				err := teardownNetwork(ctx, log, *networkID, openstackClient)
+				err := teardownNetwork(log, *networkID, openstackClient)
 				Expect(err).NotTo(HaveOccurred())
 
 				By("Tearing down router")
-				err = teardownRouter(ctx, log, *routerID, openstackClient)
+				err = teardownRouter(log, *routerID, openstackClient)
 				Expect(err).NotTo(HaveOccurred())
 
 				framework.RemoveCleanupAction(cleanupHandle)

--- a/test/integration/infrastructure/infrastructure_test.go
+++ b/test/integration/infrastructure/infrastructure_test.go
@@ -22,7 +22,6 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/gardener/gardener-extension-provider-openstack/pkg/controller/infrastructure/infraflow"
 	gardenerv1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
@@ -53,6 +52,7 @@ import (
 	openstackinstall "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack/install"
 	openstackv1alpha1 "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack/v1alpha1"
 	"github.com/gardener/gardener-extension-provider-openstack/pkg/controller/infrastructure"
+	"github.com/gardener/gardener-extension-provider-openstack/pkg/controller/infrastructure/infraflow"
 	"github.com/gardener/gardener-extension-provider-openstack/pkg/openstack"
 )
 

--- a/test/integration/infrastructure/infrastructure_test.go
+++ b/test/integration/infrastructure/infrastructure_test.go
@@ -18,9 +18,11 @@ import (
 	"context"
 	"encoding/json"
 	"flag"
+	"fmt"
 	"path/filepath"
 	"time"
 
+	"github.com/gardener/gardener-extension-provider-openstack/pkg/controller/infrastructure/infraflow"
 	gardenerv1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
@@ -52,6 +54,15 @@ import (
 	openstackv1alpha1 "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack/v1alpha1"
 	"github.com/gardener/gardener-extension-provider-openstack/pkg/controller/infrastructure"
 	"github.com/gardener/gardener-extension-provider-openstack/pkg/openstack"
+)
+
+type flowUsage int
+
+const (
+	fuUseTerraformer flowUsage = iota
+	fuMigrateFromTerraformer
+	fuUseFlow
+	fuUseFlowRecoverState
 )
 
 const (
@@ -117,7 +128,7 @@ var _ = BeforeSuite(func() {
 	// enable manager logs
 	logf.SetLogger(logger.MustNewZapLogger(logger.DebugLevel, logger.FormatJSON, zap.WriteTo(GinkgoWriter)))
 
-	log = logf.Log.WithName("bastion-test")
+	log = logf.Log.WithName("infrastructure-test")
 
 	DeferCleanup(func() {
 		defer func() {
@@ -207,13 +218,35 @@ var _ = Describe("Infrastructure tests", func() {
 			framework.RunCleanupActions()
 		})
 
-		It("should successfully create and delete", func() {
+		It("should successfully create and delete (flow)", func() {
 			providerConfig := newProviderConfig("", nil)
 			cloudProfileConfig := newCloudProfileConfig(openstackClient.Region, openstackClient.AuthURL)
 			namespace, err := generateNamespaceName()
 			Expect(err).NotTo(HaveOccurred())
 
-			err = runTest(ctx, log, c, namespace, providerConfig, decoder, openstackClient, cloudProfileConfig)
+			err = runTest(ctx, log, c, namespace, providerConfig, decoder, openstackClient, cloudProfileConfig, fuUseFlow)
+
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should successfully create and delete (migration)", func() {
+			providerConfig := newProviderConfig("", nil)
+			cloudProfileConfig := newCloudProfileConfig(openstackClient.Region, openstackClient.AuthURL)
+			namespace, err := generateNamespaceName()
+			Expect(err).NotTo(HaveOccurred())
+
+			err = runTest(ctx, log, c, namespace, providerConfig, decoder, openstackClient, cloudProfileConfig, fuMigrateFromTerraformer)
+
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should successfully create and delete (terraformer)", func() {
+			providerConfig := newProviderConfig("", nil)
+			cloudProfileConfig := newCloudProfileConfig(openstackClient.Region, openstackClient.AuthURL)
+			namespace, err := generateNamespaceName()
+			Expect(err).NotTo(HaveOccurred())
+
+			err = runTest(ctx, log, c, namespace, providerConfig, decoder, openstackClient, cloudProfileConfig, fuUseTerraformer)
 
 			Expect(err).NotTo(HaveOccurred())
 		})
@@ -224,7 +257,7 @@ var _ = Describe("Infrastructure tests", func() {
 			framework.RunCleanupActions()
 		})
 
-		It("should successfully create and delete", func() {
+		It("should successfully create and delete (flow)", func() {
 			namespace, err := generateNamespaceName()
 			Expect(err).NotTo(HaveOccurred())
 
@@ -244,7 +277,31 @@ var _ = Describe("Infrastructure tests", func() {
 			providerConfig := newProviderConfig(*routerID, nil)
 			cloudProfileConfig := newCloudProfileConfig(openstackClient.Region, openstackClient.AuthURL)
 
-			err = runTest(ctx, log, c, namespace, providerConfig, decoder, openstackClient, cloudProfileConfig)
+			err = runTest(ctx, log, c, namespace, providerConfig, decoder, openstackClient, cloudProfileConfig, fuUseFlow)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should successfully create and delete (terraformer)", func() {
+			namespace, err := generateNamespaceName()
+			Expect(err).NotTo(HaveOccurred())
+
+			cloudRouterName := namespace + "-cloud-router"
+
+			routerID, err := prepareNewRouter(ctx, log, cloudRouterName, openstackClient)
+			Expect(err).NotTo(HaveOccurred())
+
+			var cleanupHandle framework.CleanupActionHandle
+			cleanupHandle = framework.AddCleanupAction(func() {
+				err := teardownRouter(ctx, log, *routerID, openstackClient)
+				Expect(err).NotTo(HaveOccurred())
+
+				framework.RemoveCleanupAction(cleanupHandle)
+			})
+
+			providerConfig := newProviderConfig(*routerID, nil)
+			cloudProfileConfig := newCloudProfileConfig(openstackClient.Region, openstackClient.AuthURL)
+
+			err = runTest(ctx, log, c, namespace, providerConfig, decoder, openstackClient, cloudProfileConfig, fuUseTerraformer)
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})
@@ -254,7 +311,7 @@ var _ = Describe("Infrastructure tests", func() {
 			framework.RunCleanupActions()
 		})
 
-		It("should successfully create and delete", func() {
+		It("should successfully create and delete (flow)", func() {
 			namespace, err := generateNamespaceName()
 			Expect(err).NotTo(HaveOccurred())
 
@@ -274,7 +331,32 @@ var _ = Describe("Infrastructure tests", func() {
 			providerConfig := newProviderConfig("", networkID)
 			cloudProfileConfig := newCloudProfileConfig(openstackClient.Region, openstackClient.AuthURL)
 
-			err = runTest(ctx, log, c, namespace, providerConfig, decoder, openstackClient, cloudProfileConfig)
+			err = runTest(ctx, log, c, namespace, providerConfig, decoder, openstackClient, cloudProfileConfig, fuUseFlow)
+
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should successfully create and delete (terraformer)", func() {
+			namespace, err := generateNamespaceName()
+			Expect(err).NotTo(HaveOccurred())
+
+			networkName := namespace + "-network"
+
+			networkID, err := prepareNewNetwork(ctx, log, networkName, openstackClient)
+			Expect(err).NotTo(HaveOccurred())
+
+			var cleanupHandle framework.CleanupActionHandle
+			cleanupHandle = framework.AddCleanupAction(func() {
+				err := teardownNetwork(ctx, log, *networkID, openstackClient)
+				Expect(err).NotTo(HaveOccurred())
+
+				framework.RemoveCleanupAction(cleanupHandle)
+			})
+
+			providerConfig := newProviderConfig("", networkID)
+			cloudProfileConfig := newCloudProfileConfig(openstackClient.Region, openstackClient.AuthURL)
+
+			err = runTest(ctx, log, c, namespace, providerConfig, decoder, openstackClient, cloudProfileConfig, fuUseTerraformer)
 
 			Expect(err).NotTo(HaveOccurred())
 		})
@@ -285,7 +367,7 @@ var _ = Describe("Infrastructure tests", func() {
 			framework.RunCleanupActions()
 		})
 
-		It("should successfully create and delete", func() {
+		It("should successfully create and delete (flow)", func() {
 			namespace, err := generateNamespaceName()
 			Expect(err).NotTo(HaveOccurred())
 
@@ -313,7 +395,41 @@ var _ = Describe("Infrastructure tests", func() {
 			providerConfig := newProviderConfig(*routerID, networkID)
 			cloudProfileConfig := newCloudProfileConfig(openstackClient.Region, openstackClient.AuthURL)
 
-			err = runTest(ctx, log, c, namespace, providerConfig, decoder, openstackClient, cloudProfileConfig)
+			err = runTest(ctx, log, c, namespace, providerConfig, decoder, openstackClient, cloudProfileConfig, fuUseFlowRecoverState)
+
+			Expect(err).NotTo(HaveOccurred())
+
+		})
+
+		It("should successfully create and delete (terraformer)", func() {
+			namespace, err := generateNamespaceName()
+			Expect(err).NotTo(HaveOccurred())
+
+			networkName := namespace + "-network"
+			cloudRouterName := namespace + "-cloud-router"
+
+			networkID, err := prepareNewNetwork(ctx, log, networkName, openstackClient)
+			Expect(err).NotTo(HaveOccurred())
+			routerID, err := prepareNewRouter(ctx, log, cloudRouterName, openstackClient)
+			Expect(err).NotTo(HaveOccurred())
+
+			var cleanupHandle framework.CleanupActionHandle
+			cleanupHandle = framework.AddCleanupAction(func() {
+				By("Tearing down network")
+				err := teardownNetwork(ctx, log, *networkID, openstackClient)
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Tearing down router")
+				err = teardownRouter(ctx, log, *routerID, openstackClient)
+				Expect(err).NotTo(HaveOccurred())
+
+				framework.RemoveCleanupAction(cleanupHandle)
+			})
+
+			providerConfig := newProviderConfig(*routerID, networkID)
+			cloudProfileConfig := newCloudProfileConfig(openstackClient.Region, openstackClient.AuthURL)
+
+			err = runTest(ctx, log, c, namespace, providerConfig, decoder, openstackClient, cloudProfileConfig, fuUseTerraformer)
 
 			Expect(err).NotTo(HaveOccurred())
 
@@ -330,6 +446,7 @@ func runTest(
 	decoder runtime.Decoder,
 	openstackClient *OpenstackClient,
 	cloudProfileConfig *openstackv1alpha1.CloudProfileConfig,
+	flow flowUsage,
 ) error {
 	var (
 		namespace                 *corev1.Namespace
@@ -440,7 +557,7 @@ func runTest(
 	}
 
 	By("create infrastructure")
-	infra, err = newInfrastructure(namespaceName, providerConfig)
+	infra, err = newInfrastructure(namespaceName, providerConfig, flow == fuUseFlow || flow == fuUseFlowRecoverState)
 	if err != nil {
 		return err
 	}
@@ -477,7 +594,76 @@ func runTest(
 	By("verify infrastructure creation")
 	infrastructureIdentifiers = verifyCreation(openstackClient, providerStatus, providerConfig)
 
+	oldState := infra.Status.State
+	if flow == fuUseFlowRecoverState {
+		By("drop state for testing recover")
+		patch := client.MergeFrom(infra.DeepCopy())
+		infra.Status.ProviderStatus = nil
+		state, err := infraflow.NewPersistentState().ToJSON()
+		Expect(err).To(Succeed())
+		infra.Status.State = &runtime.RawExtension{Raw: state}
+		err = c.Status().Patch(ctx, infra, patch)
+		Expect(err).To(Succeed())
+	}
+
+	By("triggering infrastructure reconciliation")
+	infraCopy := infra.DeepCopy()
+	metav1.SetMetaDataAnnotation(&infra.ObjectMeta, "gardener.cloud/operation", "reconcile")
+	if flow == fuMigrateFromTerraformer {
+		metav1.SetMetaDataAnnotation(&infra.ObjectMeta, infrastructure.AnnotationKeyUseFlow, "true")
+	}
+	Expect(c.Patch(ctx, infra, client.MergeFrom(infraCopy))).To(Succeed())
+
+	By("wait until infrastructure is reconciled")
+	if err := extensions.WaitUntilObjectReadyWithHealthFunction(
+		ctx,
+		c,
+		log,
+		checkOperationAnnotationRemoved,
+		infra,
+		"Infrastucture",
+		10*time.Second,
+		30*time.Second,
+		5*time.Minute,
+		nil,
+	); err != nil {
+		Expect(err).To(Succeed())
+	}
+	if err := extensions.WaitUntilExtensionObjectReady(
+		ctx,
+		c,
+		log,
+		infra,
+		"Infrastucture",
+		10*time.Second,
+		30*time.Second,
+		16*time.Minute,
+		nil,
+	); err != nil {
+		Expect(err).To(Succeed())
+	}
+
+	if flow == fuUseFlowRecoverState {
+		By("check state recovery")
+		if err := c.Get(ctx, client.ObjectKey{Namespace: infra.Namespace, Name: infra.Name}, infra); err != nil {
+			return err
+		}
+		Expect(infra.Status.State).To(Equal(oldState))
+		newProviderStatus := &openstackv1alpha1.InfrastructureStatus{}
+		if _, _, err := decoder.Decode(infra.Status.ProviderStatus.Raw, nil, newProviderStatus); err != nil {
+			return err
+		}
+		Expect(newProviderStatus).To(Equal(providerStatus))
+	}
+
 	return nil
+}
+
+func checkOperationAnnotationRemoved(obj client.Object) error {
+	if annots := obj.GetAnnotations(); annots["gardener.cloud/operation"] == "" {
+		return nil
+	}
+	return fmt.Errorf("reconciliation not started yet")
 }
 
 // newProviderConfig creates a providerConfig with the network and router details.
@@ -519,7 +705,7 @@ func newCloudProfileConfig(region string, authURL string) *openstackv1alpha1.Clo
 	}
 }
 
-func newInfrastructure(namespace string, providerConfig *openstackv1alpha1.InfrastructureConfig) (*extensionsv1alpha1.Infrastructure, error) {
+func newInfrastructure(namespace string, providerConfig *openstackv1alpha1.InfrastructureConfig, useFlow bool) (*extensionsv1alpha1.Infrastructure, error) {
 	const sshPublicKey = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDcSZKq0lM9w+ElLp9I9jFvqEFbOV1+iOBX7WEe66GvPLOWl9ul03ecjhOf06+FhPsWFac1yaxo2xj+SJ+FVZ3DdSn4fjTpS9NGyQVPInSZveetRw0TV0rbYCFBTJuVqUFu6yPEgdcWq8dlUjLqnRNwlelHRcJeBfACBZDLNSxjj0oUz7ANRNCEne1ecySwuJUAz3IlNLPXFexRT0alV7Nl9hmJke3dD73nbeGbQtwvtu8GNFEoO4Eu3xOCKsLw6ILLo4FBiFcYQOZqvYZgCb4ncKM52bnABagG54upgBMZBRzOJvWp0ol+jK3Em7Vb6ufDTTVNiQY78U6BAlNZ8Xg+LUVeyk1C6vWjzAQf02eRvMdfnRCFvmwUpzbHWaVMsQm8gf3AgnTUuDR0ev1nQH/5892wZA86uLYW/wLiiSbvQsqtY1jSn9BAGFGdhXgWLAkGsd/E1vOT+vDcor6/6KjHBm0rG697A3TDBRkbXQ/1oFxcM9m17RteCaXuTiAYWMqGKDoJvTMDc4L+Uvy544pEfbOH39zfkIYE76WLAFPFsUWX6lXFjQrX3O7vEV73bCHoJnwzaNd03PSdJOw+LCzrTmxVezwli3F9wUDiBRB0HkQxIXQmncc1HSecCKALkogIK+1e1OumoWh6gPdkF4PlTMUxRitrwPWSaiUIlPfCpQ== your_email@example.com"
 
 	providerConfigJSON, err := json.Marshal(&providerConfig)
@@ -527,7 +713,7 @@ func newInfrastructure(namespace string, providerConfig *openstackv1alpha1.Infra
 		return nil, err
 	}
 
-	return &extensionsv1alpha1.Infrastructure{
+	infra := &extensionsv1alpha1.Infrastructure{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "infrastructure",
 			Namespace: namespace,
@@ -546,7 +732,11 @@ func newInfrastructure(namespace string, providerConfig *openstackv1alpha1.Infra
 			Region:       *region,
 			SSHPublicKey: []byte(sshPublicKey),
 		},
-	}, nil
+	}
+	if useFlow {
+		infra.Annotations = map[string]string{infrastructure.AnnotationKeyUseFlow: "true"}
+	}
+	return infra, nil
 }
 
 func generateNamespaceName() (string, error) {

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/ports/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/ports/doc.go
@@ -1,0 +1,73 @@
+/*
+Package ports contains functionality for working with Neutron port resources.
+
+A port represents a virtual switch port on a logical network switch. Virtual
+instances attach their interfaces into ports. The logical port also defines
+the MAC address and the IP address(es) to be assigned to the interfaces
+plugged into them. When IP addresses are associated to a port, this also
+implies the port is associated with a subnet, as the IP address was taken
+from the allocation pool for a specific subnet.
+
+Example to List Ports
+
+	listOpts := ports.ListOpts{
+		DeviceID: "b0b89efe-82f8-461d-958b-adbf80f50c7d",
+	}
+
+	allPages, err := ports.List(networkClient, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allPorts, err := ports.ExtractPorts(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, port := range allPorts {
+		fmt.Printf("%+v\n", port)
+	}
+
+Example to Create a Port
+
+	createOtps := ports.CreateOpts{
+		Name:         "private-port",
+		AdminStateUp: &asu,
+		NetworkID:    "a87cc70a-3e15-4acf-8205-9b711a3531b7",
+		FixedIPs: []ports.IP{
+			{SubnetID: "a0304c3a-4f08-4c43-88af-d796509c97d2", IPAddress: "10.0.0.2"},
+		},
+		SecurityGroups: &[]string{"foo"},
+		AllowedAddressPairs: []ports.AddressPair{
+			{IPAddress: "10.0.0.4", MACAddress: "fa:16:3e:c9:cb:f0"},
+		},
+	}
+
+	port, err := ports.Create(networkClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Update a Port
+
+	portID := "c34bae2b-7641-49b6-bf6d-d8e473620ed8"
+
+	updateOpts := ports.UpdateOpts{
+		Name:           "new_name",
+		SecurityGroups: &[]string{},
+	}
+
+	port, err := ports.Update(networkClient, portID, updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Delete a Port
+
+	portID := "c34bae2b-7641-49b6-bf6d-d8e473620ed8"
+	err := ports.Delete(networkClient, portID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+*/
+package ports

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/ports/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/ports/requests.go
@@ -1,0 +1,204 @@
+package ports
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// ListOptsBuilder allows extensions to add additional parameters to the
+// List request.
+type ListOptsBuilder interface {
+	ToPortListQuery() (string, error)
+}
+
+// ListOpts allows the filtering and sorting of paginated collections through
+// the API. Filtering is achieved by passing in struct field values that map to
+// the port attributes you want to see returned. SortKey allows you to sort
+// by a particular port attribute. SortDir sets the direction, and is either
+// `asc' or `desc'. Marker and Limit are used for pagination.
+type ListOpts struct {
+	Status       string `q:"status"`
+	Name         string `q:"name"`
+	Description  string `q:"description"`
+	AdminStateUp *bool  `q:"admin_state_up"`
+	NetworkID    string `q:"network_id"`
+	TenantID     string `q:"tenant_id"`
+	ProjectID    string `q:"project_id"`
+	DeviceOwner  string `q:"device_owner"`
+	MACAddress   string `q:"mac_address"`
+	ID           string `q:"id"`
+	DeviceID     string `q:"device_id"`
+	Limit        int    `q:"limit"`
+	Marker       string `q:"marker"`
+	SortKey      string `q:"sort_key"`
+	SortDir      string `q:"sort_dir"`
+	Tags         string `q:"tags"`
+	TagsAny      string `q:"tags-any"`
+	NotTags      string `q:"not-tags"`
+	NotTagsAny   string `q:"not-tags-any"`
+	FixedIPs     []FixedIPOpts
+}
+
+type FixedIPOpts struct {
+	IPAddress       string
+	IPAddressSubstr string
+	SubnetID        string
+}
+
+func (f FixedIPOpts) String() string {
+	var res []string
+	if f.IPAddress != "" {
+		res = append(res, fmt.Sprintf("ip_address=%s", f.IPAddress))
+	}
+	if f.IPAddressSubstr != "" {
+		res = append(res, fmt.Sprintf("ip_address_substr=%s", f.IPAddressSubstr))
+	}
+	if f.SubnetID != "" {
+		res = append(res, fmt.Sprintf("subnet_id=%s", f.SubnetID))
+	}
+	return strings.Join(res, ",")
+}
+
+// ToPortListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToPortListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	params := q.Query()
+	for _, fixedIP := range opts.FixedIPs {
+		params.Add("fixed_ips", fixedIP.String())
+	}
+	q = &url.URL{RawQuery: params.Encode()}
+	return q.String(), err
+}
+
+// List returns a Pager which allows you to iterate over a collection of
+// ports. It accepts a ListOpts struct, which allows you to filter and sort
+// the returned collection for greater efficiency.
+//
+// Default policy settings return only those ports that are owned by the tenant
+// who submits the request, unless the request is submitted by a user with
+// administrative rights.
+func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := listURL(c)
+	if opts != nil {
+		query, err := opts.ToPortListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
+		return PortPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+// Get retrieves a specific port based on its unique ID.
+func Get(c *gophercloud.ServiceClient, id string) (r GetResult) {
+	resp, err := c.Get(getURL(c, id), &r.Body, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
+type CreateOptsBuilder interface {
+	ToPortCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts represents the attributes used when creating a new port.
+type CreateOpts struct {
+	NetworkID           string        `json:"network_id" required:"true"`
+	Name                string        `json:"name,omitempty"`
+	Description         string        `json:"description,omitempty"`
+	AdminStateUp        *bool         `json:"admin_state_up,omitempty"`
+	MACAddress          string        `json:"mac_address,omitempty"`
+	FixedIPs            interface{}   `json:"fixed_ips,omitempty"`
+	DeviceID            string        `json:"device_id,omitempty"`
+	DeviceOwner         string        `json:"device_owner,omitempty"`
+	TenantID            string        `json:"tenant_id,omitempty"`
+	ProjectID           string        `json:"project_id,omitempty"`
+	SecurityGroups      *[]string     `json:"security_groups,omitempty"`
+	AllowedAddressPairs []AddressPair `json:"allowed_address_pairs,omitempty"`
+}
+
+// ToPortCreateMap builds a request body from CreateOpts.
+func (opts CreateOpts) ToPortCreateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "port")
+}
+
+// Create accepts a CreateOpts struct and creates a new network using the values
+// provided. You must remember to provide a NetworkID value.
+func Create(c *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToPortCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := c.Post(createURL(c), b, &r.Body, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// UpdateOptsBuilder allows extensions to add additional parameters to the
+// Update request.
+type UpdateOptsBuilder interface {
+	ToPortUpdateMap() (map[string]interface{}, error)
+}
+
+// UpdateOpts represents the attributes used when updating an existing port.
+type UpdateOpts struct {
+	Name                *string        `json:"name,omitempty"`
+	Description         *string        `json:"description,omitempty"`
+	AdminStateUp        *bool          `json:"admin_state_up,omitempty"`
+	FixedIPs            interface{}    `json:"fixed_ips,omitempty"`
+	DeviceID            *string        `json:"device_id,omitempty"`
+	DeviceOwner         *string        `json:"device_owner,omitempty"`
+	SecurityGroups      *[]string      `json:"security_groups,omitempty"`
+	AllowedAddressPairs *[]AddressPair `json:"allowed_address_pairs,omitempty"`
+
+	// RevisionNumber implements extension:standard-attr-revisions. If != "" it
+	// will set revision_number=%s. If the revision number does not match, the
+	// update will fail.
+	RevisionNumber *int `json:"-" h:"If-Match"`
+}
+
+// ToPortUpdateMap builds a request body from UpdateOpts.
+func (opts UpdateOpts) ToPortUpdateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "port")
+}
+
+// Update accepts a UpdateOpts struct and updates an existing port using the
+// values provided.
+func Update(c *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+	b, err := opts.ToPortUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	h, err := gophercloud.BuildHeaders(opts)
+	if err != nil {
+		r.Err = err
+		return
+	}
+	for k := range h {
+		if k == "If-Match" {
+			h[k] = fmt.Sprintf("revision_number=%s", h[k])
+		}
+	}
+	resp, err := c.Put(updateURL(c, id), b, &r.Body, &gophercloud.RequestOpts{
+		MoreHeaders: h,
+		OkCodes:     []int{200, 201},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// Delete accepts a unique ID and deletes the port associated with it.
+func Delete(c *gophercloud.ServiceClient, id string) (r DeleteResult) {
+	resp, err := c.Delete(deleteURL(c, id), nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/ports/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/ports/results.go
@@ -1,0 +1,199 @@
+package ports
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+// Extract is a function that accepts a result and extracts a port resource.
+func (r commonResult) Extract() (*Port, error) {
+	var s Port
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
+func (r commonResult) ExtractInto(v interface{}) error {
+	return r.Result.ExtractIntoStructPtr(v, "port")
+}
+
+// CreateResult represents the result of a create operation. Call its Extract
+// method to interpret it as a Port.
+type CreateResult struct {
+	commonResult
+}
+
+// GetResult represents the result of a get operation. Call its Extract
+// method to interpret it as a Port.
+type GetResult struct {
+	commonResult
+}
+
+// UpdateResult represents the result of an update operation. Call its Extract
+// method to interpret it as a Port.
+type UpdateResult struct {
+	commonResult
+}
+
+// DeleteResult represents the result of a delete operation. Call its
+// ExtractErr method to determine if the request succeeded or failed.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}
+
+// IP is a sub-struct that represents an individual IP.
+type IP struct {
+	SubnetID  string `json:"subnet_id"`
+	IPAddress string `json:"ip_address,omitempty"`
+}
+
+// AddressPair contains the IP Address and the MAC address.
+type AddressPair struct {
+	IPAddress  string `json:"ip_address,omitempty"`
+	MACAddress string `json:"mac_address,omitempty"`
+}
+
+// Port represents a Neutron port. See package documentation for a top-level
+// description of what this is.
+type Port struct {
+	// UUID for the port.
+	ID string `json:"id"`
+
+	// Network that this port is associated with.
+	NetworkID string `json:"network_id"`
+
+	// Human-readable name for the port. Might not be unique.
+	Name string `json:"name"`
+
+	// Describes the port.
+	Description string `json:"description"`
+
+	// Administrative state of port. If false (down), port does not forward
+	// packets.
+	AdminStateUp bool `json:"admin_state_up"`
+
+	// Indicates whether network is currently operational. Possible values include
+	// `ACTIVE', `DOWN', `BUILD', or `ERROR'. Plug-ins might define additional
+	// values.
+	Status string `json:"status"`
+
+	// Mac address to use on this port.
+	MACAddress string `json:"mac_address"`
+
+	// Specifies IP addresses for the port thus associating the port itself with
+	// the subnets where the IP addresses are picked from
+	FixedIPs []IP `json:"fixed_ips"`
+
+	// TenantID is the project owner of the port.
+	TenantID string `json:"tenant_id"`
+
+	// ProjectID is the project owner of the port.
+	ProjectID string `json:"project_id"`
+
+	// Identifies the entity (e.g.: dhcp agent) using this port.
+	DeviceOwner string `json:"device_owner"`
+
+	// Specifies the IDs of any security groups associated with a port.
+	SecurityGroups []string `json:"security_groups"`
+
+	// Identifies the device (e.g., virtual server) using this port.
+	DeviceID string `json:"device_id"`
+
+	// Identifies the list of IP addresses the port will recognize/accept
+	AllowedAddressPairs []AddressPair `json:"allowed_address_pairs"`
+
+	// Tags optionally set via extensions/attributestags
+	Tags []string `json:"tags"`
+
+	// RevisionNumber optionally set via extensions/standard-attr-revisions
+	RevisionNumber int `json:"revision_number"`
+
+	// Timestamp when the port was created
+	CreatedAt time.Time `json:"created_at"`
+
+	// Timestamp when the port was last updated
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+func (r *Port) UnmarshalJSON(b []byte) error {
+	type tmp Port
+
+	// Support for older neutron time format
+	var s1 struct {
+		tmp
+		CreatedAt gophercloud.JSONRFC3339NoZ `json:"created_at"`
+		UpdatedAt gophercloud.JSONRFC3339NoZ `json:"updated_at"`
+	}
+
+	err := json.Unmarshal(b, &s1)
+	if err == nil {
+		*r = Port(s1.tmp)
+		r.CreatedAt = time.Time(s1.CreatedAt)
+		r.UpdatedAt = time.Time(s1.UpdatedAt)
+
+		return nil
+	}
+
+	// Support for newer neutron time format
+	var s2 struct {
+		tmp
+		CreatedAt time.Time `json:"created_at"`
+		UpdatedAt time.Time `json:"updated_at"`
+	}
+
+	err = json.Unmarshal(b, &s2)
+	if err != nil {
+		return err
+	}
+
+	*r = Port(s2.tmp)
+	r.CreatedAt = time.Time(s2.CreatedAt)
+	r.UpdatedAt = time.Time(s2.UpdatedAt)
+
+	return nil
+}
+
+// PortPage is the page returned by a pager when traversing over a collection
+// of network ports.
+type PortPage struct {
+	pagination.LinkedPageBase
+}
+
+// NextPageURL is invoked when a paginated collection of ports has reached
+// the end of a page and the pager seeks to traverse over a new one. In order
+// to do this, it needs to construct the next page's URL.
+func (r PortPage) NextPageURL() (string, error) {
+	var s struct {
+		Links []gophercloud.Link `json:"ports_links"`
+	}
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+	return gophercloud.ExtractNextURL(s.Links)
+}
+
+// IsEmpty checks whether a PortPage struct is empty.
+func (r PortPage) IsEmpty() (bool, error) {
+	is, err := ExtractPorts(r)
+	return len(is) == 0, err
+}
+
+// ExtractPorts accepts a Page struct, specifically a PortPage struct,
+// and extracts the elements into a slice of Port structs. In other words,
+// a generic collection is mapped into a relevant slice.
+func ExtractPorts(r pagination.Page) ([]Port, error) {
+	var s []Port
+	err := ExtractPortsInto(r, &s)
+	return s, err
+}
+
+func ExtractPortsInto(r pagination.Page, v interface{}) error {
+	return r.(PortPage).Result.ExtractIntoSlicePtr(v, "ports")
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/ports/urls.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/ports/urls.go
@@ -1,0 +1,31 @@
+package ports
+
+import "github.com/gophercloud/gophercloud"
+
+func resourceURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL("ports", id)
+}
+
+func rootURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("ports")
+}
+
+func listURL(c *gophercloud.ServiceClient) string {
+	return rootURL(c)
+}
+
+func getURL(c *gophercloud.ServiceClient, id string) string {
+	return resourceURL(c, id)
+}
+
+func createURL(c *gophercloud.ServiceClient) string {
+	return rootURL(c)
+}
+
+func updateURL(c *gophercloud.ServiceClient, id string) string {
+	return resourceURL(c, id)
+}
+
+func deleteURL(c *gophercloud.ServiceClient, id string) string {
+	return resourceURL(c, id)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -350,6 +350,7 @@ github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/rou
 github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups
 github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules
 github.com/gophercloud/gophercloud/openstack/networking/v2/networks
+github.com/gophercloud/gophercloud/openstack/networking/v2/ports
 github.com/gophercloud/gophercloud/openstack/networking/v2/subnets
 github.com/gophercloud/gophercloud/openstack/objectstorage/v1/accounts
 github.com/gophercloud/gophercloud/openstack/objectstorage/v1/containers


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement
/platform openstack

**What this PR does / why we need it**:
Reconciliation and deletion of infrastructure resources are managed directly with a graph flow and using Openstack SDK client API instead of using Terraformer.
Migration for existing infrastructure resources is implemented, too.

**Which issue(s) this PR fixes**:
Fixes #362

**Special notes for your reviewer**:
Currently, to activate the flow based infra management, the shoot or the infrastructure resource must be annotated with
`openstack.provider.extensions.gardener.cloud/use-flow=true`

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Flow-based infrastructure reconciliation without Terraformer
```
