### PR TITLE
update calico version to v1.27.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/coreos/go-systemd/v22 v22.3.2
 	github.com/gardener/etcd-druid v0.12.3
 	github.com/gardener/gardener v1.59.0
-	github.com/gardener/gardener-extension-networking-calico v1.27.0
+	github.com/gardener/gardener-extension-networking-calico v1.27.1
 	github.com/gardener/machine-controller-manager v0.45.0
 	github.com/go-logr/logr v1.2.3
 	github.com/golang/mock v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -163,8 +163,8 @@ github.com/gardener/etcd-druid v0.12.3 h1:FBpsEe+FrBwJ1a2VhaPlXjZsfIAcHGSsF5DvDO
 github.com/gardener/etcd-druid v0.12.3/go.mod h1:EJF6z4Ghv2FGUe1UzZWOEF1MxCA186fxvjBO44oSJX4=
 github.com/gardener/gardener v1.59.0 h1:9T8C2lPwaFTKxUi3afpVjmbao/uDcn5lfYRmFqMFoYw=
 github.com/gardener/gardener v1.59.0/go.mod h1:4vopE/Pg4LJud1CRg80rAcp94v83MJIgktlHNcSKO84=
-github.com/gardener/gardener-extension-networking-calico v1.27.0 h1:L51BcYbrcpQjmGl+E9HsW+xcJVZOfjbe403DRDwuUME=
-github.com/gardener/gardener-extension-networking-calico v1.27.0/go.mod h1:MURFRmYPHiXSfmJ82S3nXH3qGcszeYQwhMVKn/J5XoU=
+github.com/gardener/gardener-extension-networking-calico v1.27.1 h1:q/lsdqbwV+qlwNPxlqFxGeqKMDwPk+dPhUGXjxObzGE=
+github.com/gardener/gardener-extension-networking-calico v1.27.1/go.mod h1:MURFRmYPHiXSfmJ82S3nXH3qGcszeYQwhMVKn/J5XoU=
 github.com/gardener/hvpa-controller/api v0.5.0 h1:f4F3O7YUrenwh4S3TgPREPiB287JjjUiUL18OqPLyAA=
 github.com/gardener/hvpa-controller/api v0.5.0/go.mod h1:QQl3ELkCaki+8RhXl0FZMfvnm0WCGwGJlGmrxJj6lvM=
 github.com/gardener/machine-controller-manager v0.45.0 h1:rpf0PHRXJMGY93oMruNP+tnMawKJXhhzCACyNJsT8Lo=

--- a/vendor/github.com/gardener/gardener-extension-networking-calico/pkg/apis/calico/v1alpha1/types_network.go
+++ b/vendor/github.com/gardener/gardener-extension-networking-calico/pkg/apis/calico/v1alpha1/types_network.go
@@ -69,7 +69,7 @@ type NetworkConfig struct {
 	metav1.TypeMeta `json:",inline"`
 	// Backend defines whether a backend should be used or not (e.g., bird or none)
 	// +optional
-	Backend *Backend `json:"backend"`
+	Backend *Backend `json:"backend,omitempty"`
 	// IPAM to use for the Calico Plugin (e.g., host-local or Calico)
 	// +optional
 	IPAM *IPAM `json:"ipam,omitempty"`

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -190,7 +190,7 @@ github.com/gardener/gardener/test/framework/reporter
 github.com/gardener/gardener/test/testmachinery/extensions/generator
 github.com/gardener/gardener/test/testmachinery/extensions/healthcheck
 github.com/gardener/gardener/test/testmachinery/extensions/operation
-# github.com/gardener/gardener-extension-networking-calico v1.27.0
+# github.com/gardener/gardener-extension-networking-calico v1.27.1
 ## explicit; go 1.19
 github.com/gardener/gardener-extension-networking-calico/pkg/apis/calico
 github.com/gardener/gardener-extension-networking-calico/pkg/apis/calico/v1alpha1


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug
/platform openstack

**What this PR does / why we need it**:
Update calico version to `v1.27.1`.

This is required because in previous calico versions the `backend` field was not omitted when set to `nil`.
This update will avoid setting `backend: null` in the shoot spec when the shoot mutator webhook in the infrastructure extension is called which leads to an error during validation.

```
error: error validating "STDIN": error validating data: unknown object type "nil" in Shoot.spec.networking.providerConfig.backend; if you choose to ignore these errors, turn validation off with --validate=false
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Update calico version to `v1.27.1`.
```
