### PR TITLE
[release-v1.30] Automated cherry pick of #532: fix nil pointer exception in route cleanup

### DIFF
--- a/pkg/internal/infrastructure/terraform.go
+++ b/pkg/internal/infrastructure/terraform.go
@@ -108,12 +108,7 @@ func ComputeTerraformerTemplateValues(
 		routerConfig["enableSNAT"] = *cloudProfileConfig.UseSNAT
 	}
 
-	workersCIDR := config.Networks.Workers
-	// Backwards compatibility - remove this code in a future version.
-	if workersCIDR == "" {
-		workersCIDR = config.Networks.Worker
-	}
-
+	workersCIDR := WorkersCIDR(config)
 	networksConfig := map[string]interface{}{
 		"workers": workersCIDR,
 	}


### PR DESCRIPTION
/area control-plane
/kind bug

Cherry pick of #532 on release-v1.30.

#532: fix nil pointer exception in route cleanup

**Release Notes:**
```other operator
Fix a nil pointer exception in the route deletion method when shoots are using the deprecated `Worker` field.
```