### PR TITLE
return early if no route changes

### DIFF
--- a/pkg/internal/infrastructure/infrastucture.go
+++ b/pkg/internal/infrastructure/infrastucture.go
@@ -52,6 +52,11 @@ func CleanupKubernetesRoutes(ctx context.Context, client openstackclient.Network
 		}
 	}
 
+	// return early if no changes were made
+	if len(router[0].Routes) == len(routes) {
+		return nil
+	}
+
 	if _, err := client.UpdateRoutesForRouter(routes, routerID); err != nil {
 		return err
 	}

--- a/pkg/internal/infrastructure/infrastucture_test.go
+++ b/pkg/internal/infrastructure/infrastucture_test.go
@@ -1,0 +1,79 @@
+package infrastructure
+
+import (
+	"context"
+
+	"github.com/golang/mock/gomock"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/gardener/gardener-extension-provider-openstack/pkg/openstack/client/mocks"
+)
+
+var _ = Describe("Infrastructure", func() {
+	var (
+		ctrl          *gomock.Controller
+		nw            *mocks.MockNetworking
+		ctx           context.Context
+		routerID      string
+		defaultWorker = "10.0.0.0/16"
+		router        *routers.Router
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		nw = mocks.NewMockNetworking(ctrl)
+		ctx = context.TODO()
+		routerID = "router"
+		router = &routers.Router{
+			ID: routerID,
+		}
+	})
+
+	type args struct {
+		workers string
+		prep    func()
+	}
+
+	prepRoutes := func(routes ...routers.Route) {
+		router.Routes = routes
+		nw.EXPECT().GetRouterByID(routerID).Return([]routers.Router{*router}, nil)
+	}
+
+	DescribeTable("#RouteCleanup", func(a args, expErr error) {
+		a.prep()
+		err := CleanupKubernetesRoutes(ctx, nw, routerID, a.workers)
+		if expErr == nil {
+			Expect(err).To(BeNil())
+		} else {
+			Expect(err).To(Equal(expErr))
+		}
+	},
+		Entry("no update request if no routes exist", args{
+			workers: defaultWorker,
+			prep:    func() { prepRoutes() },
+		}, nil),
+		Entry("no update request if no routes need change", args{
+			workers: defaultWorker,
+			prep: func() {
+				prepRoutes(
+					routers.Route{NextHop: "10.11.0.0"},
+					routers.Route{NextHop: "10.12.0.0"},
+					routers.Route{NextHop: "10.13.0.0"},
+				)
+			}}, nil),
+		Entry("expect update request", args{
+			workers: defaultWorker,
+			prep: func() {
+				prepRoutes(
+					routers.Route{NextHop: "10.0.0.0"},
+					routers.Route{NextHop: "10.0.1.0"},
+					routers.Route{NextHop: "10.0.2.0"},
+					// plus one more that needs to be preserved
+					routers.Route{NextHop: "10.11.2.0"},
+				)
+				nw.EXPECT().UpdateRoutesForRouter([]routers.Route{{NextHop: "10.11.2.0"}}, routerID).Return(router, nil)
+			}}, nil),
+	)
+})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/platform openstack

**What this PR does / why we need it**:

Do not make update requests for the routes if no changes are necessary.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Skip router update requests to remove routes if no change is necessary.
```
