### PR TITLE
add linting check for deprecated variables

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -27,7 +27,3 @@ issues:
     # typecheck:
     - "undeclared name: `.*`"
     - "\".*\" imported but not used"
-  exclude-rules:
-    - linters:
-        - staticcheck
-      text: "SA1019:" # Excludes messages where deprecated variables are used

--- a/charts/charts.go
+++ b/charts/charts.go
@@ -1,0 +1,24 @@
+//  Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package charts
+
+import (
+	"embed"
+)
+
+// InternalChart embeds the internal charts in embed.FS
+//
+//go:embed internal
+var InternalChart embed.FS

--- a/pkg/apis/config/loader/loader.go
+++ b/pkg/apis/config/loader/loader.go
@@ -15,7 +15,7 @@
 package loader
 
 import (
-	"io/ioutil"
+	"os"
 
 	"github.com/gardener/gardener-extension-provider-openstack/pkg/apis/config"
 	"github.com/gardener/gardener-extension-provider-openstack/pkg/apis/config/install"
@@ -46,7 +46,7 @@ func init() {
 
 // LoadFromFile takes a filename and de-serializes the contents into ControllerConfiguration object.
 func LoadFromFile(filename string) (*config.ControllerConfiguration, error) {
-	bytes, err := ioutil.ReadFile(filename)
+	bytes, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -30,9 +30,9 @@ import (
 	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/gardener/gardener-extension-provider-openstack/charts"
 	api "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack"
 	"github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack/helper"
-	"github.com/gardener/gardener-extension-provider-openstack/pkg/openstack"
 )
 
 // MachineClassKind yields the name of the machine class kind used by OpenStack provider.
@@ -58,7 +58,7 @@ func (w *workerDelegate) DeployMachineClasses(ctx context.Context) error {
 		}
 	}
 
-	return w.seedChartApplier.Apply(ctx, filepath.Join(openstack.InternalChartsPath, "machineclass"), w.worker.Namespace, "machineclass", kubernetes.Values(map[string]interface{}{"machineClasses": w.machineClasses}))
+	return w.seedChartApplier.ApplyFromEmbeddedFS(ctx, charts.InternalChart, filepath.Join("internal", "machineclass"), w.worker.Namespace, "machineclass", kubernetes.Values(map[string]interface{}{"machineClasses": w.machineClasses}))
 }
 
 // GenerateMachineDeployments generates the configuration for the desired machine deployments.

--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -22,11 +22,6 @@ import (
 	"strings"
 	"time"
 
-	api "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack"
-	apiv1alpha1 "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack/v1alpha1"
-	. "github.com/gardener/gardener-extension-provider-openstack/pkg/controller/worker"
-	"github.com/gardener/gardener-extension-provider-openstack/pkg/openstack"
-
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
 	"github.com/gardener/gardener/extensions/pkg/controller/common"
 	"github.com/gardener/gardener/extensions/pkg/controller/worker"
@@ -48,6 +43,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/pointer"
+
+	"github.com/gardener/gardener-extension-provider-openstack/charts"
+	api "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack"
+	apiv1alpha1 "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack/v1alpha1"
+	. "github.com/gardener/gardener-extension-provider-openstack/pkg/controller/worker"
 )
 
 var _ = Describe("Machines", func() {
@@ -513,9 +513,10 @@ var _ = Describe("Machines", func() {
 					// Test workerDelegate.DeployMachineClasses()
 					chartApplier.
 						EXPECT().
-						Apply(
+						ApplyFromEmbeddedFS(
 							context.TODO(),
-							filepath.Join(openstack.InternalChartsPath, "machineclass"),
+							charts.InternalChart,
+							filepath.Join("internal", "machineclass"),
 							namespace,
 							"machineclass",
 							kubernetes.Values(machineClasses),
@@ -569,9 +570,10 @@ var _ = Describe("Machines", func() {
 
 					chartApplier.
 						EXPECT().
-						Apply(
+						ApplyFromEmbeddedFS(
 							context.TODO(),
-							filepath.Join(openstack.InternalChartsPath, "machineclass"),
+							charts.InternalChart,
+							filepath.Join("internal", "machineclass"),
 							namespace,
 							"machineclass",
 							kubernetes.Values(machineClasses),
@@ -716,9 +718,10 @@ var _ = Describe("Machines", func() {
 
 						chartApplier.
 							EXPECT().
-							Apply(
+							ApplyFromEmbeddedFS(
 								context.TODO(),
-								filepath.Join(openstack.InternalChartsPath, "machineclass"),
+								charts.InternalChart,
+								filepath.Join("internal", "machineclass"),
 								namespace,
 								"machineclass",
 								kubernetes.Values(machineClasses),


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement
/platform openstack

**What this PR does / why we need it**:

Introduce the deprecated check back and fix linting errors

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
