### PR TITLE
Revert "expose routerIP to infrastructure.status (#520)"

### DIFF
--- a/hack/api-reference/api.md
+++ b/hack/api-reference/api.md
@@ -1358,17 +1358,6 @@ string
 <p>ID is the Router id.</p>
 </td>
 </tr>
-<tr>
-<td>
-<code>ip</code></br>
-<em>
-string
-</em>
-</td>
-<td>
-<p>IP is the router ip.</p>
-</td>
-</tr>
 </tbody>
 </table>
 <h3 id="openstack.provider.extensions.gardener.cloud/v1alpha1.SecurityGroup">SecurityGroup

--- a/pkg/apis/openstack/types_infrastructure.go
+++ b/pkg/apis/openstack/types_infrastructure.go
@@ -88,8 +88,6 @@ type NetworkStatus struct {
 type RouterStatus struct {
 	// ID is the Router id.
 	ID string
-	// IP is the router ip.
-	IP string
 }
 
 // FloatingPoolStatus contains information about the floating pool.

--- a/pkg/apis/openstack/v1alpha1/types_infrastructure.go
+++ b/pkg/apis/openstack/v1alpha1/types_infrastructure.go
@@ -92,8 +92,6 @@ type NetworkStatus struct {
 type RouterStatus struct {
 	// ID is the Router id.
 	ID string `json:"id"`
-	// IP is the router ip.
-	IP string `json:"ip"`
 }
 
 // FloatingPoolStatus contains information about the floating pool.

--- a/pkg/apis/openstack/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/openstack/v1alpha1/zz_generated.conversion.go
@@ -816,7 +816,6 @@ func Convert_openstack_Router_To_v1alpha1_Router(in *openstack.Router, out *Rout
 
 func autoConvert_v1alpha1_RouterStatus_To_openstack_RouterStatus(in *RouterStatus, out *openstack.RouterStatus, s conversion.Scope) error {
 	out.ID = in.ID
-	out.IP = in.IP
 	return nil
 }
 
@@ -827,7 +826,6 @@ func Convert_v1alpha1_RouterStatus_To_openstack_RouterStatus(in *RouterStatus, o
 
 func autoConvert_openstack_RouterStatus_To_v1alpha1_RouterStatus(in *openstack.RouterStatus, out *RouterStatus, s conversion.Scope) error {
 	out.ID = in.ID
-	out.IP = in.IP
 	return nil
 }
 

--- a/pkg/internal/infrastructure/templates/main.tpl.tf
+++ b/pkg/internal/infrastructure/templates/main.tpl.tf
@@ -139,10 +139,6 @@ output "{{ .outputKeys.routerID }}" {
   value = {{ .router.id }}
 }
 
-output "{{ .outputKeys.routerIP }}" {
-  value = openstack_networking_router_v2.router.external_fixed_ip[0].ip_address
-}
-
 output "{{ .outputKeys.networkID }}" {
   value = {{ template "network-id" $ }}
 }

--- a/pkg/internal/infrastructure/terraform.go
+++ b/pkg/internal/infrastructure/terraform.go
@@ -37,8 +37,6 @@ const (
 	TerraformOutputKeySSHKeyName = "key_name"
 	// TerraformOutputKeyRouterID is the id the router between provider network and the worker subnet.
 	TerraformOutputKeyRouterID = "router_id"
-	// TerraformOutputKeyRouterIP is the ip address of the router.
-	TerraformOutputKeyRouterIP = "router_ip"
 	// TerraformOutputKeyNetworkID is the private worker network.
 	TerraformOutputKeyNetworkID = "network_id"
 	// TerraformOutputKeyNetworkName is the private worker network name.
@@ -77,7 +75,6 @@ func ComputeTerraformerTemplateValues(
 		}
 		outputKeysConfig = map[string]interface{}{
 			"routerID":          TerraformOutputKeyRouterID,
-			"routerIP":          TerraformOutputKeyRouterIP,
 			"networkID":         TerraformOutputKeyNetworkID,
 			"networkName":       TerraformOutputKeyNetworkName,
 			"keyName":           TerraformOutputKeySSHKeyName,
@@ -194,8 +191,6 @@ type TerraformState struct {
 	SSHKeyName string
 	// RouterID is the id the router between provider network and the worker subnet.
 	RouterID string
-	// RouterIP is the ip address of the router.
-	RouterIP string
 	// NetworkID is the private worker network.
 	NetworkID string
 	// NetworkName is the private worker network name.
@@ -215,7 +210,6 @@ func ExtractTerraformState(ctx context.Context, tf terraformer.Terraformer) (*Te
 	outputKeys := []string{
 		TerraformOutputKeySSHKeyName,
 		TerraformOutputKeyRouterID,
-		TerraformOutputKeyRouterIP,
 		TerraformOutputKeyNetworkID,
 		TerraformOutputKeyNetworkName,
 		TerraformOutputKeySubnetID,
@@ -232,7 +226,6 @@ func ExtractTerraformState(ctx context.Context, tf terraformer.Terraformer) (*Te
 	return &TerraformState{
 		SSHKeyName:        vars[TerraformOutputKeySSHKeyName],
 		RouterID:          vars[TerraformOutputKeyRouterID],
-		RouterIP:          vars[TerraformOutputKeyRouterIP],
 		NetworkID:         vars[TerraformOutputKeyNetworkID],
 		NetworkName:       vars[TerraformOutputKeyNetworkName],
 		SubnetID:          vars[TerraformOutputKeySubnetID],
@@ -258,7 +251,6 @@ func StatusFromTerraformState(state *TerraformState) *apiv1alpha1.Infrastructure
 			},
 			Router: apiv1alpha1.RouterStatus{
 				ID: state.RouterID,
-				IP: state.RouterIP,
 			},
 			Subnets: []apiv1alpha1.Subnet{
 				{

--- a/pkg/internal/infrastructure/terraform_test.go
+++ b/pkg/internal/infrastructure/terraform_test.go
@@ -133,7 +133,6 @@ var _ = Describe("Terraform", func() {
 			}
 			expectedOutputKeysValues = map[string]interface{}{
 				"routerID":          TerraformOutputKeyRouterID,
-				"routerIP":          TerraformOutputKeyRouterIP,
 				"networkID":         TerraformOutputKeyNetworkID,
 				"networkName":       TerraformOutputKeyNetworkName,
 				"keyName":           TerraformOutputKeySSHKeyName,
@@ -234,7 +233,6 @@ var _ = Describe("Terraform", func() {
 		var (
 			SSHKeyName        string
 			RouterID          string
-			RouterIP          string
 			NetworkID         string
 			SubnetID          string
 			FloatingNetworkID string
@@ -248,7 +246,6 @@ var _ = Describe("Terraform", func() {
 		BeforeEach(func() {
 			SSHKeyName = "my-key"
 			RouterID = "111"
-			RouterIP = "1.1.1.1"
 			NetworkID = "222"
 			SubnetID = "333"
 			FloatingNetworkID = "444"
@@ -258,7 +255,6 @@ var _ = Describe("Terraform", func() {
 			state = TerraformState{
 				SSHKeyName:        SSHKeyName,
 				RouterID:          RouterID,
-				RouterIP:          RouterIP,
 				NetworkID:         NetworkID,
 				SubnetID:          SubnetID,
 				FloatingNetworkID: FloatingNetworkID,
@@ -275,7 +271,6 @@ var _ = Describe("Terraform", func() {
 					ID: state.NetworkID,
 					Router: apiv1alpha1.RouterStatus{
 						ID: state.RouterID,
-						IP: state.RouterIP,
 					},
 					FloatingPool: apiv1alpha1.FloatingPoolStatus{
 						ID: FloatingNetworkID,


### PR DESCRIPTION
This reverts commit 45c124451c97d22c9169f846b9530a5b717549a3.

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/area dev-productivity
/kind bug
/kind regression
/platform openstack

**What this PR does / why we need it**:
See https://github.com/gardener/gardener-extension-provider-openstack/issues/546

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener-extension-provider-openstack/issues/546

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
