### PR TITLE
fix containerName of provider-openstack within the mcm Deployment

### DIFF
--- a/charts/internal/machine-controller-manager/seed/templates/deployment.yaml
+++ b/charts/internal/machine-controller-manager/seed/templates/deployment.yaml
@@ -76,7 +76,7 @@ spec:
         - mountPath: /var/run/secrets/gardener.cloud/shoot/generic-kubeconfig
           name: kubeconfig
           readOnly: true
-      - name: provider-openstack
+      - name: machine-controller-manager-provider-openstack
         image: {{ index .Values.images "machine-controller-manager-provider-openstack" }}
         imagePullPolicy: IfNotPresent
         command:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area scalability
/kind bug
/platform openstack

**What this PR does / why we need it**:
An incorrect `containerName` in the vpa object caused the container not beeing controlled by the vpa. In decent largish clusters this can cause the container to get `OOMKilled` as it only has 32Mi of memory.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

~Helm diff might a bit large as my tar or whatever it is causing it produces a different output. But it does work 100%.~

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
An incorrect container name in the machine-controller-manager Deployment caused the container not beeing controlled by the vpa.
```
