### PR TITLE
Support for Kubernetes v1.26

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This extension controller supports the following Kubernetes versions:
 
 | Version         | Support     | Conformance test results |
 | --------------- | ----------- | ------------------------ |
+| Kubernetes 1.26 | 1.26.0+     | N/A |
 | Kubernetes 1.25 | 1.25.0+     | [![Gardener v1.25 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.25%20OpenStack/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.25%20OpenStack) |
 | Kubernetes 1.24 | 1.24.0+     | [![Gardener v1.24 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.24%20OpenStack/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.24%20OpenStack) |
 | Kubernetes 1.23 | 1.23.0+     | [![Gardener v1.23 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.23%20OpenStack/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.23%20OpenStack) |

--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -58,7 +58,7 @@ images:
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes/cloud-provider-openstack
   repository: k8scloudprovider/openstack-cloud-controller-manager
-  tag: "v1.24.3"
+  tag: "v1.24.5"
   targetVersion: "1.24.x"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
@@ -73,7 +73,21 @@ images:
   sourceRepository: github.com/kubernetes/cloud-provider-openstack
   repository: k8scloudprovider/openstack-cloud-controller-manager
   tag: "v1.25.3"
-  targetVersion: ">= 1.25"
+  targetVersion: "1.25.x"
+  labels:
+  - name: 'gardener.cloud/cve-categorisation'
+    value:
+      network_exposure: 'protected'
+      authentication_enforced: false
+      user_interaction: 'gardener-operator'
+      confidentiality_requirement: 'high'
+      integrity_requirement: 'high'
+      availability_requirement: 'low'
+- name: cloud-controller-manager
+  sourceRepository: github.com/kubernetes/cloud-provider-openstack
+  repository: k8scloudprovider/openstack-cloud-controller-manager
+  tag: "v1.26.0"
+  targetVersion: ">= 1.26"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:
@@ -167,7 +181,21 @@ images:
   sourceRepository: github.com/kubernetes/cloud-provider-openstack
   repository: docker.io/k8scloudprovider/cinder-csi-plugin
   tag: "v1.25.3"
-  targetVersion: ">= 1.25"
+  targetVersion: "1.25.x"
+  labels:
+    - name: 'gardener.cloud/cve-categorisation'
+      value:
+        network_exposure: 'protected'
+        authentication_enforced: false
+        user_interaction: 'end-user'
+        confidentiality_requirement: 'high'
+        integrity_requirement: 'high'
+        availability_requirement: 'low'
+- name: csi-driver-cinder
+  sourceRepository: github.com/kubernetes/cloud-provider-openstack
+  repository: docker.io/k8scloudprovider/cinder-csi-plugin
+  tag: "v1.26.0"
+  targetVersion: ">= 1.26"
   labels:
     - name: 'gardener.cloud/cve-categorisation'
       value:

--- a/pkg/webhook/controlplane/ensurer_test.go
+++ b/pkg/webhook/controlplane/ensurer_test.go
@@ -113,6 +113,17 @@ var _ = Describe("Ensurer", func() {
 				},
 			},
 		)
+		eContextK8s126 = gcontext.NewInternalGardenContext(
+			&extensionscontroller.Cluster{
+				Shoot: &gardencorev1beta1.Shoot{
+					Spec: gardencorev1beta1.ShootSpec{
+						Kubernetes: gardencorev1beta1.Kubernetes{
+							Version: "1.26.0",
+						},
+					},
+				},
+			},
+		)
 		eContextK8s121WithResolvConfOptions = gcontext.NewInternalGardenContext(
 			&extensionscontroller.Cluster{
 				CloudProfile: &gardencorev1beta1.CloudProfile{
@@ -182,6 +193,13 @@ var _ = Describe("Ensurer", func() {
 			checkKubeAPIServerDeployment(dep, "1.21.0")
 		})
 
+		It("should add missing elements to kube-apiserver deployment (k8s >= 1.26)", func() {
+			err := ensurer.EnsureKubeAPIServerDeployment(ctx, eContextK8s126, dep, nil)
+			Expect(err).To(Not(HaveOccurred()))
+
+			checkKubeAPIServerDeployment(dep, "1.26.0")
+		})
+
 		It("should modify existing elements of kube-apiserver deployment", func() {
 			dep = &appsv1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: v1beta1constants.DeploymentNameKubeAPIServer},
@@ -243,6 +261,13 @@ var _ = Describe("Ensurer", func() {
 			Expect(err).To(Not(HaveOccurred()))
 
 			checkKubeControllerManagerDeployment(dep, "1.21.0")
+		})
+
+		It("should add missing elements to kube-controller-manager deployment (k8s >= 1.26)", func() {
+			err := ensurer.EnsureKubeControllerManagerDeployment(ctx, eContextK8s126, dep, nil)
+			Expect(err).To(Not(HaveOccurred()))
+
+			checkKubeControllerManagerDeployment(dep, "1.26.0")
 		})
 
 		It("should modify existing elements of kube-controller-manager deployment", func() {
@@ -324,6 +349,13 @@ var _ = Describe("Ensurer", func() {
 
 			checkKubeSchedulerDeployment(dep, "1.21.0")
 		})
+
+		It("should add missing elements to kube-scheduler deployment (k8s >= 1.26)", func() {
+			err := ensurer.EnsureKubeSchedulerDeployment(ctx, eContextK8s126, dep, nil)
+			Expect(err).To(Not(HaveOccurred()))
+
+			checkKubeSchedulerDeployment(dep, "1.26.0")
+		})
 	})
 
 	Describe("#EnsureClusterAutoscalerDeployment", func() {
@@ -363,6 +395,13 @@ var _ = Describe("Ensurer", func() {
 			Expect(err).To(Not(HaveOccurred()))
 
 			checkClusterAutoscalerDeployment(dep, "1.21.0")
+		})
+
+		It("should add missing elements to cluster-autoscaler deployment (k8s >= 1.26)", func() {
+			err := ensurer.EnsureClusterAutoscalerDeployment(ctx, eContextK8s126, dep, nil)
+			Expect(err).To(Not(HaveOccurred()))
+
+			checkClusterAutoscalerDeployment(dep, "1.26.0")
 		})
 	})
 
@@ -438,7 +477,7 @@ var _ = Describe("Ensurer", func() {
 		})
 
 		DescribeTable("should modify existing elements of kubelet configuration",
-			func(gctx gcontext.GardenContext, kubeletVersion *semver.Version, unregisterFeatureGateName string, enableControllerAttachDetach *bool) {
+			func(gctx gcontext.GardenContext, kubeletVersion *semver.Version, featureGates []string, enableControllerAttachDetach *bool) {
 				newKubeletConfig := &kubeletconfigv1beta1.KubeletConfiguration{
 					FeatureGates: map[string]bool{
 						"Foo": true,
@@ -447,10 +486,8 @@ var _ = Describe("Ensurer", func() {
 					EnableControllerAttachDetach: enableControllerAttachDetach,
 				}
 
-				if unregisterFeatureGateName != "" {
-					newKubeletConfig.FeatureGates["CSIMigration"] = true
-					newKubeletConfig.FeatureGates["CSIMigrationOpenStack"] = true
-					newKubeletConfig.FeatureGates[unregisterFeatureGateName] = true
+				for _, featureGate := range featureGates {
+					newKubeletConfig.FeatureGates[featureGate] = true
 				}
 
 				kubeletConfig := *oldKubeletConfig
@@ -460,10 +497,11 @@ var _ = Describe("Ensurer", func() {
 				Expect(&kubeletConfig).To(Equal(newKubeletConfig))
 			},
 
-			Entry("control plane = 1.20, kubelet < 1.21", eContextK8s120, semver.MustParse("1.20.0"), "CSIMigrationOpenStackComplete", nil),
-			Entry("control plane >= 1.21, kubelet < 1.21", eContextK8s121, semver.MustParse("1.20.0"), "CSIMigrationOpenStackComplete", nil),
-			Entry("1.21 <= kubelet < 1.23", eContextK8s121, semver.MustParse("1.22.0"), "InTreePluginOpenStackUnregister", nil),
-			Entry("kubelet >= 1.23", eContextK8s121, semver.MustParse("1.23.0"), "InTreePluginOpenStackUnregister", pointer.Bool(true)),
+			Entry("control plane = 1.20, kubelet < 1.21", eContextK8s120, semver.MustParse("1.20.0"), []string{"CSIMigration", "CSIMigrationOpenStack", "CSIMigrationOpenStackComplete"}, nil),
+			Entry("control plane >= 1.21, kubelet < 1.21", eContextK8s121, semver.MustParse("1.20.0"), []string{"CSIMigration", "CSIMigrationOpenStack", "CSIMigrationOpenStackComplete"}, nil),
+			Entry("1.21 <= kubelet < 1.23", eContextK8s121, semver.MustParse("1.22.0"), []string{"CSIMigration", "CSIMigrationOpenStack", "InTreePluginOpenStackUnregister"}, nil),
+			Entry("kubelet >= 1.23", eContextK8s121, semver.MustParse("1.23.0"), []string{"CSIMigration", "CSIMigrationOpenStack", "InTreePluginOpenStackUnregister"}, pointer.Bool(true)),
+			Entry("kubelet >= 1.26", eContextK8s126, semver.MustParse("1.26.0"), []string{"CSIMigration"}, pointer.Bool(true)),
 		)
 	})
 
@@ -584,13 +622,16 @@ WantedBy=multi-user.target
 
 func checkKubeAPIServerDeployment(dep *appsv1.Deployment, k8sVersion string) {
 	k8sVersionAtLeast121, _ := version.CompareVersions(k8sVersion, ">=", "1.21")
+	k8sVersionAtLeast126, _ := version.CompareVersions(k8sVersion, ">=", "1.26")
 
 	// Check that the kube-apiserver container still exists and contains all needed command line args,
 	// env vars, and volume mounts
 	c := extensionswebhook.ContainerWithName(dep.Spec.Template.Spec.Containers, "kube-apiserver")
 	Expect(c).To(Not(BeNil()))
 
-	if k8sVersionAtLeast121 {
+	if k8sVersionAtLeast126 {
+		Expect(c.Command).To(ContainElement("--feature-gates=CSIMigration=true"))
+	} else if k8sVersionAtLeast121 {
 		Expect(c.Command).To(ContainElement("--feature-gates=CSIMigration=true,CSIMigrationOpenStack=true,InTreePluginOpenStackUnregister=true"))
 	} else {
 		Expect(c.Command).To(ContainElement("--feature-gates=CSIMigration=true,CSIMigrationOpenStack=true,CSIMigrationOpenStackComplete=true"))
@@ -603,6 +644,7 @@ func checkKubeAPIServerDeployment(dep *appsv1.Deployment, k8sVersion string) {
 
 func checkKubeControllerManagerDeployment(dep *appsv1.Deployment, k8sVersion string) {
 	k8sVersionAtLeast121, _ := version.CompareVersions(k8sVersion, ">=", "1.21")
+	k8sVersionAtLeast126, _ := version.CompareVersions(k8sVersion, ">=", "1.26")
 
 	// Check that the kube-controller-manager container still exists and contains all needed command line args,
 	// env vars, and volume mounts
@@ -611,7 +653,9 @@ func checkKubeControllerManagerDeployment(dep *appsv1.Deployment, k8sVersion str
 
 	Expect(c.Command).To(ContainElement("--cloud-provider=external"))
 
-	if k8sVersionAtLeast121 {
+	if k8sVersionAtLeast126 {
+		Expect(c.Command).To(ContainElement("--feature-gates=CSIMigration=true"))
+	} else if k8sVersionAtLeast121 {
 		Expect(c.Command).To(ContainElement("--feature-gates=CSIMigration=true,CSIMigrationOpenStack=true,InTreePluginOpenStackUnregister=true"))
 	} else {
 		Expect(c.Command).To(ContainElement("--feature-gates=CSIMigration=true,CSIMigrationOpenStack=true,CSIMigrationOpenStackComplete=true"))
@@ -628,12 +672,15 @@ func checkKubeControllerManagerDeployment(dep *appsv1.Deployment, k8sVersion str
 
 func checkKubeSchedulerDeployment(dep *appsv1.Deployment, k8sVersion string) {
 	k8sVersionAtLeast121, _ := version.CompareVersions(k8sVersion, ">=", "1.21")
+	k8sVersionAtLeast126, _ := version.CompareVersions(k8sVersion, ">=", "1.26")
 
 	// Check that the kube-scheduler container still exists and contains all needed command line args.
 	c := extensionswebhook.ContainerWithName(dep.Spec.Template.Spec.Containers, "kube-scheduler")
 	Expect(c).To(Not(BeNil()))
 
-	if k8sVersionAtLeast121 {
+	if k8sVersionAtLeast126 {
+		Expect(c.Command).To(ContainElement("--feature-gates=CSIMigration=true"))
+	} else if k8sVersionAtLeast121 {
 		Expect(c.Command).To(ContainElement("--feature-gates=CSIMigration=true,CSIMigrationOpenStack=true,InTreePluginOpenStackUnregister=true"))
 	} else {
 		Expect(c.Command).To(ContainElement("--feature-gates=CSIMigration=true,CSIMigrationOpenStack=true,CSIMigrationOpenStackComplete=true"))
@@ -645,12 +692,15 @@ func checkClusterAutoscalerDeployment(dep *appsv1.Deployment, k8sVersion string)
 		return
 	}
 	k8sVersionAtLeast121, _ := version.CompareVersions(k8sVersion, ">=", "1.21")
+	k8sVersionAtLeast126, _ := version.CompareVersions(k8sVersion, ">=", "1.26")
 
 	// Check that the cluster-autoscaler container still exists and contains all needed command line args.
 	c := extensionswebhook.ContainerWithName(dep.Spec.Template.Spec.Containers, "cluster-autoscaler")
 	Expect(c).To(Not(BeNil()))
 
-	if k8sVersionAtLeast121 {
+	if k8sVersionAtLeast126 {
+		Expect(c.Command).To(ContainElement("--feature-gates=CSIMigration=true"))
+	} else if k8sVersionAtLeast121 {
 		Expect(c.Command).To(ContainElement("--feature-gates=CSIMigration=true,CSIMigrationOpenStack=true,InTreePluginOpenStackUnregister=true"))
 	} else {
 		Expect(c.Command).To(ContainElement("--feature-gates=CSIMigration=true,CSIMigrationOpenStack=true,CSIMigrationOpenStackComplete=true"))


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source usability
/kind enhancement
/platform openstack
/exp intermediate
/topology garden seed shoot
/merge squash

**What this PR does / why we need it**:
This PR adds support for Kubernetes 1.26 to the extension.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/6773

**Special notes for your reviewer**:
* ~~Depends on to be opened PR for K8s 1.26 client creation, hence, PR is in draft state.~~
* I have successfully validated the functionality as follows:
  * :white_check_mark: Create new clusters with versions < 1.26
  * :white_check_mark: Create new clusters with version  = 1.26
  * :white_check_mark: Upgrade old clusters from version 1.25 to version 1.26
  * :white_check_mark: Delete clusters with versions < 1.26
  * :white_check_mark: Delete clusters with version  = 1.26

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
The provider-openstack extension does now support shoot clusters with Kubernetes version 1.26. You should consider the [Kubernetes release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.26.md) before upgrading to 1.26. 
```

```other operator
The following images are updated:
- k8scloudprovider/openstack-cloud-controller-manager: v1.24.3 ->v1.24.5 (for Kubernetes 1.24)
```
