### PR TITLE
Adopt node CIDR immutable check

### DIFF
--- a/pkg/admission/validator/shoot.go
+++ b/pkg/admission/validator/shoot.go
@@ -18,9 +18,6 @@ import (
 	"context"
 	"fmt"
 
-	api "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack"
-	openstackvalidation "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack/validation"
-	"github.com/gardener/gardener-extension-provider-openstack/pkg/openstack"
 	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
 	"github.com/gardener/gardener/pkg/apis/core"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
@@ -31,6 +28,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	api "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack"
+	openstackvalidation "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack/validation"
+	"github.com/gardener/gardener-extension-provider-openstack/pkg/openstack"
 )
 
 // NewShootValidator returns a new instance of a shoot validator.
@@ -136,6 +137,7 @@ func (s *shoot) validateShootUpdate(ctx context.Context, oldShoot, shoot *core.S
 
 	allErrs := field.ErrorList{}
 
+	allErrs = append(allErrs, openstackvalidation.ValidateNetworkingUpdate(oldShoot.Spec.Networking, shoot.Spec.Networking, nwPath)...)
 	allErrs = append(allErrs, openstackvalidation.ValidateInfrastructureConfigUpdate(oldValContext.infraConfig, valContext.infraConfig, infraConfigPath)...)
 	allErrs = append(allErrs, openstackvalidation.ValidateInfrastructureConfigAgainstCloudProfile(oldValContext.infraConfig, valContext.infraConfig, credentials.DomainName, valContext.shoot.Spec.Region, valContext.cloudProfileConfig, infraConfigPath)...)
 

--- a/pkg/apis/openstack/validation/shoot.go
+++ b/pkg/apis/openstack/validation/shoot.go
@@ -16,6 +16,7 @@ package validation
 
 import (
 	"fmt"
+	"net"
 
 	"github.com/Masterminds/semver"
 	"github.com/gardener/gardener/pkg/apis/core"
@@ -58,6 +59,18 @@ func ValidateNetworking(networking core.Networking, fldPath *field.Path) field.E
 
 	if networking.Nodes == nil {
 		allErrs = append(allErrs, field.Required(fldPath.Child("nodes"), "a nodes CIDR must be provided for Openstack shoots"))
+	}
+
+	return allErrs
+}
+
+// ValidateNetworkingUpdate validates updates to shoot's networking settings.
+func ValidateNetworkingUpdate(oldNetworking, networking core.Networking, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	if oldNetworking.Nodes != nil {
+		if _, _, err := net.ParseCIDR(*oldNetworking.Nodes); err == nil {
+			allErrs = append(allErrs, apivalidation.ValidateImmutableField(networking.Nodes, oldNetworking.Nodes, fldPath.Child("nodes"))...)
+		}
 	}
 
 	return allErrs

--- a/pkg/apis/openstack/validation/shoot_test.go
+++ b/pkg/apis/openstack/validation/shoot_test.go
@@ -90,6 +90,48 @@ var _ = Describe("Shoot validation", func() {
 			))
 		})
 	})
+
+	Describe("#ValidateNetworkingUpdate", func() {
+		var (
+			networkingPath = field.NewPath("spec", "networking")
+			oldNodes       *string
+			nodes          *string
+		)
+		BeforeEach(func() {
+			oldNodes = pointer.String("100.0.0.0/16")
+			nodes = pointer.String("100.0.0.0/16")
+		})
+
+		It("should return no error because nodes CIDR was not changed", func() {
+			networking := core.Networking{
+				Nodes: nodes,
+			}
+			oldNetworking := core.Networking{
+				Nodes: oldNodes,
+			}
+
+			errorList := ValidateNetworkingUpdate(oldNetworking, networking, networkingPath)
+			Expect(errorList).To(BeEmpty())
+		})
+
+		It("should return an error because nodes CIDR changed", func() {
+			nodes = pointer.String("100.0.0.0/8")
+			networking := core.Networking{
+				Nodes: nodes,
+			}
+			oldNetworking := core.Networking{
+				Nodes: oldNodes,
+			}
+
+			errorList := ValidateNetworkingUpdate(oldNetworking, networking, networkingPath)
+			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":     Equal(field.ErrorTypeInvalid),
+				"Field":    Equal("spec.networking.nodes"),
+				"BadValue": Equal(nodes),
+			}))))
+		})
+	})
+
 	Describe("#ValidateWorkerConfig", func() {
 		var (
 			nilPath *field.Path


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement
/platform openstack

**What this PR does / why we need it**:
We want to remove the node CIDR check from g/g. Provider extensions should adopt a check that is at the very least equivalent with the current behaviour.

**Which issue(s) this PR fixes**:
Fixes #https://github.com/gardener/gardener/issues/4834

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Adopt `shoot.spec.networking.nodes` immutability check
```
