### PR TITLE
Backport field snatToUpstreamDNS

### DIFF
--- a/pkg/admission/mutator/shoot.go
+++ b/pkg/admission/mutator/shoot.go
@@ -88,6 +88,8 @@ func (s *shoot) Mutate(ctx context.Context, new, old client.Object) error {
 		networkConfig.Overlay = overlay
 	}
 
+	networkConfig.SnatToUpstreamDNS = nil
+
 	if oldShoot != nil && networkConfig.Overlay == nil {
 		oldNetworkConfig, err := s.decodeNetworkingConfig(oldShoot.Spec.Networking.ProviderConfig)
 		if err != nil {

--- a/vendor/github.com/gardener/gardener-extension-networking-calico/pkg/apis/calico/v1alpha1/types_network.go
+++ b/vendor/github.com/gardener/gardener-extension-networking-calico/pkg/apis/calico/v1alpha1/types_network.go
@@ -88,6 +88,10 @@ type NetworkConfig struct {
 	// Overlay enables the network overlay
 	// +optional
 	Overlay *Overlay `json:"overlay,omitempty"`
+	// SnatToUpstreamDNS enables the masquerading of packets to the upstream dns server
+	// only backported to avoid validation checks to fail
+	// +optional
+	SnatToUpstreamDNS *SnatToUpstreamDNS `json:"snatToUpstreamDNS,omitempty"`
 
 	// DEPRECATED.
 	// IPIP is the IPIP Mode for the IPv4 Pool (e.g. Always, Never, CrossSubnet)
@@ -101,6 +105,11 @@ type NetworkConfig struct {
 	// Will be removed in a future Gardener release.
 	// +optional
 	IPAutoDetectionMethod *string `json:"ipAutodetectionMethod,omitempty"`
+}
+
+// SnatToUpstreamDNS  enables the masquerading of packets to the upstream dns server
+type SnatToUpstreamDNS struct {
+	Enabled bool `json:"enabled"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area delivery
/kind bug
/platform openstack

**What this PR does / why we need it**:
After applying [Revert enabling overlay as default networking setup](https://github.com/gardener/gardener-extension-provider-openstack/pull/568), the mutating openstack admission webhook cannot deal with the field `snatToUpstreamDNS`. The field is back-ported and removed by the mutating webhook if it exists.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Backport field snatToUpstreamDNS
```
