### PR TITLE
Disable overlay webhook completely

### DIFF
--- a/charts/gardener-extension-admission-openstack/charts/application/templates/mutatingwebhook-mutator.yaml
+++ b/charts/gardener-extension-admission-openstack/charts/application/templates/mutatingwebhook-mutator.yaml
@@ -13,7 +13,7 @@ webhooks:
     - CREATE
     - UPDATE
     resources:
-    - shoots
+    - blackhole
   failurePolicy: Fail
   matchPolicy: Equivalent
   objectSelector:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/platform openstack

**What this PR does / why we need it**:
It modifies the webhook in-place so as to not make shoot mutations. We opted to change the webhook watched resources instead of deleting the mutating webhook, so as to avoid manual operations needed by operators to remove the mutating webhook and to make it easier to re-enable it in the future.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Disable overlay webhook to prevent issues with overloading Neutron API with route requests.
```
