### PR TITLE
remove snat settings since they are no longer required

### DIFF
--- a/pkg/admission/mutator/shoot_test.go
+++ b/pkg/admission/mutator/shoot_test.go
@@ -158,7 +158,6 @@ var _ = Describe("Shoot mutator", func() {
 						Overlay: &calicov1alpha1.Overlay{
 							Enabled: false,
 						},
-						SnatToUpstreamDNS: &calicov1alpha1.SnatToUpstreamDNS{Enabled: true},
 					},
 				}))
 			})
@@ -170,7 +169,6 @@ var _ = Describe("Shoot mutator", func() {
 						Overlay: &calicov1alpha1.Overlay{
 							Enabled: true,
 						},
-						SnatToUpstreamDNS: &calicov1alpha1.SnatToUpstreamDNS{Enabled: false},
 					},
 				}
 				err := shootMutator.Mutate(ctx, shoot, oldShoot)
@@ -180,7 +178,6 @@ var _ = Describe("Shoot mutator", func() {
 						Overlay: &calicov1alpha1.Overlay{
 							Enabled: true,
 						},
-						SnatToUpstreamDNS: &calicov1alpha1.SnatToUpstreamDNS{Enabled: false},
 					},
 				}))
 			})
@@ -239,7 +236,6 @@ var _ = Describe("Shoot mutator", func() {
 						Overlay: &ciliumv1alpha1.Overlay{
 							Enabled: false,
 						},
-						SnatToUpstreamDNS: &ciliumv1alpha1.SnatToUpstreamDNS{Enabled: true},
 					},
 				}))
 			})
@@ -260,7 +256,6 @@ var _ = Describe("Shoot mutator", func() {
 						Overlay: &ciliumv1alpha1.Overlay{
 							Enabled: true,
 						},
-						SnatToUpstreamDNS: &ciliumv1alpha1.SnatToUpstreamDNS{Enabled: false},
 					},
 				}))
 			})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement
/platform openstack

**What this PR does / why we need it**:
Remove the setting of enabling the snat traffic to the upstream dns sever because this is now the default option in the calico extension for non-overlay cluster and thus no longer required to be explicitly set in the openstack provider extension.
Furthermore do existing shoot clusters now keep also their set overlay field values when the `EnableOverlayAsDefault` field for calico or cilium is set. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
none
```
