### PR TITLE
Switched from DockerHub to Gardener GCR

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -15,7 +15,7 @@ images:
 
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes/cloud-provider-openstack
-  repository: k8scloudprovider/openstack-cloud-controller-manager
+  repository: eu.gcr.io/gardener-project/3rd/k8scloudprovider/openstack-cloud-controller-manager
   tag: "v1.21.0"
   targetVersion: "< 1.22"
   labels:
@@ -29,7 +29,7 @@ images:
       availability_requirement: 'low'
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes/cloud-provider-openstack
-  repository: k8scloudprovider/openstack-cloud-controller-manager
+  repository: eu.gcr.io/gardener-project/3rd/k8scloudprovider/openstack-cloud-controller-manager
   tag: "v1.22.2"
   targetVersion: "1.22.x"
   labels:
@@ -43,7 +43,7 @@ images:
       availability_requirement: 'low'
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes/cloud-provider-openstack
-  repository: k8scloudprovider/openstack-cloud-controller-manager
+  repository: eu.gcr.io/gardener-project/3rd/k8scloudprovider/openstack-cloud-controller-manager
   tag: "v1.23.4"
   targetVersion: "1.23.x"
   labels:
@@ -57,7 +57,7 @@ images:
       availability_requirement: 'low'
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes/cloud-provider-openstack
-  repository: k8scloudprovider/openstack-cloud-controller-manager
+  repository: eu.gcr.io/gardener-project/3rd/k8scloudprovider/openstack-cloud-controller-manager
   tag: "v1.24.6"
   targetVersion: "1.24.x"
   labels:
@@ -71,7 +71,7 @@ images:
       availability_requirement: 'low'
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes/cloud-provider-openstack
-  repository: k8scloudprovider/openstack-cloud-controller-manager
+  repository: eu.gcr.io/gardener-project/3rd/k8scloudprovider/openstack-cloud-controller-manager
   tag: "v1.25.5"
   targetVersion: "1.25.x"
   labels:
@@ -85,7 +85,7 @@ images:
       availability_requirement: 'low'
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes/cloud-provider-openstack
-  repository: k8scloudprovider/openstack-cloud-controller-manager
+  repository: eu.gcr.io/gardener-project/3rd/k8scloudprovider/openstack-cloud-controller-manager
   tag: "v1.26.2"
   targetVersion: ">= 1.26"
   labels:
@@ -127,7 +127,7 @@ images:
 
 - name: csi-driver-cinder
   sourceRepository: github.com/kubernetes/cloud-provider-openstack
-  repository: docker.io/k8scloudprovider/cinder-csi-plugin
+  repository: eu.gcr.io/gardener-project/3rd/k8scloudprovider/cinder-csi-plugin
   tag: "v1.20.3"
   targetVersion: "1.20.x"
   labels:
@@ -141,7 +141,7 @@ images:
       availability_requirement: 'low'
 - name: csi-driver-cinder
   sourceRepository: github.com/kubernetes/cloud-provider-openstack
-  repository: docker.io/k8scloudprovider/cinder-csi-plugin
+  repository: eu.gcr.io/gardener-project/3rd/k8scloudprovider/cinder-csi-plugin
   tag: "v1.21.0"
   targetVersion: "1.21.x"
   labels:
@@ -155,7 +155,7 @@ images:
       availability_requirement: 'low'
 - name: csi-driver-cinder
   sourceRepository: github.com/kubernetes/cloud-provider-openstack
-  repository: docker.io/k8scloudprovider/cinder-csi-plugin
+  repository: eu.gcr.io/gardener-project/3rd/k8scloudprovider/cinder-csi-plugin
   tag: "v1.22.2"
   targetVersion: "1.22.x"
   labels:
@@ -169,7 +169,7 @@ images:
       availability_requirement: 'low'
 - name: csi-driver-cinder
   sourceRepository: github.com/kubernetes/cloud-provider-openstack
-  repository: docker.io/k8scloudprovider/cinder-csi-plugin
+  repository: eu.gcr.io/gardener-project/3rd/k8scloudprovider/cinder-csi-plugin
   tag: "v1.23.4"
   targetVersion: "1.23.x"
   labels:
@@ -183,7 +183,7 @@ images:
       availability_requirement: 'low'
 - name: csi-driver-cinder
   sourceRepository: github.com/kubernetes/cloud-provider-openstack
-  repository: docker.io/k8scloudprovider/cinder-csi-plugin
+  repository: eu.gcr.io/gardener-project/3rd/k8scloudprovider/cinder-csi-plugin
   tag: "v1.24.5"
   targetVersion: "1.24.x"
   labels:
@@ -197,7 +197,7 @@ images:
       availability_requirement: 'low'
 - name: csi-driver-cinder
   sourceRepository: github.com/kubernetes/cloud-provider-openstack
-  repository: docker.io/k8scloudprovider/cinder-csi-plugin
+  repository: eu.gcr.io/gardener-project/3rd/k8scloudprovider/cinder-csi-plugin
   tag: "v1.25.3"
   targetVersion: "1.25.x"
   labels:
@@ -211,7 +211,7 @@ images:
         availability_requirement: 'low'
 - name: csi-driver-cinder
   sourceRepository: github.com/kubernetes/cloud-provider-openstack
-  repository: docker.io/k8scloudprovider/cinder-csi-plugin
+  repository: eu.gcr.io/gardener-project/3rd/k8scloudprovider/cinder-csi-plugin
   tag: "v1.26.0"
   targetVersion: ">= 1.26"
   labels:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
This PR is needed to support IPv6 single stack and avoid DockerHub pull limits as it uses copied images from Gardener GCR instead.
Part of https://github.com/gardener/ci-infra/issues/619

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Switched images from DockerHub to copies in Gardener GCR
```
