### PR TITLE
Switch back to upstream GCR images for `openstack-cloud-controller-manager` and `cinder-csi-plugin`

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -57,7 +57,7 @@ images:
       availability_requirement: 'low'
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes/cloud-provider-openstack
-  repository: eu.gcr.io/gardener-project/3rd/k8scloudprovider/openstack-cloud-controller-manager
+  repository: registry.k8s.io/provider-os/openstack-cloud-controller-manager
   tag: "v1.24.6"
   targetVersion: "1.24.x"
   labels:
@@ -71,7 +71,7 @@ images:
       availability_requirement: 'low'
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes/cloud-provider-openstack
-  repository: eu.gcr.io/gardener-project/3rd/k8scloudprovider/openstack-cloud-controller-manager
+  repository: registry.k8s.io/provider-os/openstack-cloud-controller-manager
   tag: "v1.25.5"
   targetVersion: "1.25.x"
   labels:
@@ -85,7 +85,7 @@ images:
       availability_requirement: 'low'
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes/cloud-provider-openstack
-  repository: eu.gcr.io/gardener-project/3rd/k8scloudprovider/openstack-cloud-controller-manager
+  repository: registry.k8s.io/provider-os/openstack-cloud-controller-manager
   tag: "v1.26.2"
   targetVersion: ">= 1.26"
   labels:
@@ -183,8 +183,8 @@ images:
       availability_requirement: 'low'
 - name: csi-driver-cinder
   sourceRepository: github.com/kubernetes/cloud-provider-openstack
-  repository: eu.gcr.io/gardener-project/3rd/k8scloudprovider/cinder-csi-plugin
-  tag: "v1.24.5"
+  repository: registry.k8s.io/provider-os/cinder-csi-plugin
+  tag: "v1.24.6"
   targetVersion: "1.24.x"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
@@ -197,8 +197,8 @@ images:
       availability_requirement: 'low'
 - name: csi-driver-cinder
   sourceRepository: github.com/kubernetes/cloud-provider-openstack
-  repository: eu.gcr.io/gardener-project/3rd/k8scloudprovider/cinder-csi-plugin
-  tag: "v1.25.3"
+  repository: registry.k8s.io/provider-os/cinder-csi-plugin
+  tag: "v1.25.5"
   targetVersion: "1.25.x"
   labels:
     - name: 'gardener.cloud/cve-categorisation'
@@ -211,8 +211,8 @@ images:
         availability_requirement: 'low'
 - name: csi-driver-cinder
   sourceRepository: github.com/kubernetes/cloud-provider-openstack
-  repository: eu.gcr.io/gardener-project/3rd/k8scloudprovider/cinder-csi-plugin
-  tag: "v1.26.0"
+  repository: registry.k8s.io/provider-os/cinder-csi-plugin
+  tag: "v1.26.2"
   targetVersion: ">= 1.26"
   labels:
     - name: 'gardener.cloud/cve-categorisation'


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/area open-source
/kind enhancement
/platform openstack

**What this PR does / why we need it**:
With https://github.com/kubernetes/cloud-provider-openstack/issues/1540 `openstack-cloud-controller-manager` and `cinder-csi-plugin` images are pushed to GCR. See https://github.com/kubernetes/k8s.io/blob/main/k8s.gcr.io/images/k8s-staging-provider-os/images.yaml
Hence, we do no longer need to maintain our copies for 1.24, 1.25, 1.26.

**Which issue(s) this PR fixes**:
See above.

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
provider-openstack does no longer use Gardener GCR copies for `openstack-cloud-controller-manager` and `cinder-csi-plugin` in versions 1.24, 1.25 and 1.26. Instead, the upstream GCR container images are used (`registry.k8s.io/provider-os/openstack-cloud-controller-manager` and `registry.k8s.io/provider-os/cinder-csi-plugin`).
```
