### PR TITLE
update occm lb settings

### DIFF
--- a/charts/internal/cloud-provider-config/templates/_cloud-provider-config-loadbalancer.tpl
+++ b/charts/internal/cloud-provider-config/templates/_cloud-provider-config-loadbalancer.tpl
@@ -1,9 +1,9 @@
 {{- define "cloud-provider-config-loadbalancer" -}}
 [LoadBalancer]
 create-monitor=true
-monitor-delay="60s"
-monitor-timeout="30s"
-monitor-max-retries=5
+monitor-delay="{{ .Values.monitorDelay }}"
+monitor-timeout="{{ .Values.monitorTimeout }}"
+monitor-max-retries={{ .Values.monitorMaxRetries }}
 lb-version="v2"
 lb-provider="{{ .Values.lbProvider }}"
 floating-network-id="{{ .Values.floatingNetworkID }}"

--- a/charts/internal/cloud-provider-config/values.yaml
+++ b/charts/internal/cloud-provider-config/values.yaml
@@ -41,3 +41,7 @@ ignoreVolumeAZ: false
 # nodeVolumeAttachLimit: 25
 # [Metadata]
 # requestTimeout: 1m
+
+monitorDelay: 20s
+monitorMaxRetries: 2
+monitorTimeout: 30s


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement
/platform openstack

**What this PR does / why we need it**:
Update OCCM LB config according to latest testing

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Cloud-controller-manager Loadbalancer configuration has been updated: `monitorDelay: 60s -> 20s`, `monitorMaxRetries: 5 -> 2`
```
