### PR TITLE
Improve worker hash calculation

### DIFF
--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -731,136 +731,138 @@ var _ = Describe("Machines", func() {
 						err := workerDelegate.DeployMachineClasses(context.TODO())
 						Expect(err).NotTo(HaveOccurred())
 					})
-				})
 
-				It("should fail if the server group dependencies do not exist", func() {
-					setup(region, machineImage, "")
+					It("should fail if the server group dependencies do not exist", func() {
+						setup(region, machineImage, "")
 
-					workerWithServerGroup := w.DeepCopy()
-					workerWithServerGroup.Spec.Pools[0].ProviderConfig = &runtime.RawExtension{
-						Object: &apiv1alpha1.WorkerConfig{
-							TypeMeta: metav1.TypeMeta{
-								Kind:       "WorkerConfig",
-								APIVersion: apiv1alpha1.SchemeGroupVersion.String(),
+						workerWithServerGroup := w.DeepCopy()
+						workerWithServerGroup.Spec.Pools[0].ProviderConfig = &runtime.RawExtension{
+							Object: &apiv1alpha1.WorkerConfig{
+								TypeMeta: metav1.TypeMeta{
+									Kind:       "WorkerConfig",
+									APIVersion: apiv1alpha1.SchemeGroupVersion.String(),
+								},
+								ServerGroup: &apiv1alpha1.ServerGroup{
+									Policy: "policy",
+								},
 							},
-							ServerGroup: &apiv1alpha1.ServerGroup{
-								Policy: "policy",
-							},
-						},
-					}
-
-					workerDelegate, _ := NewWorkerDelegate(common.NewClientContext(c, scheme, decoder), chartApplier, "", workerWithServerGroup, cluster, nil)
-					err := workerDelegate.DeployMachineClasses(context.TODO())
-					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(Equal(`server group is required for pool "pool-1", but no server group dependency found`))
-				})
-
-				It("should consider rolling machine labels for the worker pool hash", func() {
-					setup(region, machineImage, "")
-
-					applyLabelsAndPolicy := func(labels []apiv1alpha1.MachineLabel, policy *string) string {
-						w.Spec.Pools[0].Labels = map[string]string{"k1": "v1"}
-						workerConfig := &apiv1alpha1.WorkerConfig{
-							TypeMeta: metav1.TypeMeta{
-								Kind:       "WorkerConfig",
-								APIVersion: apiv1alpha1.SchemeGroupVersion.String(),
-							},
-							MachineLabels: labels,
 						}
-						if policy != nil {
-							workerConfig.ServerGroup = &apiv1alpha1.ServerGroup{Policy: *policy}
-							w.Status.ProviderStatus = &runtime.RawExtension{
-								Object: &apiv1alpha1.WorkerStatus{
-									TypeMeta: metav1.TypeMeta{
-										Kind:       "WorkerStatus",
-										APIVersion: apiv1alpha1.SchemeGroupVersion.String(),
-									},
-									ServerGroupDependencies: []apiv1alpha1.ServerGroupDependency{
-										{
-											PoolName: namePool1,
-											Name:     "servergroup1",
-											ID:       "id1",
+
+						workerDelegate, _ := NewWorkerDelegate(common.NewClientContext(c, scheme, decoder), chartApplier, "", workerWithServerGroup, cluster, nil)
+						err := workerDelegate.DeployMachineClasses(context.TODO())
+						Expect(err).To(HaveOccurred())
+						Expect(err.Error()).To(Equal(`server group is required for pool "pool-1", but no server group dependency found`))
+					})
+				})
+
+				Context("Machine Labels", func() {
+					It("should consider rolling machine labels for the worker pool hash", func() {
+						setup(region, machineImage, "")
+
+						applyLabelsAndPolicy := func(labels []apiv1alpha1.MachineLabel, policy *string) string {
+							w.Spec.Pools[0].Labels = map[string]string{"k1": "v1"}
+							workerConfig := &apiv1alpha1.WorkerConfig{
+								TypeMeta: metav1.TypeMeta{
+									Kind:       "WorkerConfig",
+									APIVersion: apiv1alpha1.SchemeGroupVersion.String(),
+								},
+								MachineLabels: labels,
+							}
+							if policy != nil {
+								workerConfig.ServerGroup = &apiv1alpha1.ServerGroup{Policy: *policy}
+								w.Status.ProviderStatus = &runtime.RawExtension{
+									Object: &apiv1alpha1.WorkerStatus{
+										TypeMeta: metav1.TypeMeta{
+											Kind:       "WorkerStatus",
+											APIVersion: apiv1alpha1.SchemeGroupVersion.String(),
+										},
+										ServerGroupDependencies: []apiv1alpha1.ServerGroupDependency{
+											{
+												PoolName: namePool1,
+												Name:     "servergroup1",
+												ID:       *policy,
+											},
 										},
 									},
-								},
+								}
 							}
+							w.Spec.Pools[0].ProviderConfig = &runtime.RawExtension{
+								Raw: encode(workerConfig),
+							}
+							workerDelegate, _ := NewWorkerDelegate(common.NewClientContext(c, scheme, decoder), chartApplier, "", w, cluster, nil)
+							result, err := workerDelegate.GenerateMachineDeployments(context.TODO())
+							Expect(err).NotTo(HaveOccurred())
+							Expect(result[0].Labels).To(Equal(map[string]string{"k1": "v1"}))
+							return result[0].ClassName
 						}
-						w.Spec.Pools[0].ProviderConfig = &runtime.RawExtension{
-							Raw: encode(workerConfig),
-						}
-						workerDelegate, _ := NewWorkerDelegate(common.NewClientContext(c, scheme, decoder), chartApplier, "", w, cluster, nil)
-						result, err := workerDelegate.GenerateMachineDeployments(context.TODO())
-						Expect(err).NotTo(HaveOccurred())
-						Expect(result[0].Labels).To(Equal(map[string]string{"k1": "v1"}))
-						return result[0].ClassName
-					}
 
-					className0 := applyLabelsAndPolicy(nil, nil)
-					className1 := applyLabelsAndPolicy([]apiv1alpha1.MachineLabel{
-						{Name: "foo", Value: "bar"},
-					}, nil)
-					className1b := applyLabelsAndPolicy([]apiv1alpha1.MachineLabel{
-						{Name: "foo", Value: "bar2"},
-					}, nil)
-					className2 := applyLabelsAndPolicy([]apiv1alpha1.MachineLabel{
-						{Name: "foo", Value: "bar"},
-						{Name: "vmspec/a", Value: "blabla", TriggerRollingOnUpdate: true},
-						{Name: "vmspec/c", Value: "rabarber1", TriggerRollingOnUpdate: true},
-					}, nil)
-					className2b := applyLabelsAndPolicy([]apiv1alpha1.MachineLabel{
-						{Name: "vmspec/c", Value: "rabarber1", TriggerRollingOnUpdate: true},
-						{Name: "vmspec/b", Value: "abc"},
-						{Name: "vmspec/a", Value: "blabla", TriggerRollingOnUpdate: true},
-					}, nil)
-					className3 := applyLabelsAndPolicy([]apiv1alpha1.MachineLabel{
-						{Name: "foo", Value: "bar"},
-						{Name: "vmspec/a", Value: "blabla", TriggerRollingOnUpdate: true},
-						{Name: "vmspec/c", Value: "rabarber2", TriggerRollingOnUpdate: true},
-					}, nil)
-					className4 := applyLabelsAndPolicy([]apiv1alpha1.MachineLabel{
-						{Name: "foo", Value: "bar"},
-						{Name: "vmspec/a", Value: "blabla", TriggerRollingOnUpdate: true},
-						{Name: "vmspec/c", Value: "rabarber2", TriggerRollingOnUpdate: false},
-					}, nil)
+						className0 := applyLabelsAndPolicy(nil, nil)
+						className1 := applyLabelsAndPolicy([]apiv1alpha1.MachineLabel{
+							{Name: "foo", Value: "bar"},
+						}, nil)
+						className1b := applyLabelsAndPolicy([]apiv1alpha1.MachineLabel{
+							{Name: "foo", Value: "bar2"},
+						}, nil)
+						className2 := applyLabelsAndPolicy([]apiv1alpha1.MachineLabel{
+							{Name: "foo", Value: "bar"},
+							{Name: "vmspec/a", Value: "blabla", TriggerRollingOnUpdate: true},
+							{Name: "vmspec/c", Value: "rabarber1", TriggerRollingOnUpdate: true},
+						}, nil)
+						className2b := applyLabelsAndPolicy([]apiv1alpha1.MachineLabel{
+							{Name: "vmspec/c", Value: "rabarber1", TriggerRollingOnUpdate: true},
+							{Name: "vmspec/b", Value: "abc"},
+							{Name: "vmspec/a", Value: "blabla", TriggerRollingOnUpdate: true},
+						}, nil)
+						className3 := applyLabelsAndPolicy([]apiv1alpha1.MachineLabel{
+							{Name: "foo", Value: "bar"},
+							{Name: "vmspec/a", Value: "blabla", TriggerRollingOnUpdate: true},
+							{Name: "vmspec/c", Value: "rabarber2", TriggerRollingOnUpdate: true},
+						}, nil)
+						className4 := applyLabelsAndPolicy([]apiv1alpha1.MachineLabel{
+							{Name: "foo", Value: "bar"},
+							{Name: "vmspec/a", Value: "blabla", TriggerRollingOnUpdate: true},
+							{Name: "vmspec/c", Value: "rabarber2", TriggerRollingOnUpdate: false},
+						}, nil)
 
-					Expect(className0).NotTo(Equal(className1)) // should be equal, but cannot be avoided as old and new hash mechanism are colliding
-					Expect(className1).To(Equal(className1b))
-					Expect(className0).NotTo(Equal(className2))
-					Expect(className2).To(Equal(className2b))
-					Expect(className0).NotTo(Equal(className3))
-					Expect(className2).NotTo(Equal(className3))
-					Expect(className3).NotTo(Equal(className4))
+						Expect(className0).To(Equal(className1))
+						Expect(className1).To(Equal(className1b))
+						Expect(className0).NotTo(Equal(className2))
+						Expect(className2).To(Equal(className2b))
+						Expect(className0).NotTo(Equal(className3))
+						Expect(className2).NotTo(Equal(className3))
+						Expect(className3).NotTo(Equal(className4))
 
-					By("with server group policy")
-					policy1 := pointer.String("soft-anti-affinity")
-					policy2 := pointer.String("foo")
-					classNamePolicy01 := applyLabelsAndPolicy(nil, policy1)
-					classNamePolicy02 := applyLabelsAndPolicy(nil, policy2)
-					classNamePolicy11 := applyLabelsAndPolicy([]apiv1alpha1.MachineLabel{
-						{Name: "foo", Value: "bar"},
-					}, policy1)
-					classNamePolicy21 := applyLabelsAndPolicy([]apiv1alpha1.MachineLabel{
-						{Name: "foo", Value: "bar"},
-						{Name: "vmspec/a", Value: "blabla", TriggerRollingOnUpdate: true},
-						{Name: "vmspec/c", Value: "rabarber1", TriggerRollingOnUpdate: true},
-					}, policy1)
-					classNamePolicy22 := applyLabelsAndPolicy([]apiv1alpha1.MachineLabel{
-						{Name: "foo", Value: "bar"},
-						{Name: "vmspec/a", Value: "blabla", TriggerRollingOnUpdate: true},
-						{Name: "vmspec/c", Value: "rabarber1", TriggerRollingOnUpdate: true},
-					}, policy2)
-					classNamePolicy22b := applyLabelsAndPolicy([]apiv1alpha1.MachineLabel{
-						{Name: "vmspec/a", Value: "blabla", TriggerRollingOnUpdate: true},
-						{Name: "vmspec/c", Value: "rabarber1", TriggerRollingOnUpdate: true},
-					}, policy2)
+						By("with server group policy")
+						policy1 := pointer.String("soft-anti-affinity")
+						policy2 := pointer.String("foo")
+						classNamePolicy01 := applyLabelsAndPolicy(nil, policy1)
+						classNamePolicy02 := applyLabelsAndPolicy(nil, policy2)
+						classNamePolicy11 := applyLabelsAndPolicy([]apiv1alpha1.MachineLabel{
+							{Name: "foo", Value: "bar"},
+						}, policy1)
+						classNamePolicy21 := applyLabelsAndPolicy([]apiv1alpha1.MachineLabel{
+							{Name: "foo", Value: "bar"},
+							{Name: "vmspec/a", Value: "blabla", TriggerRollingOnUpdate: true},
+							{Name: "vmspec/c", Value: "rabarber1", TriggerRollingOnUpdate: true},
+						}, policy1)
+						classNamePolicy22 := applyLabelsAndPolicy([]apiv1alpha1.MachineLabel{
+							{Name: "foo", Value: "bar"},
+							{Name: "vmspec/a", Value: "blabla", TriggerRollingOnUpdate: true},
+							{Name: "vmspec/c", Value: "rabarber1", TriggerRollingOnUpdate: true},
+						}, policy2)
+						classNamePolicy22b := applyLabelsAndPolicy([]apiv1alpha1.MachineLabel{
+							{Name: "vmspec/a", Value: "blabla", TriggerRollingOnUpdate: true},
+							{Name: "vmspec/c", Value: "rabarber1", TriggerRollingOnUpdate: true},
+						}, policy2)
 
-					Expect(className0).NotTo(Equal(classNamePolicy01))
-					Expect(className0).NotTo(Equal(classNamePolicy02))
-					Expect(classNamePolicy01).NotTo(Equal(classNamePolicy02))
-					Expect(classNamePolicy01).NotTo(Equal(classNamePolicy11)) // should be equal, but cannot be avoided as old and new hash mechanism are colliding
-					Expect(classNamePolicy11).NotTo(Equal(classNamePolicy21))
-					Expect(classNamePolicy21).NotTo(Equal(classNamePolicy22))
-					Expect(classNamePolicy22).To(Equal(classNamePolicy22b))
+						Expect(className0).NotTo(Equal(classNamePolicy01))
+						Expect(className0).NotTo(Equal(classNamePolicy02))
+						Expect(classNamePolicy01).NotTo(Equal(classNamePolicy02))
+						Expect(classNamePolicy01).To(Equal(classNamePolicy11))
+						Expect(classNamePolicy11).NotTo(Equal(classNamePolicy21))
+						Expect(classNamePolicy21).NotTo(Equal(classNamePolicy22))
+						Expect(classNamePolicy22).To(Equal(classNamePolicy22b))
+					})
 				})
 			})
 

--- a/pkg/openstack/types.go
+++ b/pkg/openstack/types.go
@@ -152,6 +152,10 @@ const (
 	MachineControllerManagerVpaName = "machine-controller-manager-vpa"
 	// MachineControllerManagerMonitoringConfigName is the name of the ConfigMap containing monitoring stack configurations for machine-controller-manager.
 	MachineControllerManagerMonitoringConfigName = "machine-controller-manager-monitoring-config"
+	// PreserveWorkerHashAnnotation controls whether the providerConfig will be included in the hash calculation for the respective worker pool.
+	// Deprecated: It is only introduced to ease the transition to the new hash calculation.
+	// TODO(KA): Remove in release v1.36
+	PreserveWorkerHashAnnotation = "openstack.provider.extensions.gardener.cloud/worker-preserve-hash"
 )
 
 var (


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement
/platform openstack

**What this PR does / why we need it**:
Improve the hash calculation for machine-deployments. We should not include the providerConfig in the hash calculation and instead let the extension decide what is "important" enough to trigger a node rollout. This is a breaking change because changing the hash will trigger a node rollout. 

To ease the transition we include an annotation that shoot owners can use  to preserve the old hash calculation. This is done to allow shoot owners the freedom to make the node rollout at their discretion. Only worker pools using `server groups` should be affected by the change in the hash. However using the new annotation means **all** `machineLabels` will trigger a rollout. Users should complete the transition before using the `machineLabels` feature.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block. 

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking user
Adapt worker node hash calculation. Shoots that are currently using the server group feature will be rolled out. You can prevent the rollout if the shoot is annotated with `openstack.provider.extensions.gardener.cloud/worker-preserve-hash`. 
```
