### PR TITLE
[release-v1.32] Automated cherry pick of #603: Do not delete `csi-snapshot-validation` ClusterRole and ClusterRoleBinding from the wrong cluster (Seed cluster) when deleting Shoot

### DIFF
--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -156,8 +156,6 @@ var (
 					{Type: &appsv1.Deployment{}, Name: openstack.CSISnapshotValidationName},
 					{Type: &corev1.Service{}, Name: openstack.CSISnapshotValidationName},
 					{Type: &networkingv1.NetworkPolicy{}, Name: "allow-kube-apiserver-to-csi-snapshot-validation"},
-					{Type: &rbacv1.ClusterRole{}, Name: openstack.UsernamePrefix + openstack.CSISnapshotValidationName},
-					{Type: &rbacv1.ClusterRoleBinding{}, Name: openstack.UsernamePrefix + openstack.CSISnapshotValidationName},
 				},
 			},
 		},
@@ -219,6 +217,8 @@ var (
 					{Type: &rbacv1.RoleBinding{}, Name: openstack.UsernamePrefix + openstack.CSIResizerName},
 					// csi-snapshot-validation-webhook
 					{Type: &admissionregistrationv1.ValidatingWebhookConfiguration{}, Name: openstack.CSISnapshotValidationName},
+					{Type: &rbacv1.ClusterRole{}, Name: openstack.UsernamePrefix + openstack.CSISnapshotValidationName},
+					{Type: &rbacv1.ClusterRoleBinding{}, Name: openstack.UsernamePrefix + openstack.CSISnapshotValidationName},
 				},
 			},
 		},


### PR DESCRIPTION
/area quality
/kind bug
/kind regression

Cherry pick of #603 on release-v1.32.

#603: Do not delete `csi-snapshot-validation` ClusterRole and ClusterRoleBinding from the wrong cluster (Seed cluster) when deleting Shoot

**Release Notes:**
```bugfix operator
An issue causing provider-openstack to wrongly delete the `extensions.gardener.cloud:provider-openstack:csi-snapshot-validation` ClusterRole and ClusterRoleBinding from the Seed cluster on every Shoot deletion is now fixed.
```