### PR TITLE
add topology support for manila

### DIFF
--- a/charts/internal/seed-controlplane/charts/csi-driver-manila-controller/templates/deployment-controller.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-driver-manila-controller/templates/deployment-controller.yaml
@@ -51,7 +51,6 @@ spec:
             - --cluster-id={{ .Values.csimanila.clusterID }}
             {{- if .Values.csimanila.topologyAwarenessEnabled }}
             - --with-topology
-            - --nodeaz={{ .Values.csimanila.nodeAZ }}
             {{- end }}
             {{- if .Values.csimanila.runtimeConfig.enabled }}
             - --runtime-config-file=/runtimeconfig/runtimeconfig.json

--- a/charts/internal/seed-controlplane/charts/csi-driver-manila-controller/values.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-driver-manila-controller/values.yaml
@@ -91,10 +91,7 @@ csimanila:
         }
       }
 
-  topologyAwarenessEnabled: false
-  # Availability zone for each node. topologyAwarenessEnabled must be set to true for this option to have any effect.
-  # If your Kubernetes cluster runs atop of Nova and want to use Nova AZs as AZs for the nodes of the cluster, uncomment the line below:
-  #nodeAZ: "$(curl http://169.254.169.254/openstack/latest/meta_data.json | jq -r .availability_zone)"
+  topologyAwarenessEnabled: true
 
   # You may set ID of the cluster where manila-csi is deployed. This value will be appended
   # to share metadata in newly provisioned shares as `manila.csi.openstack.org/cluster=<cluster ID>`.

--- a/charts/internal/shoot-system-components/charts/csi-driver-manila/templates/daemonset-node.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-manila/templates/daemonset-node.yaml
@@ -42,22 +42,24 @@ spec:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
           image: {{ index .Values.images "csi-driver-manila" }}
-          args:
-            - /bin/manila-csi-plugin
-            - --nodeid=$(NODE_ID)
+          command:
+            - "/bin/sh"
+            - "-c"
+            - "/bin/manila-csi-plugin \
+              --nodeid=$(NODE_ID) \
             {{- if .Values.csimanila.runtimeConfig.enabled }}
-            - --runtime-config-file=/runtimeconfig/runtimeconfig.json
+              --runtime-config-file=/runtimeconfig/runtimeconfig.json \
             {{- end }}
             {{- if .Values.csimanila.topologyAwarenessEnabled }}
-            - --with-topology
-            - --nodeaz={{ .Values.csimanila.nodeAZ }}
+              --with-topology \
+              --nodeaz={{ .Values.csimanila.nodeAZ }}
             {{- end }}
-            - --endpoint=/csi/csi.sock
-            - --drivername=$(DRIVER_NAME)
-            - --share-protocol-selector=$(MANILA_SHARE_PROTO)
-            - --fwdendpoint=/csi-fwd/csi.sock
-            - --cluster-id={{ .Values.csimanila.clusterID }}
-            - --v=2
+              --endpoint=/csi/csi.sock \
+              --drivername=$(DRIVER_NAME) \
+              --share-protocol-selector=$(MANILA_SHARE_PROTO) \
+              --fwdendpoint=/csi-fwd/csi.sock \
+              --cluster-id={{ .Values.csimanila.clusterID }} \
+              --v=2"
           env:
             - name: DRIVER_NAME
               value: nfs.manila.csi.openstack.org

--- a/charts/internal/shoot-system-components/charts/csi-driver-manila/templates/storageclass.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-manila/templates/storageclass.yaml
@@ -1,3 +1,26 @@
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  annotations:
+    resources.gardener.cloud/delete-on-invalid-update: "true"
+  name: csi-manila-nfs
+provisioner: nfs.manila.csi.openstack.org
+allowVolumeExpansion: true
+volumeBindingMode: WaitForFirstConsumer
+parameters:
+  type: default
+  shareNetworkID: {{ required "openstack.shareNetworkID needs to be set" $.Values.openstack.shareNetworkID }}
+  nfs-shareClient: {{ required "openstack.shareClient needs to be set" $.Values.openstack.shareClient }}
+  csi.storage.k8s.io/provisioner-secret-name: manila-csi-plugin
+  csi.storage.k8s.io/provisioner-secret-namespace: {{ $.Release.Namespace }}
+  csi.storage.k8s.io/node-stage-secret-name: manila-csi-plugin
+  csi.storage.k8s.io/node-stage-secret-namespace: {{ $.Release.Namespace }}
+  csi.storage.k8s.io/node-publish-secret-name: manila-csi-plugin
+  csi.storage.k8s.io/node-publish-secret-namespace: {{ $.Release.Namespace }}
+  csi.storage.k8s.io/controller-expand-secret-name: manila-csi-plugin
+  csi.storage.k8s.io/controller-expand-secret-namespace: {{ $.Release.Namespace }}
+
 {{- range .Values.openstack.availabilityZones }}
 ---
 apiVersion: storage.k8s.io/v1
@@ -8,6 +31,38 @@ metadata:
   name: csi-manila-nfs-{{ . }}
 provisioner: nfs.manila.csi.openstack.org
 allowVolumeExpansion: true
+volumeBindingMode: WaitForFirstConsumer
+parameters:
+  type: default
+  availability: {{ required "openstack.availabilityZones needs to be set" . }}
+  shareNetworkID: {{ required "openstack.shareNetworkID needs to be set" $.Values.openstack.shareNetworkID }}
+  nfs-shareClient: {{ required "openstack.shareClient needs to be set" $.Values.openstack.shareClient }}
+  csi.storage.k8s.io/provisioner-secret-name: manila-csi-plugin
+  csi.storage.k8s.io/provisioner-secret-namespace: {{ $.Release.Namespace }}
+  csi.storage.k8s.io/node-stage-secret-name: manila-csi-plugin
+  csi.storage.k8s.io/node-stage-secret-namespace: {{ $.Release.Namespace }}
+  csi.storage.k8s.io/node-publish-secret-name: manila-csi-plugin
+  csi.storage.k8s.io/node-publish-secret-namespace: {{ $.Release.Namespace }}
+  csi.storage.k8s.io/controller-expand-secret-name: manila-csi-plugin
+  csi.storage.k8s.io/controller-expand-secret-namespace: {{ $.Release.Namespace }}
+{{ end }}
+
+{{- range .Values.openstack.availabilityZones }}
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  annotations:
+    resources.gardener.cloud/delete-on-invalid-update: "true"
+  name: csi-manila-nfs-constrain-{{ . }}
+provisioner: nfs.manila.csi.openstack.org
+allowVolumeExpansion: true
+volumeBindingMode: WaitForFirstConsumer
+allowedTopologies:
+- matchLabelExpressions:
+  - key: topology.manila.csi.openstack.org/zone
+    values:
+      - "{{ . }}"
 parameters:
   type: default
   availability: {{ required "openstack.availabilityZones needs to be set" . }}

--- a/charts/internal/shoot-system-components/charts/csi-driver-manila/values.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-manila/values.yaml
@@ -84,10 +84,10 @@ csimanila:
         }
       }
 
-  topologyAwarenessEnabled: false
+  topologyAwarenessEnabled: true
   # Availability zone for each node. topologyAwarenessEnabled must be set to true for this option to have any effect.
   # If your Kubernetes cluster runs atop of Nova and want to use Nova AZs as AZs for the nodes of the cluster, uncomment the line below:
-  #nodeAZ: "$(curl http://169.254.169.254/openstack/latest/meta_data.json | jq -r .availability_zone)"
+  nodeAZ: "$(curl http://169.254.169.254/openstack/latest/meta_data.json | jq -r .availability_zone)"
 
   # You may set ID of the cluster where manila-csi is deployed. This value will be appended
   # to share metadata in newly provisioned shares as `manila.csi.openstack.org/cluster=<cluster ID>`.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement
/platform openstack

**What this PR does / why we need it**:
+ Current storageclasses have now `volumeBindingMode: WaitForFirstConsumer`
+ Adds topology awareness support for Manila
+ Default deployment now is with TopologyAwareness
+ Fix an issue where the `nodeaz` was not computed correctly when enabled
+ Adds the following storageclasses:
  - A storage class without specifying the `availability` ( leaves it up to the Manila Scheduler to make decision about the location) 
  - Exclusive storageclasses per region (`*-constrain-*` variants). These storageclasses will make it so that both the provisioning and the scheduling of workloads using these volumes is exclusive to the target zone. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Add topology awareness support for Manila
```
