### PR TITLE
manila observability

### DIFF
--- a/charts/internal/seed-controlplane/charts/csi-driver-manila-controller/templates/deployment-controller.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-driver-manila-controller/templates/deployment-controller.yaml
@@ -1,11 +1,11 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: csi-driver-manila-controller
+  name: csi-driver-controller-manila
   namespace: {{ .Release.Namespace }}
   labels:
     app: csi
-    role: driver-manila-controller
+    role: controller-manila
     high-availability-config.resources.gardener.cloud/type: controller
 spec:
   replicas: {{ .Values.replicas }}
@@ -13,7 +13,7 @@ spec:
   selector:
     matchLabels:
       app: csi
-      role: driver-manila-controller
+      role: controller-manila
   strategy:
     rollingUpdate:
       maxSurge: 25%
@@ -28,7 +28,7 @@ spec:
       creationTimestamp: null
       labels:
         app: csi
-        role: driver-manila-controller
+        role: controller-manila
         gardener.cloud/role: controlplane
         networking.gardener.cloud/to-dns: allowed
         networking.gardener.cloud/to-public-networks: allowed
@@ -38,7 +38,7 @@ spec:
       automountServiceAccountToken: false
       priorityClassName: gardener-system-300
       containers:
-        - name: openstack-nfs-driver
+        - name: openstack-csi-manila-driver
           image: {{ index .Values.images "csi-driver-manila" }}
           args:
             - /bin/manila-csi-plugin
@@ -86,9 +86,7 @@ spec:
               mountPath: /var/run/csi-manila
             {{- end }}
 
-
-
-        - name: openstack-nfs-nfs-controller
+        - name: openstack-csi-manila-nfs-driver
           image: {{ index .Values.images "csi-driver-nfs" }}
           args:
             - "--v=5"
@@ -137,7 +135,7 @@ spec:
             - name: nfs-fwd-plugin-dir
               mountPath: /csi
 
-        - name: openstack-nfs-provisioner
+        - name: openstack-csi-manila-provisioner
           image: {{ index .Values.images "csi-provisioner" }}
           args:
             - --kubeconfig=/var/run/secrets/gardener.cloud/shoot/generic-kubeconfig/kubeconfig
@@ -161,7 +159,7 @@ spec:
               name: kubeconfig-csi-provisioner
               readOnly: true
 
-        - name: openstack-nfs-snapshotter
+        - name: openstack-csi-manila-snapshotter
           image: {{ index .Values.images "csi-snapshotter" }}
           args:
             - --kubeconfig=/var/run/secrets/gardener.cloud/shoot/generic-kubeconfig/kubeconfig
@@ -181,7 +179,7 @@ spec:
               name: kubeconfig-csi-snapshotter
               readOnly: true
 
-        - name: openstack-nfs-resizer
+        - name: openstack-csi-manila-resizer
           image: {{ index .Values.images "csi-resizer" }}
           args:
             - --kubeconfig=/var/run/secrets/gardener.cloud/shoot/generic-kubeconfig/kubeconfig


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/platform openstack

**What this PR does / why we need it**:

Add observability config map for manila CSI driver

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Add observability configuration for Manila CSI Driver. 
```
