### PR TITLE
add bastion ingress rules in worker node security group

### DIFF
--- a/pkg/controller/bastion/actuator_delete.go
+++ b/pkg/controller/bastion/actuator_delete.go
@@ -79,6 +79,7 @@ func (a *actuator) Delete(ctx context.Context, log logr.Logger, bastion *extensi
 		}
 	}
 
+	// The bastion ingress rule in worker node security groups was also removed after the bastion security group was removed.
 	return util.DetermineError(removeSecurityGroup(networkingClient, opt), helper.KnownCodes)
 }
 

--- a/pkg/controller/bastion/resourcesdefine.go
+++ b/pkg/controller/bastion/resourcesdefine.go
@@ -19,7 +19,7 @@ import (
 )
 
 // IngressAllowSSH ingress allow ssh
-func IngressAllowSSH(opt *Options, etherType rules.RuleEtherType, secGroupID, cidr string) rules.CreateOpts {
+func IngressAllowSSH(opt *Options, etherType rules.RuleEtherType, secGroupID, cidr, remoteGroupID string) rules.CreateOpts {
 	return rules.CreateOpts{
 		Direction:      "ingress",
 		Description:    ingressAllowSSHResourceName(opt.BastionInstanceName),
@@ -29,6 +29,7 @@ func IngressAllowSSH(opt *Options, etherType rules.RuleEtherType, secGroupID, ci
 		Protocol:       "tcp",
 		SecGroupID:     secGroupID,
 		RemoteIPPrefix: cidr,
+		RemoteGroupID:  remoteGroupID,
 	}
 }
 

--- a/test/integration/bastion/bastion_test.go
+++ b/test/integration/bastion/bastion_test.go
@@ -566,7 +566,7 @@ func verifyCreation(openstackClient *OpenstackClient, options *bastionctrl.Optio
 	Expect(securityGroup[0].Description).To(Equal(options.SecurityGroup))
 
 	By("checkNSGExists")
-	checkSecurityRuleslExists(openstackClient, bastionctrl.IngressAllowSSH(options, "", "", "").Description)
+	checkSecurityRuleslExists(openstackClient, bastionctrl.IngressAllowSSH(options, "", "", "", "").Description)
 
 	By("checking bastion instance")
 	allPages, err = servers.List(openstackClient.ComputeClient, servers.ListOpts{Name: options.BastionInstanceName}).AllPages()


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind bug
/platform openstack

**What this PR does / why we need it**:
Floating IP subnets and private networks are independent from each other without any correlation. I cannot deduce which floating IP subnet is associated with a private network A before assigning. Therefore, the current solution I used is to add a bastion ingress rule in the worker node security group to establish the connection to fit different networks.
 
**Which issue(s) this PR fixes**:
Fixes #
https://github.com/gardener/gardener-extension-provider-openstack/issues/615
**Special notes for your reviewer**:
after this PR, ideally, it should work after restriction port_range = 22, 30000~32767

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
add a bastion ingress rule in the worker node security group to establish the connection to fit different networks.
```

/invite @kon-angelo 
