### PR TITLE
specify fip subnet based on router

### DIFF
--- a/pkg/controller/bastion/actuator_reconcile.go
+++ b/pkg/controller/bastion/actuator_reconcile.go
@@ -188,20 +188,15 @@ func ensurePublicIPAddress(opt *Options, log logr.Logger, client openstackclient
 		return nil, fmt.Errorf("router with ID %s was not found", infraStatus.Networks.Router.ID)
 	}
 
-	var (
-		subnetID string
-	)
-
 	router := routerList[0]
 	if len(router.GatewayInfo.ExternalFixedIPs) == 0 {
 		return nil, errors.New("no external fixed IPs detected on the router")
 	}
 
-	subnetID = router.GatewayInfo.ExternalFixedIPs[0].SubnetID
 	createOpts := floatingips.CreateOpts{
 		Description:       opt.BastionInstanceName,
 		FloatingNetworkID: infraStatus.Networks.FloatingPool.ID,
-		SubnetID:          subnetID,
+		SubnetID:          router.GatewayInfo.ExternalFixedIPs[0].SubnetID,
 	}
 
 	fip, err := createFloatingIP(client, createOpts)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement
/platform openstack

**What this PR does / why we need it**:
This PR will make it so that the bastion controller binds FIPs from the same subnet as the router. We can potentially change the logic to use processing logic similar as with `FloatingPoolSubnetName`, but for simplicity this PR chooses the router subnet. The downside of that choice is that we depend on that particular subnet for available FIPs. 

**Which issue(s) this PR fixes**:
Fixes #615 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The bastion with try to reserve Floating IPs from the router's external subnet
```
