### PR TITLE
restrict-port

### DIFF
--- a/pkg/internal/infrastructure/templates/main.tpl.tf
+++ b/pkg/internal/infrastructure/templates/main.tpl.tf
@@ -110,6 +110,8 @@ resource "openstack_networking_secgroup_rule_v2" "cluster_tcp_all" {
   ethertype         = "IPv4"
   protocol          = "tcp"
   remote_ip_prefix  = "0.0.0.0/0"
+  port_range_min    = 30000
+  port_range_max    = 32767
   security_group_id = openstack_networking_secgroup_v2.cluster.id
 }
 
@@ -118,6 +120,8 @@ resource "openstack_networking_secgroup_rule_v2" "cluster_udp_all" {
   ethertype         = "IPv4"
   protocol          = "udp"
   remote_ip_prefix  = "0.0.0.0/0"
+  port_range_min    = 30000
+  port_range_max    = 32767
   security_group_id = openstack_networking_secgroup_v2.cluster.id
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind enhancement
/platform openstack

**What this PR does / why we need it**:
Restrict security group ingress port-range to kubernetes node-port range
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
per PR https://github.com/gardener/gardener-extension-provider-openstack/pull/621 and https://github.com/gardener/gardener-extension-provider-openstack/pull/608
**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Restrict security group ingress port-range to kubernetes node-port range
```
