### PR TITLE
Add cve categorziation for extension and admission controller

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -20,6 +20,14 @@ gardener-extension-provider-openstack:
                 username: 'dkistner'
               - type: 'githubUser'
                 username: 'kon-angelo'
+            - name: 'gardener.cloud/cve-categorisation'
+              value:
+                network_exposure: 'protected'
+                authentication_enforced: false
+                user_interaction: 'gardener-operator'
+                confidentiality_requirement: 'high'
+                integrity_requirement: 'high'
+                availability_requirement: 'high'
           gardener-extension-admission-openstack:
             registry: 'gcr-readwrite'
             image: 'eu.gcr.io/gardener-project/gardener/extensions/admission-openstack'
@@ -32,6 +40,14 @@ gardener-extension-provider-openstack:
                 username: 'dkistner'
               - type: 'githubUser'
                 username: 'kon-angelo'
+            - name: 'gardener.cloud/cve-categorisation'
+              value:
+                network_exposure: 'protected'
+                authentication_enforced: false
+                user_interaction: 'end-user'
+                confidentiality_requirement: 'high'
+                integrity_requirement: 'high'
+                availability_requirement: 'high'
   jobs:
     head-update:
       traits:


### PR DESCRIPTION
**How to categorize this PR?**
/area compliance
/kind enhancement
/platform openstack

**What this PR does / why we need it**:
Add cve categorizations for the extension and admissions controllers.

**Release note**:
```NONE
```
