### PR TITLE
Allow changing share network section

### DIFF
--- a/pkg/apis/openstack/validation/infrastructure.go
+++ b/pkg/apis/openstack/validation/infrastructure.go
@@ -83,7 +83,12 @@ func ValidateInfrastructureConfig(infra *api.InfrastructureConfig, nodesCIDR *st
 func ValidateInfrastructureConfigUpdate(oldConfig, newConfig *api.InfrastructureConfig, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newConfig.Networks, oldConfig.Networks, fldPath.Child("networks"))...)
+	newNetworks := newConfig.Networks
+	oldNetworks := oldConfig.Networks
+	// share network changes are allowed, therefore ignore them on comparing
+	newNetworks.ShareNetwork = nil
+	oldNetworks.ShareNetwork = nil
+	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newNetworks, oldNetworks, fldPath.Child("networks"))...)
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newConfig.FloatingPoolName, oldConfig.FloatingPoolName, fldPath.Child("floatingPoolName"))...)
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newConfig.FloatingPoolSubnetName, oldConfig.FloatingPoolSubnetName, fldPath.Child("floatingPoolSubnetName"))...)
 

--- a/pkg/apis/openstack/validation/infrastructure_test.go
+++ b/pkg/apis/openstack/validation/infrastructure_test.go
@@ -181,6 +181,15 @@ var _ = Describe("InfrastructureConfig validation", func() {
 			}))))
 		})
 
+		It("should allow changing the share network section", func() {
+			newInfrastructureConfig := infrastructureConfig.DeepCopy()
+			newInfrastructureConfig.Networks.ShareNetwork = &api.ShareNetwork{Enabled: true}
+
+			errorList := ValidateInfrastructureConfigUpdate(infrastructureConfig, newInfrastructureConfig, nilPath)
+
+			Expect(errorList).To(BeEmpty())
+		})
+
 		It("should forbid changing the floating pool", func() {
 			newInfrastructureConfig := infrastructureConfig.DeepCopy()
 			newInfrastructureConfig.FloatingPoolName = "test"

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -181,7 +181,7 @@ var (
 				},
 				Objects: []*chart.Object{
 					// csi-driver-manila-controller
-					{Type: &appsv1.Deployment{}, Name: openstack.CSIDriverManilaController},
+					{Type: &appsv1.Deployment{}, Name: "csi-driver-controller-manila"},
 					{Type: &autoscalingv1.VerticalPodAutoscaler{}, Name: openstack.CSIDriverManilaController},
 				},
 			},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/platform openstack

**What this PR does / why we need it**:
The admission webhook disallows changing network settings in the infrastructure config. But it also contains the `shareNetwork` section needed for CSI Manila support. This PR allows to enable or disable the share network for existing clusters.

Additionally it fixes the deletion of the CSI Manila controller deployment as a wrong name was specified ("csi-driver-manila-controller" instead of "csi-driver-controller-manila")

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Allow changing share network section in `InfrastructureConfig` for existing cluster.
```
