### PR TITLE
[release-v1.35] Automated cherry pick of #646: [ci:component:github.com/gardener/machine-controller-manager:v0.49.2->v0.49.3]

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -115,7 +115,7 @@ images:
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager
-  tag: "v0.49.2"
+  tag: "v0.49.3"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:


### PR DESCRIPTION
/area ops-productivity
/kind bug

Cherry pick of #646 on release-v1.35.

#646: [ci:component:github.com/gardener/machine-controller-manager:v0.49.2->v0.49.3]

**Release Notes:**
``` bugfix operator github.com/gardener/machine-controller-manager #834 @ialidzhikov
Included `UnavailableReplicas` in determining if a machine deployment status update is needed
```