### PR TITLE
Fix rendering of CSI manila storageclass if creating infrastructure fails.

### DIFF
--- a/charts/internal/shoot-system-components/charts/csi-driver-manila/templates/storageclass.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-manila/templates/storageclass.yaml
@@ -10,7 +10,7 @@ allowVolumeExpansion: true
 volumeBindingMode: WaitForFirstConsumer
 parameters:
   type: default
-  shareNetworkID: {{ required "openstack.shareNetworkID needs to be set" $.Values.openstack.shareNetworkID }}
+  shareNetworkID: {{ $.Values.openstack.shareNetworkID }}
   nfs-shareClient: {{ required "openstack.shareClient needs to be set" $.Values.openstack.shareClient }}
   csi.storage.k8s.io/provisioner-secret-name: manila-csi-plugin
   csi.storage.k8s.io/provisioner-secret-namespace: {{ $.Release.Namespace }}
@@ -35,7 +35,7 @@ volumeBindingMode: WaitForFirstConsumer
 parameters:
   type: default
   availability: {{ required "openstack.availabilityZones needs to be set" . }}
-  shareNetworkID: {{ required "openstack.shareNetworkID needs to be set" $.Values.openstack.shareNetworkID }}
+  shareNetworkID: {{ $.Values.openstack.shareNetworkID }}
   nfs-shareClient: {{ required "openstack.shareClient needs to be set" $.Values.openstack.shareClient }}
   csi.storage.k8s.io/provisioner-secret-name: manila-csi-plugin
   csi.storage.k8s.io/provisioner-secret-namespace: {{ $.Release.Namespace }}
@@ -66,7 +66,7 @@ allowedTopologies:
 parameters:
   type: default
   availability: {{ required "openstack.availabilityZones needs to be set" . }}
-  shareNetworkID: {{ required "openstack.shareNetworkID needs to be set" $.Values.openstack.shareNetworkID }}
+  shareNetworkID: {{ $.Values.openstack.shareNetworkID }}
   nfs-shareClient: {{ required "openstack.shareClient needs to be set" $.Values.openstack.shareClient }}
   csi.storage.k8s.io/provisioner-secret-name: manila-csi-plugin
   csi.storage.k8s.io/provisioner-secret-namespace: {{ $.Release.Namespace }}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/platform openstack

**What this PR does / why we need it**:
If the infrastructure cannot be reconciled successfully (e.g. out of quota), the share network cannot be created and the rendering of the charts fail with 
```
Error reconciling ControlPlane: could not apply control plane shoot chart for controlplane 'shoot--hc-ci--a9a998-orc/a9a998-orc': could not render chart: could not render chart 'shoot-system-components' in namespace 'kube-system': render error in "shoot-system-components/charts/csi-driver-manila/templates/storageclass.yaml": template: shoot-system-components/charts/csi-driver-manila/templates/storageclass.yaml:13:21: executing "shoot-system-components/charts/csi-driver-manila/templates/storageclass.yaml" at <required "openstack.shareNetworkID needs to be set" $.Values.openstack.shareNetworkID>: error calling required: openstack.shareNetworkID needs to be set
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fix rendering of CSI manila storageclass if creating infrastructure fails.
```
