### PR TITLE
remove control plane limits

### DIFF
--- a/charts/internal/machine-controller-manager/seed/values.yaml
+++ b/charts/internal/machine-controller-manager/seed/values.yaml
@@ -38,11 +38,7 @@ resources:
     requests:
       cpu: 31m
       memory: 70Mi
-    limits:
-      memory: 750Mi 
   mcmProviderOpenstack:
     requests:
       cpu: 30m
       memory: 64Mi
-    limits:
-      memory: 400Mi

--- a/charts/internal/seed-controlplane/charts/cloud-controller-manager/values.yaml
+++ b/charts/internal/seed-controlplane/charts/cloud-controller-manager/values.yaml
@@ -14,8 +14,6 @@ resources:
   requests:
     cpu: 100m
     memory: 64Mi
-  limits:
-    memory: 2Gi
 tlsCipherSuites: []
 secrets:
   server: cloud-controller-manager-server

--- a/charts/internal/seed-controlplane/charts/csi-driver-controller/values.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-driver-controller/values.yaml
@@ -23,39 +23,26 @@ resources:
     requests:
       cpu: 20m
       memory: 50Mi
-    limits:
-      memory: 360Mi
   provisioner:
     requests:
       cpu: 11m
       memory: 38Mi
-    limits:
-      memory: 400Mi
   attacher:
     requests:
       cpu: 11m
       memory: 36Mi
-    limits:
-      memory: 320Mi
   snapshotter:
     requests:
       cpu: 11m
       memory: 36Mi
-    limits:
-      memory: 220Mi
   resizer:
     requests:
       cpu: 11m
       memory: 32Mi
-    limits:
-      memory: 220Mi
   livenessProbe:
     requests:
       cpu: 11m
       memory: 32Mi
-    limits:
-      memory: 220Mi
-
 vpa:
   resourcePolicy:
     driver:
@@ -90,9 +77,6 @@ csiSnapshotController:
     requests:
       cpu: 11m
       memory: 32Mi
-    limits:
-      memory: 2.2Gi
-
 csiSnapshotValidationWebhook:
   replica: 1
   podAnnotations: {}
@@ -102,6 +86,4 @@ csiSnapshotValidationWebhook:
     requests:
       cpu: 10m
       memory: 32Mi
-    limits:
-      memory: 200Mi
   topologyAwareRoutingEnabled: false

--- a/charts/internal/seed-controlplane/charts/csi-driver-manila-controller/values.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-driver-manila-controller/values.yaml
@@ -19,38 +19,26 @@ resources:
     requests:
       cpu: 20m
       memory: 50Mi
-    limits:
-      memory: 360Mi
   driverNFSController:
     requests:
       cpu: 20m
       memory: 50Mi
-    limits:
-      memory: 360Mi
   provisioner:
     requests:
       cpu: 11m
       memory: 38Mi
-    limits:
-      memory: 400Mi
   snapshotter:
     requests:
       cpu: 11m
       memory: 36Mi
-    limits:
-      memory: 220Mi
   resizer:
     requests:
       cpu: 11m
       memory: 32Mi
-    limits:
-      memory: 220Mi
   livenessProbe:
     requests:
       cpu: 11m
       memory: 32Mi
-    limits:
-      memory: 200Mi
 
 vpa:
   resourcePolicy:

--- a/charts/internal/shoot-system-components/charts/csi-driver-manila/values.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-manila/values.yaml
@@ -33,20 +33,14 @@ resources:
     requests:
       cpu: 15m
       memory: 42Mi
-    limits:
-      memory: 2Gi
   nodeDriverRegistrar:
     requests:
       cpu: 11m
       memory: 32Mi
-    limits:
-      memory: 1Gi
   livenessProbe:
     requests:
       cpu: 11m
       memory: 32Mi
-    limits:
-      memory: 200Mi
 
 vpa:
   resourcePolicy:

--- a/charts/internal/shoot-system-components/charts/csi-driver-node/values.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/values.yaml
@@ -23,20 +23,14 @@ resources:
     requests:
       cpu: 15m
       memory: 42Mi
-    limits:
-      memory: 2Gi
   nodeDriverRegistrar:
     requests:
       cpu: 11m
       memory: 32Mi
-    limits:
-      memory: 1Gi
   livenessProbe:
     requests:
       cpu: 11m
       memory: 32Mi
-    limits:
-      memory: 200Mi
 
 pspDisabled: false
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement
/platform openstack

**What this PR does / why we need it**:
Remove limits from critical control plane components. There should still be a limitation via the vpa controlling the requests (via `maxAllowed`) on certain components

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Remove limits from critical control plane components.
```
