### PR TITLE
add convenient description to security group rules

### DIFF
--- a/pkg/controller/infrastructure/infraflow/reconcile.go
+++ b/pkg/controller/infrastructure/infraflow/reconcile.go
@@ -376,21 +376,22 @@ func (c *FlowContext) ensureSecGroupRules(ctx context.Context) error {
 		return fmt.Errorf("internal error: casting to SecGroup failed")
 	}
 
-	desc := "managed by Gardener"
 	desiredRules := []rules.SecGroupRule{
 		{
 			Direction:     string(rules.DirIngress),
 			EtherType:     string(rules.EtherType4),
 			RemoteGroupID: access.SecurityGroupIDSelf,
-			Description:   desc,
+			Description:   "IPv4: allow all incoming traffic within the same security group",
 		},
 		{
-			Direction: string(rules.DirEgress),
-			EtherType: string(rules.EtherType4),
+			Direction:   string(rules.DirEgress),
+			EtherType:   string(rules.EtherType4),
+			Description: "IPv4: allow all outgoing traffic",
 		},
 		{
-			Direction: string(rules.DirEgress),
-			EtherType: string(rules.EtherType6),
+			Direction:   string(rules.DirEgress),
+			EtherType:   string(rules.EtherType6),
+			Description: "IPv6: allow all outgoing traffic",
 		},
 		{
 			Direction:      string(rules.DirIngress),
@@ -399,7 +400,7 @@ func (c *FlowContext) ensureSecGroupRules(ctx context.Context) error {
 			PortRangeMin:   30000,
 			PortRangeMax:   32767,
 			RemoteIPPrefix: "0.0.0.0/0",
-			Description:    desc,
+			Description:    "IPv4: allow all incoming tcp traffic with port range 30000-32767",
 		},
 		{
 			Direction:      string(rules.DirIngress),
@@ -408,7 +409,7 @@ func (c *FlowContext) ensureSecGroupRules(ctx context.Context) error {
 			PortRangeMin:   30000,
 			PortRangeMax:   32767,
 			RemoteIPPrefix: "0.0.0.0/0",
-			Description:    desc,
+			Description:    "IPv4: allow all incoming udp traffic with port range 30000-32767",
 		},
 	}
 

--- a/pkg/internal/infrastructure/templates/main.tpl.tf
+++ b/pkg/internal/infrastructure/templates/main.tpl.tf
@@ -94,6 +94,7 @@ resource "openstack_networking_secgroup_v2" "cluster" {
 
 resource "openstack_networking_secgroup_rule_v2" "cluster_self" {
   direction         = "ingress"
+  description       = "IPv4: allow all incoming traffic within the same security group"
   ethertype         = "IPv4"
   security_group_id = openstack_networking_secgroup_v2.cluster.id
   remote_group_id   = openstack_networking_secgroup_v2.cluster.id
@@ -101,12 +102,14 @@ resource "openstack_networking_secgroup_rule_v2" "cluster_self" {
 
 resource "openstack_networking_secgroup_rule_v2" "cluster_egress" {
   direction         = "egress"
+  description       = "IPv4: allow all outgoing traffic"
   ethertype         = "IPv4"
   security_group_id = openstack_networking_secgroup_v2.cluster.id
 }
 
 resource "openstack_networking_secgroup_rule_v2" "cluster_tcp_all" {
   direction         = "ingress"
+  description       = "IPv4: allow all incoming tcp traffic with port range 30000-32767"
   ethertype         = "IPv4"
   protocol          = "tcp"
   remote_ip_prefix  = "0.0.0.0/0"
@@ -117,6 +120,7 @@ resource "openstack_networking_secgroup_rule_v2" "cluster_tcp_all" {
 
 resource "openstack_networking_secgroup_rule_v2" "cluster_udp_all" {
   direction         = "ingress"
+  description       = "IPv4: allow all incoming udp traffic with port range 30000-32767"
   ethertype         = "IPv4"
   protocol          = "udp"
   remote_ip_prefix  = "0.0.0.0/0"


### PR DESCRIPTION
**How to categorize this PR?**
/area networking
/kind enhancement
/platform openstack

Adds convenient descriptions to security group rules in terraformer.

**What this PR does / why we need it**:

N.A.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Added description to openstack security group rules.
```
