### PR TITLE
Honor cloudprofile specific TLS settings

### DIFF
--- a/pkg/openstack/client/client.go
+++ b/pkg/openstack/client/client.go
@@ -81,7 +81,19 @@ func NewOpenstackClientFromCredentials(credentials *os.Credentials) (Factory, er
 	// re-authenticate automatically if/when your token expires.
 	authOpts.AllowReauth = true
 
-	provider, err := openstack.AuthenticatedClient(*authOpts)
+	provider, err := openstack.NewClient(authOpts.IdentityEndpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	provider.HTTPClient = *opts.HTTPClient
+
+	err = openstack.Authenticate(provider, *authOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = openstack.NewIdentityV3(provider, gophercloud.EndpointOpts{})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/openstack/client/client.go
+++ b/pkg/openstack/client/client.go
@@ -93,11 +93,6 @@ func NewOpenstackClientFromCredentials(credentials *os.Credentials) (Factory, er
 		return nil, err
 	}
 
-	_, err = openstack.NewIdentityV3(provider, gophercloud.EndpointOpts{})
-	if err != nil {
-		return nil, err
-	}
-
 	return &OpenstackClientFactory{
 		providerClient: provider,
 	}, nil


### PR DESCRIPTION
**How to categorize this PR?**
/area networking
/kind bug
/platform openstack

**What this PR does / why we need it**:

As briefly discussed [here](https://github.com/gardener/gardener-extension-provider-openstack/pull/563#discussion_r1331585432), openstack clients constructed for cloudprofiles don't honor cloudprofile specific TLS settings. A suitable HTTPClient is created but isn't used by the provider. 

This PR is to fix this issue.
