### PR TITLE
Drop support for Shoots with Kubernetes version < 1.24

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,6 @@ This extension controller supports the following Kubernetes versions:
 | Kubernetes 1.26 | 1.26.0+     | [![Gardener v1.26 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.26%20OpenStack/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.26%20OpenStack) |
 | Kubernetes 1.25 | 1.25.0+     | [![Gardener v1.25 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.25%20OpenStack/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.25%20OpenStack) |
 | Kubernetes 1.24 | 1.24.0+     | [![Gardener v1.24 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.24%20OpenStack/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.24%20OpenStack) |
-| Kubernetes 1.23 | 1.23.0+     | [![Gardener v1.23 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.23%20OpenStack/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.23%20OpenStack) |
-| Kubernetes 1.22 | 1.22.0+     | [![Gardener v1.22 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.22%20OpenStack/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.22%20OpenStack) |
 
 Please take a look [here](https://github.com/gardener/gardener/blob/master/docs/usage/supported_k8s_versions.md) to see which versions are supported by Gardener in general.
 

--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -15,34 +15,6 @@ images:
 
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes/cloud-provider-openstack
-  repository: eu.gcr.io/gardener-project/3rd/k8scloudprovider/openstack-cloud-controller-manager
-  tag: "v1.22.2"
-  targetVersion: "1.22.x"
-  labels:
-  - name: 'gardener.cloud/cve-categorisation'
-    value:
-      network_exposure: 'protected'
-      authentication_enforced: false
-      user_interaction: 'gardener-operator'
-      confidentiality_requirement: 'high'
-      integrity_requirement: 'high'
-      availability_requirement: 'low'
-- name: cloud-controller-manager
-  sourceRepository: github.com/kubernetes/cloud-provider-openstack
-  repository: eu.gcr.io/gardener-project/3rd/k8scloudprovider/openstack-cloud-controller-manager
-  tag: "v1.23.4"
-  targetVersion: "1.23.x"
-  labels:
-  - name: 'gardener.cloud/cve-categorisation'
-    value:
-      network_exposure: 'protected'
-      authentication_enforced: false
-      user_interaction: 'gardener-operator'
-      confidentiality_requirement: 'high'
-      integrity_requirement: 'high'
-      availability_requirement: 'low'
-- name: cloud-controller-manager
-  sourceRepository: github.com/kubernetes/cloud-provider-openstack
   repository: registry.k8s.io/provider-os/openstack-cloud-controller-manager
   tag: "v1.24.6"
   targetVersion: "1.24.x"
@@ -125,34 +97,6 @@ images:
       integrity_requirement: 'high'
       availability_requirement: 'low'
 
-- name: csi-driver-cinder
-  sourceRepository: github.com/kubernetes/cloud-provider-openstack
-  repository: eu.gcr.io/gardener-project/3rd/k8scloudprovider/cinder-csi-plugin
-  tag: "v1.22.2"
-  targetVersion: "1.22.x"
-  labels:
-  - name: 'gardener.cloud/cve-categorisation'
-    value:
-      network_exposure: 'protected'
-      authentication_enforced: false
-      user_interaction: 'end-user'
-      confidentiality_requirement: 'high'
-      integrity_requirement: 'high'
-      availability_requirement: 'low'
-- name: csi-driver-cinder
-  sourceRepository: github.com/kubernetes/cloud-provider-openstack
-  repository: eu.gcr.io/gardener-project/3rd/k8scloudprovider/cinder-csi-plugin
-  tag: "v1.23.4"
-  targetVersion: "1.23.x"
-  labels:
-  - name: 'gardener.cloud/cve-categorisation'
-    value:
-      network_exposure: 'protected'
-      authentication_enforced: false
-      user_interaction: 'end-user'
-      confidentiality_requirement: 'high'
-      integrity_requirement: 'high'
-      availability_requirement: 'low'
 - name: csi-driver-cinder
   sourceRepository: github.com/kubernetes/cloud-provider-openstack
   repository: registry.k8s.io/provider-os/cinder-csi-plugin

--- a/charts/internal/seed-controlplane/charts/cloud-controller-manager/templates/cloud-controller-manager.yaml
+++ b/charts/internal/seed-controlplane/charts/cloud-controller-manager/templates/cloud-controller-manager.yaml
@@ -53,9 +53,6 @@ spec:
         - --authorization-kubeconfig=/var/run/secrets/gardener.cloud/shoot/generic-kubeconfig/kubeconfig
         - --leader-elect=true
         - --secure-port={{ include "cloud-controller-manager.port" . }}
-        {{- if semverCompare "< 1.24" .Values.kubernetesVersion }}
-        - --port=0
-        {{- end }}
         - --tls-cert-file=/var/lib/cloud-controller-manager-server/tls.crt
         - --tls-private-key-file=/var/lib/cloud-controller-manager-server/tls.key
         - --tls-cipher-suites={{ .Values.tlsCipherSuites | join "," }}

--- a/charts/internal/seed-controlplane/charts/cloud-controller-manager/values.yaml
+++ b/charts/internal/seed-controlplane/charts/cloud-controller-manager/values.yaml
@@ -1,6 +1,6 @@
 replicas: 1
 clusterName: shoot-foo-bar
-kubernetesVersion: 1.23.9
+kubernetesVersion: 1.27.4
 podNetwork: 192.168.0.0/16
 podAnnotations: {}
 podLabels: {}

--- a/docs/operations/operations.md
+++ b/docs/operations/operations.md
@@ -151,8 +151,8 @@ spec:
   type: openstack
   kubernetes:
     versions:
-    - version: 1.24.3
-    - version: 1.23.8
+    - version: 1.27.3
+    - version: 1.26.8
       expirationDate: "2022-10-31T23:59:59Z"
   machineImages:
   - name: coreos

--- a/pkg/webhook/controlplane/ensurer_test.go
+++ b/pkg/webhook/controlplane/ensurer_test.go
@@ -96,23 +96,12 @@ var _ = Describe("Ensurer", func() {
 		ensurer genericmutator.Ensurer
 
 		dummyContext   = gcontext.NewGardenContext(nil, nil)
-		eContextK8s122 = gcontext.NewInternalGardenContext(
+		eContextK8s125 = gcontext.NewInternalGardenContext(
 			&extensionscontroller.Cluster{
 				Shoot: &gardencorev1beta1.Shoot{
 					Spec: gardencorev1beta1.ShootSpec{
 						Kubernetes: gardencorev1beta1.Kubernetes{
-							Version: "1.22.0",
-						},
-					},
-				},
-			},
-		)
-		eContextK8s123 = gcontext.NewInternalGardenContext(
-			&extensionscontroller.Cluster{
-				Shoot: &gardencorev1beta1.Shoot{
-					Spec: gardencorev1beta1.ShootSpec{
-						Kubernetes: gardencorev1beta1.Kubernetes{
-							Version: "1.23.0",
+							Version: "1.25.0",
 						},
 					},
 				},
@@ -140,7 +129,7 @@ var _ = Describe("Ensurer", func() {
 				},
 			},
 		)
-		eContextK8s122WithResolvConfOptions = gcontext.NewInternalGardenContext(
+		eContextK8s126WithResolvConfOptions = gcontext.NewInternalGardenContext(
 			&extensionscontroller.Cluster{
 				CloudProfile: &gardencorev1beta1.CloudProfile{
 					Spec: gardencorev1beta1.CloudProfileSpec{
@@ -158,7 +147,7 @@ var _ = Describe("Ensurer", func() {
 				Shoot: &gardencorev1beta1.Shoot{
 					Spec: gardencorev1beta1.ShootSpec{
 						Kubernetes: gardencorev1beta1.Kubernetes{
-							Version: "1.22.0",
+							Version: "1.26.0",
 						},
 					},
 				},
@@ -195,14 +184,7 @@ var _ = Describe("Ensurer", func() {
 			}
 		})
 
-		It("should add missing elements to kube-apiserver deployment", func() {
-			err := ensurer.EnsureKubeAPIServerDeployment(ctx, eContextK8s122, dep, nil)
-			Expect(err).To(Not(HaveOccurred()))
-
-			checkKubeAPIServerDeployment(dep, "1.22.0")
-		})
-
-		It("should add missing elements to kube-apiserver deployment (k8s >= 1.26)", func() {
+		It("should add missing elements to kube-apiserver deployment (k8s < 1.27)", func() {
 			err := ensurer.EnsureKubeAPIServerDeployment(ctx, eContextK8s126, dep, nil)
 			Expect(err).To(Not(HaveOccurred()))
 
@@ -238,10 +220,10 @@ var _ = Describe("Ensurer", func() {
 				},
 			}
 
-			err := ensurer.EnsureKubeAPIServerDeployment(ctx, eContextK8s122, dep, nil)
+			err := ensurer.EnsureKubeAPIServerDeployment(ctx, eContextK8s126, dep, nil)
 			Expect(err).To(Not(HaveOccurred()))
 
-			checkKubeAPIServerDeployment(dep, "1.22.0")
+			checkKubeAPIServerDeployment(dep, "1.26.0")
 		})
 	})
 
@@ -265,14 +247,7 @@ var _ = Describe("Ensurer", func() {
 			}
 		})
 
-		It("should add missing elements to kube-controller-manager deployment", func() {
-			err := ensurer.EnsureKubeControllerManagerDeployment(ctx, eContextK8s122, dep, nil)
-			Expect(err).To(Not(HaveOccurred()))
-
-			checkKubeControllerManagerDeployment(dep, "1.22.0")
-		})
-
-		It("should add missing elements to kube-controller-manager deployment (k8s >= 1.26)", func() {
+		It("should add missing elements to kube-controller-manager deployment (k8s < 1.27)", func() {
 			err := ensurer.EnsureKubeControllerManagerDeployment(ctx, eContextK8s126, dep, nil)
 			Expect(err).To(Not(HaveOccurred()))
 
@@ -320,10 +295,10 @@ var _ = Describe("Ensurer", func() {
 				},
 			}
 
-			err := ensurer.EnsureKubeControllerManagerDeployment(ctx, eContextK8s122, dep, nil)
+			err := ensurer.EnsureKubeControllerManagerDeployment(ctx, eContextK8s126, dep, nil)
 			Expect(err).To(Not(HaveOccurred()))
 
-			checkKubeControllerManagerDeployment(dep, "1.22.0")
+			checkKubeControllerManagerDeployment(dep, "1.26.0")
 		})
 	})
 
@@ -352,11 +327,11 @@ var _ = Describe("Ensurer", func() {
 			ensurer = NewEnsurer(logger, false)
 		})
 
-		It("should add missing elements to kube-scheduler deployment", func() {
-			err := ensurer.EnsureKubeSchedulerDeployment(ctx, eContextK8s122, dep, nil)
+		It("should add missing elements to kube-scheduler deployment (k8s < 1.26)", func() {
+			err := ensurer.EnsureKubeSchedulerDeployment(ctx, eContextK8s125, dep, nil)
 			Expect(err).To(Not(HaveOccurred()))
 
-			checkKubeSchedulerDeployment(dep, "1.22.0")
+			checkKubeSchedulerDeployment(dep, "1.25.0")
 		})
 
 		It("should add missing elements to kube-scheduler deployment (k8s = 1.26)", func() {
@@ -399,11 +374,11 @@ var _ = Describe("Ensurer", func() {
 			ensurer = NewEnsurer(logger, false)
 		})
 
-		It("should add missing elements to cluster-autoscaler deployment", func() {
-			err := ensurer.EnsureClusterAutoscalerDeployment(ctx, eContextK8s122, dep, nil)
+		It("should add missing elements to cluster-autoscaler deployment (k8s < 1.26))", func() {
+			err := ensurer.EnsureClusterAutoscalerDeployment(ctx, eContextK8s125, dep, nil)
 			Expect(err).To(Not(HaveOccurred()))
 
-			checkClusterAutoscalerDeployment(dep, "1.22.0")
+			checkClusterAutoscalerDeployment(dep, "1.25.0")
 		})
 
 		It("should add missing elements to cluster-autoscaler deployment (k8s >= 1.26)", func() {
@@ -445,7 +420,7 @@ var _ = Describe("Ensurer", func() {
 		})
 
 		DescribeTable("should modify existing elements of kubelet.service unit options",
-			func(gctx gcontext.GardenContext, kubeletVersion *semver.Version, cloudProvider string, withControllerAttachDetachFlag bool) {
+			func(gctx gcontext.GardenContext, kubeletVersion *semver.Version, cloudProvider string) {
 				newUnitOptions := []*unit.UnitOption{
 					{
 						Section: "Service",
@@ -466,18 +441,12 @@ var _ = Describe("Ensurer", func() {
 					}
 				}
 
-				if withControllerAttachDetachFlag {
-					newUnitOptions[0].Value += ` \
-    --enable-controller-attach-detach=true`
-				}
-
 				opts, err := ensurer.EnsureKubeletServiceUnitOptions(ctx, gctx, kubeletVersion, oldUnitOptions, nil)
 				Expect(err).To(Not(HaveOccurred()))
 				Expect(opts).To(Equal(newUnitOptions))
 			},
 
-			Entry("1.22 <= kubelet version < 1.23", dummyContext, semver.MustParse("1.22.0"), "external", true),
-			Entry("kubelet version >= 1.23", dummyContext, semver.MustParse("1.23.0"), "external", false),
+			Entry("kubelet version >= 1.24", dummyContext, semver.MustParse("1.25.0"), "external"),
 		)
 	})
 
@@ -493,13 +462,13 @@ var _ = Describe("Ensurer", func() {
 		})
 
 		DescribeTable("should modify existing elements of kubelet configuration",
-			func(gctx gcontext.GardenContext, kubeletVersion *semver.Version, featureGates []string, enableControllerAttachDetach *bool) {
+			func(gctx gcontext.GardenContext, kubeletVersion *semver.Version, featureGates []string) {
 				newKubeletConfig := &kubeletconfigv1beta1.KubeletConfiguration{
 					FeatureGates: map[string]bool{
 						"Foo": true,
 					},
 					ResolverConfig:               pointer.String("/etc/resolv-for-kubelet.conf"),
-					EnableControllerAttachDetach: enableControllerAttachDetach,
+					EnableControllerAttachDetach: pointer.Bool(true),
 				}
 
 				for _, featureGate := range featureGates {
@@ -513,10 +482,9 @@ var _ = Describe("Ensurer", func() {
 				Expect(&kubeletConfig).To(Equal(newKubeletConfig))
 			},
 
-			Entry("1.22 <= kubelet < 1.23", eContextK8s122, semver.MustParse("1.22.0"), []string{"CSIMigration", "CSIMigrationOpenStack", "InTreePluginOpenStackUnregister"}, nil),
-			Entry("kubelet >= 1.23", eContextK8s123, semver.MustParse("1.23.0"), []string{"CSIMigration", "CSIMigrationOpenStack", "InTreePluginOpenStackUnregister"}, pointer.Bool(true)),
-			Entry("kubelet >= 1.26", eContextK8s126, semver.MustParse("1.26.0"), []string{"CSIMigration"}, pointer.Bool(true)),
-			Entry("kubelet >= 1.27", eContextK8s127, semver.MustParse("1.27.1"), nil, pointer.Bool(true)),
+			Entry("kubelet < 1.26", eContextK8s125, semver.MustParse("1.25.0"), []string{"CSIMigration", "CSIMigrationOpenStack", "InTreePluginOpenStackUnregister"}),
+			Entry("kubelet >= 1.26", eContextK8s126, semver.MustParse("1.26.0"), []string{"CSIMigration"}),
+			Entry("kubelet >= 1.27", eContextK8s127, semver.MustParse("1.27.1"), nil),
 		)
 	})
 
@@ -550,7 +518,7 @@ WantedBy=multi-user.target
 			ensurer := NewEnsurer(logger, false)
 
 			// Call EnsureAdditionalUnits method and check the result
-			err := ensurer.EnsureAdditionalUnits(ctx, eContextK8s122, &units, nil)
+			err := ensurer.EnsureAdditionalUnits(ctx, eContextK8s126, &units, nil)
 			Expect(err).To(Not(HaveOccurred()))
 			Expect(units).To(ConsistOf(oldUnit, additionalPath, additionalUnit))
 		})
@@ -568,7 +536,7 @@ WantedBy=multi-user.target
 			ensurer := NewEnsurer(logger, false)
 
 			// Call EnsureAdditionalUnits method and check the result
-			err := ensurer.EnsureAdditionalUnits(ctx, eContextK8s122WithResolvConfOptions, &units, nil)
+			err := ensurer.EnsureAdditionalUnits(ctx, eContextK8s126WithResolvConfOptions, &units, nil)
 			Expect(err).To(Not(HaveOccurred()))
 			Expect(units).To(ConsistOf(oldUnit, additionalPath, additionalUnit))
 		})
@@ -601,7 +569,7 @@ WantedBy=multi-user.target
 			ensurer := NewEnsurer(logger, false)
 
 			// Call EnsureAdditionalFiles method and check the result
-			err := ensurer.EnsureAdditionalFiles(ctx, eContextK8s122, &files, nil)
+			err := ensurer.EnsureAdditionalFiles(ctx, eContextK8s126, &files, nil)
 			Expect(err).To(Not(HaveOccurred()))
 			Expect(files).To(ConsistOf(oldFile, additionalFileFunc(`""`)))
 		})
@@ -612,7 +580,7 @@ WantedBy=multi-user.target
 			ensurer := NewEnsurer(logger, false)
 
 			// Call EnsureAdditionalFiles method and check the result
-			err := ensurer.EnsureAdditionalFiles(ctx, eContextK8s122WithResolvConfOptions, &files, nil)
+			err := ensurer.EnsureAdditionalFiles(ctx, eContextK8s126WithResolvConfOptions, &files, nil)
 			Expect(err).To(Not(HaveOccurred()))
 			Expect(files).To(ConsistOf(oldFile, additionalFileFunc(`"options rotate timeout:1"`)))
 		})
@@ -627,7 +595,7 @@ WantedBy=multi-user.target
 			ensurer := NewEnsurer(logger, false)
 
 			// Call EnsureAdditionalFiles method and check the result
-			err := ensurer.EnsureAdditionalFiles(ctx, eContextK8s122WithResolvConfOptions, &files, nil)
+			err := ensurer.EnsureAdditionalFiles(ctx, eContextK8s126WithResolvConfOptions, &files, nil)
 			Expect(err).To(Not(HaveOccurred()))
 			Expect(files).To(ConsistOf(oldFile, additionalFile))
 			Expect(files).To(HaveLen(2))


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind cleanup
/platform openstack

**What this PR does / why we need it**:
Drop support for kubernetes < 1.24 for Openstack extension provider

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/8405

**Special notes for your reviewer**:


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
`provider-openstack` no longer supports Shoots or Seeds with Кubernetes version < 1.24.
```
