### PR TITLE
Use existing subnet in shoot creation

### DIFF
--- a/hack/api-reference/api.md
+++ b/hack/api-reference/api.md
@@ -1363,6 +1363,18 @@ string
 </tr>
 <tr>
 <td>
+<code>subnetId</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>SubnetID is the ID of an existing subnet.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>shareNetwork</code></br>
 <em>
 <a href="#openstack.provider.extensions.gardener.cloud/v1alpha1.ShareNetwork">

--- a/pkg/apis/openstack/types_infrastructure.go
+++ b/pkg/apis/openstack/types_infrastructure.go
@@ -43,6 +43,8 @@ type Networks struct {
 	Workers string
 	// ID is the ID of an existing private network.
 	ID *string
+	// SubnetID is the ID of an existing subnet.
+	SubnetID *string
 	// ShareNetwork holds information about the share network (used for shared file systems like NFS)
 	ShareNetwork *ShareNetwork
 }

--- a/pkg/apis/openstack/v1alpha1/types_infrastructure.go
+++ b/pkg/apis/openstack/v1alpha1/types_infrastructure.go
@@ -47,6 +47,9 @@ type Networks struct {
 	// ID is the ID of an existing private network.
 	// +optional
 	ID *string `json:"id,omitempty"`
+	// SubnetID is the ID of an existing subnet.
+	// +optional
+	SubnetID *string `json:"subnetId,omitempty"`
 	// ShareNetwork holds information about the share network (used for shared file systems like NFS)
 	// +optional
 	ShareNetwork *ShareNetwork `json:"shareNetwork,omitempty"`

--- a/pkg/apis/openstack/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/openstack/v1alpha1/zz_generated.conversion.go
@@ -836,6 +836,7 @@ func autoConvert_v1alpha1_Networks_To_openstack_Networks(in *Networks, out *open
 	out.Worker = in.Worker
 	out.Workers = in.Workers
 	out.ID = (*string)(unsafe.Pointer(in.ID))
+	out.SubnetID = (*string)(unsafe.Pointer(in.SubnetID))
 	out.ShareNetwork = (*openstack.ShareNetwork)(unsafe.Pointer(in.ShareNetwork))
 	return nil
 }
@@ -850,6 +851,7 @@ func autoConvert_openstack_Networks_To_v1alpha1_Networks(in *openstack.Networks,
 	out.Worker = in.Worker
 	out.Workers = in.Workers
 	out.ID = (*string)(unsafe.Pointer(in.ID))
+	out.SubnetID = (*string)(unsafe.Pointer(in.SubnetID))
 	out.ShareNetwork = (*ShareNetwork)(unsafe.Pointer(in.ShareNetwork))
 	return nil
 }

--- a/pkg/apis/openstack/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/openstack/v1alpha1/zz_generated.deepcopy.go
@@ -572,6 +572,11 @@ func (in *Networks) DeepCopyInto(out *Networks) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.SubnetID != nil {
+		in, out := &in.SubnetID, &out.SubnetID
+		*out = new(string)
+		**out = **in
+	}
 	if in.ShareNetwork != nil {
 		in, out := &in.ShareNetwork, &out.ShareNetwork
 		*out = new(ShareNetwork)

--- a/pkg/apis/openstack/zz_generated.deepcopy.go
+++ b/pkg/apis/openstack/zz_generated.deepcopy.go
@@ -572,6 +572,11 @@ func (in *Networks) DeepCopyInto(out *Networks) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.SubnetID != nil {
+		in, out := &in.SubnetID, &out.SubnetID
+		*out = new(string)
+		**out = **in
+	}
 	if in.ShareNetwork != nil {
 		in, out := &in.ShareNetwork, &out.ShareNetwork
 		*out = new(ShareNetwork)

--- a/pkg/internal/infrastructure/terraform.go
+++ b/pkg/internal/infrastructure/terraform.go
@@ -76,6 +76,7 @@ func ComputeTerraformerTemplateValues(
 ) (map[string]interface{}, error) {
 	var (
 		createRouter  = true
+		createSubnet  = true
 		createNetwork = true
 		useCACert     = false
 		routerConfig  = map[string]interface{}{
@@ -136,6 +137,11 @@ func ComputeTerraformerTemplateValues(
 		outputKeysConfig["shareNetworkName"] = TerraformOutputKeyShareNetworkName
 	}
 
+	if config.Networks.SubnetID != nil {
+		createSubnet = false
+		networksConfig["subnet"] = *config.Networks.SubnetID
+	}
+
 	return map[string]interface{}{
 		"openstack": map[string]interface{}{
 			"maxApiCallRetries": MaxApiCallRetries,
@@ -147,6 +153,7 @@ func ComputeTerraformerTemplateValues(
 		},
 		"create": map[string]interface{}{
 			"router":       createRouter,
+			"subnet":       createSubnet,
 			"network":      createNetwork,
 			"shareNetwork": createShareNetwork,
 		},


### PR DESCRIPTION
**How to categorize this PR?**
/area networking
/kind enhancement
/kind api-change
/platform openstack

**What this PR does / why we need it**:
Adds the possibility to specify an already existing openstack subnet in the shoot creation.

Specifying existing networks and routers is already possible.
This PR adds support for the following use-cases:
- already existing network & subnet - router (including interface to subnet) created by extension
- already existing network, subnet & router - router interface to subnet must be manually created

**Release note**:
```feature user
Allow usage of existing subnet in shoot creation
```
