### PR TITLE
add manila labels

### DIFF
--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -293,5 +293,8 @@ func (w *workerDelegate) hasPreserveAnnotation() bool {
 }
 
 func addTopologyLabel(labels map[string]string, zone string) map[string]string {
-	return utils.MergeStringMaps(labels, map[string]string{openstack.CSIDiskDriverTopologyKey: zone})
+	return utils.MergeStringMaps(labels, map[string]string{
+		openstack.CSIDiskDriverTopologyKey:   zone,
+		openstack.CSIManilaDriverTopologyKey: zone,
+	})
 }

--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -464,8 +464,8 @@ var _ = Describe("Machines", func() {
 						machineClassPool2Zone2,
 					}}
 
-					labelsZone1 := map[string]string{openstack.CSIDiskDriverTopologyKey: zone1}
-					labelsZone2 := map[string]string{openstack.CSIDiskDriverTopologyKey: zone2}
+					labelsZone1 := map[string]string{openstack.CSIDiskDriverTopologyKey: zone1, openstack.CSIManilaDriverTopologyKey: zone1}
+					labelsZone2 := map[string]string{openstack.CSIDiskDriverTopologyKey: zone2, openstack.CSIManilaDriverTopologyKey: zone2}
 					machineDeployments = worker.MachineDeployments{
 						{
 							Name:                 machineClassNamePool1Zone1,

--- a/pkg/openstack/types.go
+++ b/pkg/openstack/types.go
@@ -40,6 +40,8 @@ const (
 	// See https://github.com/kubernetes/cloud-provider-openstack/blob/master/examples/cinder-csi-plugin/topology/example.yaml
 	// See https://gitlab.cern.ch/cloud/cloud-provider-openstack/-/blob/release-1.19/docs/using-cinder-csi-plugin.md#enable-topology-aware-dynamic-provisioning-for-cinder-volumes
 	CSIDiskDriverTopologyKey = "topology.cinder.csi.openstack.org/zone"
+	// CSIManilaDriverTopologyKey is the label on persistent volumes that represents availability by zone.
+	CSIManilaDriverTopologyKey = "topology.manila.csi.openstack.org/zone"
 	// CSISnapshotterImageName is the name of the csi-snapshotter image.
 	CSISnapshotterImageName = "csi-snapshotter"
 	// CSIResizerImageName is the name of the csi-resizer image.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement
/platform openstack

**What this PR does / why we need it**:
Allows autoscaling for manila volumes

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Add manila topology labels to machines. This enables scaling from 0 for pods depending on manila volumes.
```
