### PR TITLE
update image definitions

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -58,7 +58,7 @@ images:
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes/cloud-provider-openstack
   repository: registry.k8s.io/provider-os/openstack-cloud-controller-manager
-  tag: "v1.27.1"
+  tag: "v1.27.2"
   targetVersion: ">= 1.27"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
@@ -142,7 +142,7 @@ images:
 - name: csi-driver-cinder
   sourceRepository: github.com/kubernetes/cloud-provider-openstack
   repository: registry.k8s.io/provider-os/cinder-csi-plugin
-  tag: "v1.27.1"
+  tag: "v1.27.2"
   targetVersion: ">= 1.27"
   labels:
     - name: 'gardener.cloud/cve-categorisation'
@@ -185,7 +185,7 @@ images:
 - name: csi-driver-manila
   sourceRepository: github.com/kubernetes/cloud-provider-openstack
   repository: registry.k8s.io/provider-os/manila-csi-plugin
-  tag: "v1.27.1"
+  tag: "v1.27.2"
   targetVersion: ">= 1.27"
   labels:
     - name: 'gardener.cloud/cve-categorisation'
@@ -200,7 +200,7 @@ images:
 - name: csi-driver-nfs
   sourceRepository: github.com/kubernetes-csi/csi-driver-nfs
   repository: registry.k8s.io/sig-storage/nfsplugin
-  tag: "v4.1.0"
+  tag: "v4.4.0"
   labels:
     - name: 'gardener.cloud/cve-categorisation'
       value:
@@ -214,7 +214,7 @@ images:
 - name: csi-provisioner
   sourceRepository: github.com/kubernetes-csi/external-provisioner
   repository: registry.k8s.io/sig-storage/csi-provisioner
-  tag: "v3.4.1"
+  tag: "v3.6.0"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:
@@ -227,7 +227,7 @@ images:
 - name: csi-attacher
   sourceRepository: github.com/kubernetes-csi/external-attacher
   repository: registry.k8s.io/sig-storage/csi-attacher
-  tag: "v4.1.0"
+  tag: "v4.4.0"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:
@@ -240,7 +240,7 @@ images:
 - name: csi-snapshotter
   sourceRepository: github.com/kubernetes-csi/external-snapshotter
   repository: registry.k8s.io/sig-storage/csi-snapshotter
-  tag: "v6.2.1"
+  tag: "v6.3.0"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:
@@ -253,7 +253,7 @@ images:
 - name: csi-snapshot-controller
   sourceRepository: github.com/kubernetes-csi/external-snapshotter
   repository: registry.k8s.io/sig-storage/snapshot-controller
-  tag: "v6.2.1"
+  tag: "v6.3.0"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:
@@ -266,7 +266,7 @@ images:
 - name: csi-snapshot-validation-webhook
   sourceRepository: github.com/kubernetes-csi/external-snapshotter
   repository: registry.k8s.io/sig-storage/snapshot-validation-webhook
-  tag: "v6.2.1"
+  tag: "v6.3.0"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:
@@ -279,7 +279,7 @@ images:
 - name: csi-resizer
   sourceRepository: github.com/kubernetes-csi/external-resizer
   repository: registry.k8s.io/sig-storage/csi-resizer
-  tag: "v1.7.0"
+  tag: "v1.9.0"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:
@@ -292,7 +292,7 @@ images:
 - name: csi-node-driver-registrar
   sourceRepository: github.com/kubernetes-csi/node-driver-registrar
   repository: registry.k8s.io/sig-storage/csi-node-driver-registrar
-  tag: "v2.7.0"
+  tag: "v2.9.0"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:
@@ -305,7 +305,7 @@ images:
 - name: csi-liveness-probe
   sourceRepository: github.com/kubernetes-csi/livenessprobe
   repository: registry.k8s.io/sig-storage/livenessprobe
-  tag: "v2.9.0"
+  tag: "v2.11.0"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement
/platform openstack

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
updated image csi-provisioner -> `v3.6.0`
```
```other operator
updated image csi-attacher -> `v4.4.0`
```
```other operator
updated image csi-resizer -> `v1.9.0`
```
```other operator
updated image snapshot-controller -> `v6.3.0`
```
```other operator
updated image livenessprobe -> `v2.11.0`
```
```other operator
updated image cloud-provider-openstack `v1.27.1`-> `v1.27.2`
```
```other operator
updated image cinder-csi-plugin `v1.27.1`-> `v1.27.2`
```
```other operator
updated image manila-csi-plugin `v1.27.1`-> `v1.27.2`
```
