### PR TITLE
Support for Kubernetes v1.28

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This extension controller supports the following Kubernetes versions:
 
 | Version         | Support     | Conformance test results |
 | --------------- | ----------- | ------------------------ |
+| Kubernetes 1.28 | 1.28.0+     | N/A |
 | Kubernetes 1.27 | 1.27.0+     | [![Gardener v1.27 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.27%20OpenStack/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.27%20OpenStack) |
 | Kubernetes 1.26 | 1.26.0+     | [![Gardener v1.26 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.26%20OpenStack/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.26%20OpenStack) |
 | Kubernetes 1.25 | 1.25.0+     | [![Gardener v1.25 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.25%20OpenStack/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.25%20OpenStack) |

--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -59,7 +59,21 @@ images:
   sourceRepository: github.com/kubernetes/cloud-provider-openstack
   repository: registry.k8s.io/provider-os/openstack-cloud-controller-manager
   tag: "v1.27.2"
-  targetVersion: ">= 1.27"
+  targetVersion: "1.27.x"
+  labels:
+  - name: 'gardener.cloud/cve-categorisation'
+    value:
+      network_exposure: 'protected'
+      authentication_enforced: false
+      user_interaction: 'gardener-operator'
+      confidentiality_requirement: 'high'
+      integrity_requirement: 'high'
+      availability_requirement: 'low'
+- name: cloud-controller-manager
+  sourceRepository: github.com/kubernetes/cloud-provider-openstack
+  repository: registry.k8s.io/provider-os/openstack-cloud-controller-manager
+  tag: "v1.28.0"
+  targetVersion: ">= 1.28"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:
@@ -143,7 +157,21 @@ images:
   sourceRepository: github.com/kubernetes/cloud-provider-openstack
   repository: registry.k8s.io/provider-os/cinder-csi-plugin
   tag: "v1.27.2"
-  targetVersion: ">= 1.27"
+  targetVersion: "1.27.x"
+  labels:
+    - name: 'gardener.cloud/cve-categorisation'
+      value:
+        network_exposure: 'protected'
+        authentication_enforced: false
+        user_interaction: 'end-user'
+        confidentiality_requirement: 'high'
+        integrity_requirement: 'high'
+        availability_requirement: 'low'
+- name: csi-driver-cinder
+  sourceRepository: github.com/kubernetes/cloud-provider-openstack
+  repository: registry.k8s.io/provider-os/cinder-csi-plugin
+  tag: "v1.28.0"
+  targetVersion: ">= 1.28"
   labels:
     - name: 'gardener.cloud/cve-categorisation'
       value:
@@ -186,7 +214,21 @@ images:
   sourceRepository: github.com/kubernetes/cloud-provider-openstack
   repository: registry.k8s.io/provider-os/manila-csi-plugin
   tag: "v1.27.2"
-  targetVersion: ">= 1.27"
+  targetVersion: "1.27.x"
+  labels:
+    - name: 'gardener.cloud/cve-categorisation'
+      value:
+        network_exposure: 'protected'
+        authentication_enforced: false
+        user_interaction: 'end-user'
+        confidentiality_requirement: 'high'
+        integrity_requirement: 'high'
+        availability_requirement: 'low'
+- name: csi-driver-manila
+  sourceRepository: github.com/kubernetes/cloud-provider-openstack
+  repository: registry.k8s.io/provider-os/manila-csi-plugin
+  tag: "v1.28.0"
+  targetVersion: ">= 1.28"
   labels:
     - name: 'gardener.cloud/cve-categorisation'
       value:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source usability
/kind enhancement
/platform openstack
/exp intermediate
/topology garden seed shoot
/merge squash

**What this PR does / why we need it**:
This PR adds support for Kubernetes 1.28 to the extension.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/8291

**Special notes for your reviewer**:
* I have successfully validated the functionality as follows:
  * :white_check_mark: Create new clusters with versions < 1.28
  * :white_check_mark: Create new clusters with version  = 1.28
  * :white_check_mark: Upgrade old clusters from version 1.27 to version 1.28
  * :white_check_mark: Delete clusters with versions < 1.28
  * :white_check_mark: Delete clusters with version  = 1.28

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
The provider-openstack extension does now support shoot clusters with Kubernetes version 1.28. You should consider the [Kubernetes release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.28.md) before upgrading to 1.28. 
```