### PR TITLE
[release-v1.37] Automated cherry pick of #682: Update external-snapshotter to v6.3.1

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -240,7 +240,7 @@ images:
 - name: csi-snapshotter
   sourceRepository: github.com/kubernetes-csi/external-snapshotter
   repository: registry.k8s.io/sig-storage/csi-snapshotter
-  tag: "v6.3.0"
+  tag: "v6.3.1"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:
@@ -253,7 +253,7 @@ images:
 - name: csi-snapshot-controller
   sourceRepository: github.com/kubernetes-csi/external-snapshotter
   repository: registry.k8s.io/sig-storage/snapshot-controller
-  tag: "v6.3.0"
+  tag: "v6.3.1"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:
@@ -266,7 +266,7 @@ images:
 - name: csi-snapshot-validation-webhook
   sourceRepository: github.com/kubernetes-csi/external-snapshotter
   repository: registry.k8s.io/sig-storage/snapshot-validation-webhook
-  tag: "v6.3.0"
+  tag: "v6.3.1"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:


### PR DESCRIPTION
/area storage
/kind bug

Cherry pick of #682 on release-v1.37.

#682: Update external-snapshotter to v6.3.1

**Release Notes:**
```other operator
Update external-snapshotter to v6.3.1
```