### PR TITLE
readiness check

### DIFF
--- a/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/csi-snapshot-validation-webhook-deployment.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/csi-snapshot-validation-webhook-deployment.yaml
@@ -38,6 +38,10 @@ spec:
         resources:
 {{ toYaml .Values.csiSnapshotValidationWebhook.resources | indent 10 }}
 {{- end }}
+        readinessProbe:
+          tcpSocket:
+            port: 443
+          initialDelaySeconds: 5
         volumeMounts:
           - mountPath: /var/run/secrets/gardener.cloud/shoot/generic-kubeconfig
             name: kubeconfig


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement
/platform openstack

**What this PR does / why we need it**:

Adds a healthcheck to the snapshot-validation webhook server. Has the disadvantage that the logs will be spammed with messages like:

```
2023/10/30 18:30:38 http: TLS handshake error from 10.180.0.17:53028: EOF
```
This is to prevent issues like those introduced with external-snapshoter v6.3.0 where the server never started successfully and the bug took too long to detect.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Add tcp healthcheck to csi-snapshot-validation-webhook
```
