### PR TITLE
use nfs v4.1 by default

### DIFF
--- a/charts/internal/shoot-system-components/charts/csi-driver-manila/templates/storageclass.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-manila/templates/storageclass.yaml
@@ -8,6 +8,8 @@ metadata:
 provisioner: nfs.manila.csi.openstack.org
 allowVolumeExpansion: true
 volumeBindingMode: WaitForFirstConsumer
+mountOptions:
+{{ toYaml $.Values.csimanila.mountOptions | indent 2 }}
 parameters:
   type: default
   shareNetworkID: {{ $.Values.openstack.shareNetworkID }}
@@ -32,6 +34,8 @@ metadata:
 provisioner: nfs.manila.csi.openstack.org
 allowVolumeExpansion: true
 volumeBindingMode: WaitForFirstConsumer
+mountOptions:
+{{ toYaml $.Values.csimanila.mountOptions | indent 2 }}
 parameters:
   type: default
   availability: {{ required "openstack.availabilityZones needs to be set" . }}
@@ -58,6 +62,8 @@ metadata:
 provisioner: nfs.manila.csi.openstack.org
 allowVolumeExpansion: true
 volumeBindingMode: WaitForFirstConsumer
+mountOptions:
+{{ toYaml $.Values.csimanila.mountOptions | indent 2 }}
 allowedTopologies:
 - matchLabelExpressions:
   - key: topology.manila.csi.openstack.org/zone

--- a/charts/internal/shoot-system-components/charts/csi-driver-manila/values.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-manila/values.yaml
@@ -86,3 +86,8 @@ csimanila:
   # You may set ID of the cluster where manila-csi is deployed. This value will be appended
   # to share metadata in newly provisioned shares as `manila.csi.openstack.org/cluster=<cluster ID>`.
   clusterID: ""
+
+  # mountOptions are additional mount options to be used for the storage classes.
+  mountOptions:
+  - nfsvers=4.1
+


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement
/platform openstack

**What this PR does / why we need it**:

Use nfs v4.1 by default on manila mounts. This is due to the lack of proper support by netapp for v4.2. In subsequent PRs we plan to integrate the manila storage classes better with the `storageClassDefinitions` in the cloudprofile. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Use NFS version v4.1 as mount options for manila storage classes
```
