### PR TITLE
Add Manila autoTopology storage class

### DIFF
--- a/charts/internal/shoot-system-components/charts/csi-driver-manila/templates/storageclass.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-manila/templates/storageclass.yaml
@@ -23,7 +23,35 @@ parameters:
   csi.storage.k8s.io/controller-expand-secret-name: manila-csi-plugin
   csi.storage.k8s.io/controller-expand-secret-namespace: {{ $.Release.Namespace }}
 
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  annotations:
+    resources.gardener.cloud/delete-on-invalid-update: "true"
+  name: csi-manila-nfs-auto
+provisioner: nfs.manila.csi.openstack.org
+allowVolumeExpansion: true
+volumeBindingMode: WaitForFirstConsumer
+{{- if .Values.csimanila.mountOptions }}
+mountOptions:
+{{ toYaml $.Values.csimanila.mountOptions | indent 2 }}
+{{- end }}
+parameters:
+  type: default
+  autoTopology: "true"
+  shareNetworkID: {{ $.Values.openstack.shareNetworkID }}
+  nfs-shareClient: {{ required "openstack.shareClient needs to be set" $.Values.openstack.shareClient }}
+  csi.storage.k8s.io/provisioner-secret-name: manila-csi-plugin
+  csi.storage.k8s.io/provisioner-secret-namespace: {{ $.Release.Namespace }}
+  csi.storage.k8s.io/node-stage-secret-name: manila-csi-plugin
+  csi.storage.k8s.io/node-stage-secret-namespace: {{ $.Release.Namespace }}
+  csi.storage.k8s.io/node-publish-secret-name: manila-csi-plugin
+  csi.storage.k8s.io/node-publish-secret-namespace: {{ $.Release.Namespace }}
+  csi.storage.k8s.io/controller-expand-secret-name: manila-csi-plugin
+  csi.storage.k8s.io/controller-expand-secret-namespace: {{ $.Release.Namespace }}
 {{- range .Values.openstack.availabilityZones }}
+
 ---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass

--- a/charts/internal/shoot-system-components/charts/csi-driver-manila/templates/storageclass.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-manila/templates/storageclass.yaml
@@ -8,8 +8,10 @@ metadata:
 provisioner: nfs.manila.csi.openstack.org
 allowVolumeExpansion: true
 volumeBindingMode: WaitForFirstConsumer
+{{- if $.Values.csimanila.mountOptions }}
 mountOptions:
 {{ toYaml $.Values.csimanila.mountOptions | indent 2 }}
+{{- end }}
 parameters:
   type: default
   shareNetworkID: {{ $.Values.openstack.shareNetworkID }}
@@ -33,7 +35,7 @@ metadata:
 provisioner: nfs.manila.csi.openstack.org
 allowVolumeExpansion: true
 volumeBindingMode: WaitForFirstConsumer
-{{- if .Values.csimanila.mountOptions }}
+{{- if $.Values.csimanila.mountOptions }}
 mountOptions:
 {{ toYaml $.Values.csimanila.mountOptions | indent 2 }}
 {{- end }}
@@ -50,8 +52,8 @@ parameters:
   csi.storage.k8s.io/node-publish-secret-namespace: {{ $.Release.Namespace }}
   csi.storage.k8s.io/controller-expand-secret-name: manila-csi-plugin
   csi.storage.k8s.io/controller-expand-secret-namespace: {{ $.Release.Namespace }}
-{{- range .Values.openstack.availabilityZones }}
 
+{{- range .Values.openstack.availabilityZones }}
 ---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
@@ -62,8 +64,10 @@ metadata:
 provisioner: nfs.manila.csi.openstack.org
 allowVolumeExpansion: true
 volumeBindingMode: WaitForFirstConsumer
+{{- if $.Values.csimanila.mountOptions }}
 mountOptions:
 {{ toYaml $.Values.csimanila.mountOptions | indent 2 }}
+{{- end }}
 parameters:
   type: default
   availability: {{ required "openstack.availabilityZones needs to be set" . }}
@@ -90,8 +94,10 @@ metadata:
 provisioner: nfs.manila.csi.openstack.org
 allowVolumeExpansion: true
 volumeBindingMode: WaitForFirstConsumer
+{{- if $.Values.csimanila.mountOptions }}
 mountOptions:
 {{ toYaml $.Values.csimanila.mountOptions | indent 2 }}
+{{- end }}
 allowedTopologies:
 - matchLabelExpressions:
   - key: topology.manila.csi.openstack.org/zone


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement
/platform openstack

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Add manila auto-topology storage class
```
```breaking user
The zonal manila storage classes are now deprecated and will be removed in a future version.
```