### PR TITLE
[release-v1.38] Automated cherry pick of #692: [ci:component:github.com/gardener/machine-controller-manager-provider-openstack:v0.15.0->v0.15.1]

### DIFF
--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -100,7 +100,7 @@ images:
 - name: machine-controller-manager-provider-openstack
   sourceRepository: github.com/gardener/machine-controller-manager-provider-openstack
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager-provider-openstack
-  tag: "v0.15.0"
+  tag: "v0.15.1"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:


### PR DESCRIPTION
/kind bug

Cherry pick of #692 on release-v1.38.

#692: [ci:component:github.com/gardener/machine-controller-manager-provider-openstack:v0.15.0->v0.15.1]

**Release Notes:**
```other operator github.com/gardener/machine-controller-manager #866 @himanshu-kun
The default `machine-safety-orphan-vms-period` has been reduced from 30m to 15m.
```
```bugfix operator github.com/gardener/machine-controller-manager #866 @himanshu-kun
Removes `node.machine.sapcloud.io/not-managed-by-mcm` annotation from nodes managed by the MCM.
```