### PR TITLE
[release-v1.38] Fix panic, when overlay config is empty in old shoot.

### DIFF
--- a/pkg/admission/mutator/shoot.go
+++ b/pkg/admission/mutator/shoot.go
@@ -120,7 +120,10 @@ func (s *shoot) Mutate(_ context.Context, newObj, oldObj client.Object) error {
 			}
 		}
 
-		overlayConfig, _ = networkConfig["overlay"].(map[string]interface{})
+		if currentOverlayConfig, ok := networkConfig["overlay"].(map[string]interface{}); ok {
+			overlayConfig = currentOverlayConfig
+		}
+
 		if !overlayConfig["enabled"].(bool) && overlayConfig[createPodRoutesKey] == nil {
 			overlayConfig[createPodRoutesKey] = true
 			networkConfig[overlayKey] = overlayConfig


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug
/platform openstack

**What this PR does / why we need it**:
Cherry pick from https://github.com/gardener/gardener-extension-provider-openstack/pull/694
Fix a crash, when a shoot that is updated has an empty overlay config. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fix a crash, when a shoot that is updated has an empty overlay config. 
```