### PR TITLE
Update image definitions

### DIFF
--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -58,7 +58,7 @@ images:
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes/cloud-provider-openstack
   repository: registry.k8s.io/provider-os/openstack-cloud-controller-manager
-  tag: "v1.28.1"
+  tag: "v1.28.2"
   targetVersion: "1.28.x"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
@@ -143,7 +143,7 @@ images:
 - name: csi-driver-cinder
   sourceRepository: github.com/kubernetes/cloud-provider-openstack
   repository: registry.k8s.io/provider-os/cinder-csi-plugin
-  tag: "v1.28.1"
+  tag: "v1.28.2"
   targetVersion: "1.28.x"
   labels:
     - name: 'gardener.cloud/cve-categorisation'
@@ -214,7 +214,7 @@ images:
 - name: csi-driver-manila
   sourceRepository: github.com/kubernetes/cloud-provider-openstack
   repository: registry.k8s.io/provider-os/manila-csi-plugin
-  tag: "v1.28.1"
+  tag: "v1.28.2"
   targetVersion: "1.28.x"
   labels:
     - name: 'gardener.cloud/cve-categorisation'
@@ -257,7 +257,7 @@ images:
 - name: csi-provisioner
   sourceRepository: github.com/kubernetes-csi/external-provisioner
   repository: registry.k8s.io/sig-storage/csi-provisioner
-  tag: "v3.6.1"
+  tag: "v4.0.0"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:
@@ -270,7 +270,7 @@ images:
 - name: csi-attacher
   sourceRepository: github.com/kubernetes-csi/external-attacher
   repository: registry.k8s.io/sig-storage/csi-attacher
-  tag: "v4.4.1"
+  tag: "v4.5.0"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:
@@ -283,7 +283,7 @@ images:
 - name: csi-snapshotter
   sourceRepository: github.com/kubernetes-csi/external-snapshotter
   repository: registry.k8s.io/sig-storage/csi-snapshotter
-  tag: "v6.3.1"
+  tag: "v7.0.1"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:
@@ -296,7 +296,7 @@ images:
 - name: csi-snapshot-controller
   sourceRepository: github.com/kubernetes-csi/external-snapshotter
   repository: registry.k8s.io/sig-storage/snapshot-controller
-  tag: "v6.3.1"
+  tag: "v7.0.1"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:
@@ -309,7 +309,7 @@ images:
 - name: csi-snapshot-validation-webhook
   sourceRepository: github.com/kubernetes-csi/external-snapshotter
   repository: registry.k8s.io/sig-storage/snapshot-validation-webhook
-  tag: "v6.3.1"
+  tag: "v7.0.1"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:
@@ -322,7 +322,7 @@ images:
 - name: csi-resizer
   sourceRepository: github.com/kubernetes-csi/external-resizer
   repository: registry.k8s.io/sig-storage/csi-resizer
-  tag: "v1.9.1"
+  tag: "v1.10.0"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:
@@ -335,7 +335,7 @@ images:
 - name: csi-node-driver-registrar
   sourceRepository: github.com/kubernetes-csi/node-driver-registrar
   repository: registry.k8s.io/sig-storage/csi-node-driver-registrar
-  tag: "v2.9.0"
+  tag: "v2.10.0"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:
@@ -348,7 +348,7 @@ images:
 - name: csi-liveness-probe
   sourceRepository: github.com/kubernetes-csi/livenessprobe
   repository: registry.k8s.io/sig-storage/livenessprobe
-  tag: "v2.11.0"
+  tag: "v2.12.0"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:


### PR DESCRIPTION
**How to categorize this PR?**

/area control-plane
/kind enhancement
/platform openstack

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```dependency operator
updated image cloud-controller-manager -> `v1.28.2`
```
```dependency operator
updated image csi-driver-cinder -> `v1.28.2`
```
```dependency operator
updated image csi-driver-manila -> `v1.28.2`
```
```dependency operator
updated image csi-provisioner -> `v4.0.0`
```
```dependency operator
updated image csi-attacher -> `v4.5.0`
```
```dependency operator
updated image csi-snapshotter -> `v7.0.1`
```
```dependency operator
updated image csi-snapshot-controller -> `v7.0.1`
```
```dependency operator
updated image csi-snapshot-validation-webhook -> `v7.0.1`
```
```dependency operator
updated image csi-resizer -> `v1.10.0`
```
```dependency operator
updated image csi-node-driver-registrar -> `v2.10.0`
```
```dependency operator
updated image csi-liveness-probe -> `v2.12.0`
```
