### PR TITLE
Set lb-method="SOURCE_IP_PORT" when using "ovn" loadbalancer provider

### DIFF
--- a/charts/internal/cloud-provider-config/templates/cloud-provider-config-loadbalancer.tpl
+++ b/charts/internal/cloud-provider-config/templates/cloud-provider-config-loadbalancer.tpl
@@ -6,6 +6,9 @@ monitor-timeout="{{ .Values.monitorTimeout }}"
 monitor-max-retries={{ .Values.monitorMaxRetries }}
 lb-version="v2"
 lb-provider="{{ .Values.lbProvider }}"
+{{- if eq .Values.lbProvider "ovn" }}
+lb-method="SOURCE_IP_PORT"
+{{- end }}
 floating-network-id="{{ .Values.floatingNetworkID }}"
 use-octavia="{{ .Values.useOctavia }}"
 {{- if .Values.floatingSubnetID }}


### PR DESCRIPTION
/area networking
/kind enhancement
/platform openstack

**What this PR does / why we need it**:
The extension doesn't allow setting a loadbalancer's lb-method attribute. The default for lb-method is `ROUND_ROBIN`, but the ovn loadbalancer provider only supports `SOURCE_IP_PORT`. This renders ovn unusable. Since `SOURCE_IP_PORT` is to be used when and only when the provider is ovn, and ovn doesn't work without it, it seems reasonable to just hard-code the value.

> `lb-method` The load balancing algorithm used to create the load balancer pool. [...] If lb-provider is set to "ovn" the value must be set to SOURCE_IP_PORT.
(https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md#load-balancer)

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
