### PR TITLE
add operatingsystem label

### DIFF
--- a/charts/internal/machineclass/templates/machineclass.yaml
+++ b/charts/internal/machineclass/templates/machineclass.yaml
@@ -18,10 +18,13 @@ kind: MachineClass
 metadata:
   name: {{ $machineClass.name }}
   namespace: {{ $.Release.Namespace }}
-{{- if $machineClass.labels }}
   labels:
-  {{ toYaml $machineClass.labels | indent 4 }}
-{{- end }}
+    {{- if $machineClass.labels }}
+{{ toYaml $machineClass.labels | indent 4 }}
+    {{- end }}
+    {{- if $machineClass.operatingSystem }}
+{{ toYaml $machineClass.operatingSystem | indent 4 }}
+    {{- end }}
 provider: "OpenStack"
 {{- if $machineClass.nodeTemplate }}
 nodeTemplate:

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -223,6 +223,13 @@ func (w *workerDelegate) generateMachineConfig() error {
 				v1beta1constants.GardenerPurpose: v1beta1constants.GardenPurposeMachineClass,
 			}
 
+			if pool.MachineImage.Name != "" && pool.MachineImage.Version != "" {
+				machineClassSpec["operatingSystem"] = map[string]interface{}{
+					"operatingSystemName":    pool.MachineImage.Name,
+					"operatingSystemVersion": pool.MachineImage.Version,
+				}
+			}
+
 			machineClasses = append(machineClasses, machineClassSpec)
 		}
 	}

--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -387,6 +387,10 @@ var _ = Describe("Machines", func() {
 						"secret": map[string]interface{}{
 							"cloudConfig": string(userData),
 						},
+						"operatingSystem": map[string]interface{}{
+							"operatingSystemName":    machineImageName,
+							"operatingSystemVersion": machineImageVersion,
+						},
 					}
 					if imageID == "" {
 						defaultMachineClass["imageName"] = name


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind enhancement
/platform openstack

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
https://github.com/gardener/machine-controller-manager/issues/880 

**Special notes for your reviewer**:
add os information as labels in machine class objects

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
add os information as labels in machine class objects.
```
