### PR TITLE
allow bastion to work with ids

### DIFF
--- a/pkg/openstack/client/compute.go
+++ b/pkg/openstack/client/compute.go
@@ -142,6 +142,12 @@ func (c *ComputeClient) ListImages(listOpts images.ListOpts) ([]images.Image, er
 	return images.ExtractImages(allPages)
 }
 
+// FindImageByID returns the image with the given ID. It returns nil if the image is not found.
+func (c *ComputeClient) FindImageByID(id string) (*images.Image, error) {
+	image, err := images.Get(c.client, id).Extract()
+	return image, IgnoreNotFoundError(err)
+}
+
 // CreateKeyPair creates an SSH key pair
 func (c *ComputeClient) CreateKeyPair(name, publicKey string) (*keypairs.KeyPair, error) {
 	opts := keypairs.CreateOpts{

--- a/pkg/openstack/client/mocks/client_mocks.go
+++ b/pkg/openstack/client/mocks/client_mocks.go
@@ -356,6 +356,21 @@ func (mr *MockComputeMockRecorder) FindFloatingIDByInstanceID(arg0 interface{}) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindFloatingIDByInstanceID", reflect.TypeOf((*MockCompute)(nil).FindFloatingIDByInstanceID), arg0)
 }
 
+// FindImageByID mocks base method.
+func (m *MockCompute) FindImageByID(arg0 string) (*images.Image, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindImageByID", arg0)
+	ret0, _ := ret[0].(*images.Image)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindImageByID indicates an expected call of FindImageByID.
+func (mr *MockComputeMockRecorder) FindImageByID(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindImageByID", reflect.TypeOf((*MockCompute)(nil).FindImageByID), arg0)
+}
+
 // FindImages mocks base method.
 func (m *MockCompute) FindImages(arg0 string) ([]images.Image, error) {
 	m.ctrl.T.Helper()

--- a/pkg/openstack/client/types.go
+++ b/pkg/openstack/client/types.go
@@ -98,6 +98,7 @@ type Compute interface {
 
 	FindFlavorID(name string) (string, error)
 	FindImages(name string) ([]images.Image, error)
+	FindImageByID(name string) (*images.Image, error)
 	ListImages(listOpts images.ListOpts) ([]images.Image, error)
 
 	// KeyPairs


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement
/platform openstack

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Allows bastion to use images by ID instead of just by name.
```
