### PR TITLE
Set responsible label in component descriptor

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -5,6 +5,12 @@ gardener-extension-provider-openstack:
         preprocess: 'inject-commit-hash'
       component_descriptor:
         ocm_repository: europe-docker.pkg.dev/gardener-project/snapshots
+        component_labels:
+        - name: 'cloud.gardener.cnudie/responsibles'
+          value:
+          - type: 'githubTeam'
+            teamname: 'gardener/gardener-extension-provider-openstack-maintainers'
+            github_hostname: 'github.com'
       publish:
         oci-builder: 'docker-buildx'
         dockerimages:
@@ -13,12 +19,6 @@ gardener-extension-provider-openstack:
             dockerfile: 'Dockerfile'
             target: gardener-extension-provider-openstack
             resource_labels:
-            - name: 'cloud.gardener.cnudie/responsibles'
-              value:
-              - type: 'githubUser'
-                username: 'dkistner'
-              - type: 'githubUser'
-                username: 'kon-angelo'
             - name: 'gardener.cloud/cve-categorisation'
               value:
                 network_exposure: 'protected'
@@ -32,12 +32,6 @@ gardener-extension-provider-openstack:
             dockerfile: 'Dockerfile'
             target: gardener-extension-admission-openstack
             resource_labels:
-            - name: 'cloud.gardener.cnudie/responsibles'
-              value:
-              - type: 'githubUser'
-                username: 'dkistner'
-              - type: 'githubUser'
-                username: 'kon-angelo'
             - name: 'gardener.cloud/cve-categorisation'
               value:
                 network_exposure: 'protected'


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds component-responsible label to the component descriptor. This way, the responsibles will also be recognized for findings on images that are referenced, not only for those that are built.
Also, simplify by referring to the maintainer team.