### PR TITLE
Add cluster-autoscaler options to machine deployment

### DIFF
--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -17,6 +17,7 @@ import (
 	genericworkeractuator "github.com/gardener/gardener/extensions/pkg/controller/worker/genericactuator"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	extensionsv1alpha1helper "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1/helper"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/utils"
 	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
@@ -205,17 +206,18 @@ func (w *workerDelegate) generateMachineConfig() error {
 			)
 
 			machineDeployments = append(machineDeployments, worker.MachineDeployment{
-				Name:                 deploymentName,
-				ClassName:            className,
-				SecretName:           className,
-				Minimum:              worker.DistributeOverZones(zoneIdx, pool.Minimum, zoneLen),
-				Maximum:              worker.DistributeOverZones(zoneIdx, pool.Maximum, zoneLen),
-				MaxSurge:             worker.DistributePositiveIntOrPercent(zoneIdx, pool.MaxSurge, zoneLen, pool.Maximum),
-				MaxUnavailable:       worker.DistributePositiveIntOrPercent(zoneIdx, pool.MaxUnavailable, zoneLen, pool.Minimum),
-				Labels:               addTopologyLabel(pool.Labels, zone),
-				Annotations:          pool.Annotations,
-				Taints:               pool.Taints,
-				MachineConfiguration: genericworkeractuator.ReadMachineConfiguration(pool),
+				Name:                         deploymentName,
+				ClassName:                    className,
+				SecretName:                   className,
+				Minimum:                      worker.DistributeOverZones(zoneIdx, pool.Minimum, zoneLen),
+				Maximum:                      worker.DistributeOverZones(zoneIdx, pool.Maximum, zoneLen),
+				MaxSurge:                     worker.DistributePositiveIntOrPercent(zoneIdx, pool.MaxSurge, zoneLen, pool.Maximum),
+				MaxUnavailable:               worker.DistributePositiveIntOrPercent(zoneIdx, pool.MaxUnavailable, zoneLen, pool.Minimum),
+				Labels:                       addTopologyLabel(pool.Labels, zone),
+				Annotations:                  pool.Annotations,
+				Taints:                       pool.Taints,
+				MachineConfiguration:         genericworkeractuator.ReadMachineConfiguration(pool),
+				ClusterAutoscalerAnnotations: extensionsv1alpha1helper.GetMachineDeploymentClusterAutoscalerAnnotations(pool.ClusterAutoscaler),
 			})
 
 			machineClassSpec["name"] = className


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind enhancement
/platform openstack

**What this PR does / why we need it**:
This PR adds cluster-autoscaler options for worker groups from workers to machine deployments. These options allow users to specify some cluster-autoscaler specific for worker groups

**Which issue(s) this PR fixes**:
Fixes partially gardener/autoscaler#240

**Special notes for your reviewer**:
- `Autoscaler` will read these values from annotations in the `machineDeployment` (ref: https://github.com/gardener/autoscaler/pull/257)
- These values are specified in the shoot via `spec.provider.workers.clusterAutoscaler` and are added to the worker (ref: https://github.com/gardener/gardener/pull/9245)

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NodeGroupAutoscalingOptions can now be specified per worker group via the worker through the field `worker.spec.pools.clusterAutoscaler`
```
