### PR TITLE
Fix bastion userData

### DIFF
--- a/.ci/testruns/default/templates/testrun.yaml
+++ b/.ci/testruns/default/templates/testrun.yaml
@@ -81,4 +81,4 @@ spec:
             value: g_c2_m4
           - name: IMAGE_REF
             type: env
-            value: gardenlinux-1312.3
+            value: gardenlinux-1443.3

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ DOMAIN_NAME        := .kube-secrets/openstack/domain_name.secret
 FLOATING_POOL_NAME := .kube-secrets/openstack/floating_pool_name.secret
 TENANT_NAME        := .kube-secrets/openstack/tenant_name.secret
 # for bastion test
-IMAGE_REF          := gardenlinux-318.9
+IMAGE_REF          := gardenlinux-1443.3
 FLAVOR_REF         := g_c2_m4
 # either authenticate with username/password credentials
 USER_NAME          := .kube-secrets/openstack/user_name.secret

--- a/test/integration/bastion/bastion_test.go
+++ b/test/integration/bastion/bastion_test.go
@@ -63,7 +63,8 @@ var (
 	flavorRef        = flag.String("flavor-ref", "", "Operating System flavour reference for openstack")
 	imageRef         = flag.String("image-ref", "", "Image reference for openstack")
 
-	userDataConst = "IyEvYmluL2Jhc2ggLWV1CmlkIGdhcmRlbmVyIHx8IHVzZXJhZGQgZ2FyZGVuZXIgLW1VCm1rZGlyIC1wIC9ob21lL2dhcmRlbmVyLy5zc2gKZWNobyAic3NoLXJzYSBBQUFBQjNOemFDMXljMkVBQUFBREFRQUJBQUFCQVFDazYyeDZrN2orc0lkWG9TN25ITzRrRmM3R0wzU0E2UmtMNEt4VmE5MUQ5RmxhcmtoRzFpeU85WGNNQzZqYnh4SzN3aWt0M3kwVTBkR2h0cFl6Vjh3YmV3Z3RLMWJBWnl1QXJMaUhqbnJnTFVTRDBQazNvWGh6RkpKN0MvRkxNY0tJZFN5bG4vMENKVkVscENIZlU5Y3dqQlVUeHdVQ2pnVXRSYjdZWHN6N1Y5dllIVkdJKzRLaURCd3JzOWtVaTc3QWMyRHQ1UzBJcit5dGN4b0p0bU5tMWgxTjNnNzdlbU8rWXhtWEo4MzFXOThoVFVTeFljTjNXRkhZejR5MWhrRDB2WHE1R1ZXUUtUQ3NzRE1wcnJtN0FjQTBCcVRsQ0xWdWl3dXVmTEJLWGhuRHZRUEQrQ2Jhbk03bUZXRXdLV0xXelZHME45Z1VVMXE1T3hhMzhvODUgbWVAbWFjIiA+IC9ob21lL2dhcmRlbmVyLy5zc2gvYXV0aG9yaXplZF9rZXlzCmNob3duIGdhcmRlbmVyOmdhcmRlbmVyIC9ob21lL2dhcmRlbmVyLy5zc2gvYXV0aG9yaXplZF9rZXlzCmVjaG8gImdhcmRlbmVyIEFMTD0oQUxMKSBOT1BBU1NXRDpBTEwiID4vZXRjL3N1ZG9lcnMuZC85OS1nYXJkZW5lci11c2VyCg=="
+	userDataConst = "#!/bin/bash \n" +
+		"systemctl start ssh"
 )
 
 func validateFlags() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug
/platform openstack

**What this PR does / why we need it**:
To support newer GardenLinux versions in our bastion test we need to enable ssh via userData

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
The reason for the userData being b64 encoded is that the [format type of the field is byte](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#:~:text=%27string%27%20with%20format%3Dbyte%20(base64%20encoded)). 
So we actually have to define them in plaintext.
The same has to be done for the bastion tests of the other providers.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other bugfix
Fix userData of bastion test
```
