### PR TITLE
Fix indentation in CCM ServiceMonitor

### DIFF
--- a/charts/internal/seed-controlplane/charts/cloud-controller-manager/templates/servicemonitor.yaml
+++ b/charts/internal/seed-controlplane/charts/cloud-controller-manager/templates/servicemonitor.yaml
@@ -21,12 +21,12 @@ spec:
       - __name__
       action: keep
       regex: ^(rest_client_requests_total|process_max_fds|process_open_fds)$
-  honorLabels: false
-  authorization:
-    credentials:
-      name: shoot-access-prometheus-shoot
-      key: token
-  scheme: https
-  tlsConfig:
-    insecureSkipVerify: true
+    honorLabels: false
+    authorization:
+      credentials:
+        name: shoot-access-prometheus-shoot
+        key: token
+    scheme: https
+    tlsConfig:
+      insecureSkipVerify: true
 {{- end }}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind bug
/platform openstack

**What this PR does / why we need it**:
The `honorLabels`, `authorization`, `scheme`, and `tlsConfig` fields are part of the Endpoint API, not the Spec. This indentation error caused the prometheus-operator to generate a scrape job configuration that specified http instead of https (because the scheme field was "missing". This in turn caused CCM-down alerts to fire because the scrape failed with a 400 error.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
FYI: I haven't tested this in the extension setup yet.
/cc @istvanballok @hendrikKahl
FYI @rfranzke

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fixes a monitoring configuration issue that caused false CCM-down alerts to fire.
```
