### PR TITLE
rm failing preStop hook

### DIFF
--- a/charts/internal/shoot-system-components/charts/csi-driver-node/templates/daemonset.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/templates/daemonset.yaml
@@ -96,13 +96,6 @@ spec:
         - --csi-address=$(ADDRESS)
         - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
         - --v=5
-        lifecycle:
-          preStop:
-            exec:
-              command:
-              - /bin/sh
-              - -c
-              - "rm -rf /registration/{{ include "csi-driver-node.provisioner" . }}-reg.sock {{ .Values.socketPath }}"
         env:
         - name: ADDRESS
           value: {{ .Values.socketPath }}


### PR DESCRIPTION
**How to categorize this PR?**
/area storage
/kind bug
/platform openstack

**What this PR does / why we need it**:
This PR removes the failing `preStop` lifecycle hook from the `node-driver-registrar` container in `csi-driver-node` daemonset.yaml. The distroless registrar image lacks `/bin/sh`, causing the hook to fail. Socket removal is now handled internally by the registrar, eliminating the need for the hook (see kubernetes-csi/node-driver-registrar#61).

**Special notes for your reviewer**:
This is https://github.com/gardener/gardener-extension-provider-gcp/pull/792 for Openstack

**Release note**:
```bugfix operator
Removed unnecessary preStop hook from `node-driver-registrar` in `csi-driver-node`, as socket removal is now handled internally by `node-driver-registrar`, resolving distroless image error.
```
