### PR TITLE
Inserts Architecture from worker to machineclass 

### DIFF
--- a/charts/internal/machineclass/templates/machineclass.yaml
+++ b/charts/internal/machineclass/templates/machineclass.yaml
@@ -28,6 +28,7 @@ metadata:
 provider: "OpenStack"
 {{- if $machineClass.nodeTemplate }}
 nodeTemplate:
+  architecture: { { $machineClass.nodeTemplate.architecture } }
   capacity:
 {{ toYaml $machineClass.nodeTemplate.capacity | indent 4 }}
   instanceType: {{ $machineClass.nodeTemplate.instanceType }}

--- a/charts/internal/machineclass/templates/machineclass.yaml
+++ b/charts/internal/machineclass/templates/machineclass.yaml
@@ -28,7 +28,7 @@ metadata:
 provider: "OpenStack"
 {{- if $machineClass.nodeTemplate }}
 nodeTemplate:
-  architecture: { { $machineClass.nodeTemplate.architecture } }
+  architecture: {{ $machineClass.nodeTemplate.architecture }}
   capacity:
 {{ toYaml $machineClass.nodeTemplate.capacity | indent 4 }}
   instanceType: {{ $machineClass.nodeTemplate.instanceType }}

--- a/charts/internal/machineclass/values.yaml
+++ b/charts/internal/machineclass/values.yaml
@@ -6,6 +6,7 @@ machineClasses:
   availabilityZone: europe-1a
   machineType: medium_2_4
   nodeTemplate:
+    architecture: amd64
     capacity:
       cpu: 2
       gpu: 1

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -195,6 +195,7 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 					InstanceType: pool.MachineType,
 					Region:       w.worker.Spec.Region,
 					Zone:         zone,
+					Architecture: ptr.To(architecture),
 				}
 			} else if pool.NodeTemplate != nil {
 				machineClassSpec["nodeTemplate"] = machinev1alpha1.NodeTemplate{
@@ -202,6 +203,7 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 					InstanceType: pool.MachineType,
 					Region:       w.worker.Spec.Region,
 					Zone:         zone,
+					Architecture: ptr.To(architecture),
 				}
 			}
 

--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -107,6 +107,9 @@ var _ = Describe("Machines", func() {
 				machineImage        string
 				machineImageID      string
 
+				archAMD string
+				archARM string
+
 				keyName               string
 				machineType           string
 				userData              []byte
@@ -132,10 +135,12 @@ var _ = Describe("Machines", func() {
 				zone1 string
 				zone2 string
 
-				nodeCapacity         corev1.ResourceList
-				nodeTemplateZone1    machinev1alpha1.NodeTemplate
-				nodeTemplateZone2    machinev1alpha1.NodeTemplate
-				machineConfiguration *machinev1alpha1.MachineConfiguration
+				nodeCapacity           corev1.ResourceList
+				nodeTemplatePool1Zone1 machinev1alpha1.NodeTemplate
+				nodeTemplatePool1Zone2 machinev1alpha1.NodeTemplate
+				nodeTemplatePool2Zone1 machinev1alpha1.NodeTemplate
+				nodeTemplatePool2Zone2 machinev1alpha1.NodeTemplate
+				machineConfiguration   *machinev1alpha1.MachineConfiguration
 
 				workerPoolHash1 string
 				workerPoolHash2 string
@@ -193,18 +198,36 @@ var _ = Describe("Machines", func() {
 					"gpu":    resource.MustParse("1"),
 					"memory": resource.MustParse("128Gi"),
 				}
-				nodeTemplateZone1 = machinev1alpha1.NodeTemplate{
+				nodeTemplatePool1Zone1 = machinev1alpha1.NodeTemplate{
 					Capacity:     nodeCapacity,
 					InstanceType: machineType,
 					Region:       region,
 					Zone:         zone1,
+					Architecture: ptr.To(archAMD),
 				}
 
-				nodeTemplateZone2 = machinev1alpha1.NodeTemplate{
+				nodeTemplatePool1Zone2 = machinev1alpha1.NodeTemplate{
 					Capacity:     nodeCapacity,
 					InstanceType: machineType,
 					Region:       region,
 					Zone:         zone2,
+					Architecture: ptr.To(archAMD),
+				}
+
+				nodeTemplatePool2Zone1 = machinev1alpha1.NodeTemplate{
+					Capacity:     nodeCapacity,
+					InstanceType: machineType,
+					Region:       region,
+					Zone:         zone2,
+					Architecture: ptr.To(archARM),
+				}
+
+				nodeTemplatePool2Zone2 = machinev1alpha1.NodeTemplate{
+					Capacity:     nodeCapacity,
+					InstanceType: machineType,
+					Region:       region,
+					Zone:         zone2,
+					Architecture: ptr.To(archARM),
 				}
 
 				machineConfiguration = &machinev1alpha1.MachineConfiguration{}
@@ -316,6 +339,7 @@ var _ = Describe("Machines", func() {
 								MaxSurge:       maxSurgePool1,
 								MaxUnavailable: maxUnavailablePool1,
 								MachineType:    machineType,
+								Architecture:   ptr.To(archAMD),
 								MachineImage: extensionsv1alpha1.MachineImage{
 									Name:    machineImageName,
 									Version: machineImageVersion,
@@ -337,6 +361,7 @@ var _ = Describe("Machines", func() {
 								Minimum:        minPool2,
 								Maximum:        maxPool2,
 								MaxSurge:       maxSurgePool2,
+								Architecture:   ptr.To(archARM),
 								MaxUnavailable: maxUnavailablePool2,
 								MachineType:    machineType,
 								MachineImage: extensionsv1alpha1.MachineImage{
@@ -720,10 +745,10 @@ var _ = Describe("Machines", func() {
 						addNameAndSecretToMachineClass(machineClassPool1Zone2, machineClassWithHashPool1Zone2, w.Spec.SecretRef)
 						addNameAndSecretToMachineClass(machineClassPool2Zone1, machineClassWithHashPool2Zone1, w.Spec.SecretRef)
 						addNameAndSecretToMachineClass(machineClassPool2Zone2, machineClassWithHashPool2Zone2, w.Spec.SecretRef)
-						addNodeTemplateToMachineClass(machineClassPool1Zone1, nodeTemplateZone1)
-						addNodeTemplateToMachineClass(machineClassPool1Zone2, nodeTemplateZone2)
-						addNodeTemplateToMachineClass(machineClassPool2Zone1, nodeTemplateZone1)
-						addNodeTemplateToMachineClass(machineClassPool2Zone2, nodeTemplateZone2)
+						addNodeTemplateToMachineClass(machineClassPool1Zone1, nodeTemplatePool1Zone1)
+						addNodeTemplateToMachineClass(machineClassPool1Zone2, nodeTemplatePool1Zone2)
+						addNodeTemplateToMachineClass(machineClassPool2Zone1, nodeTemplatePool2Zone1)
+						addNodeTemplateToMachineClass(machineClassPool2Zone2, nodeTemplatePool2Zone2)
 						machineClasses := map[string]interface{}{"machineClasses": []map[string]interface{}{
 							machineClassPool1Zone1,
 							machineClassPool1Zone2,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement
/platform openstack

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes Part of #https://github.com/gardener/autoscaler/issues/122

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Inserts architecture from worker to the machine class
```
