### PR TITLE
Clean up cloudprovider webhook after dropping the gardener version check

### DIFF
--- a/pkg/cmd/options.go
+++ b/pkg/cmd/options.go
@@ -53,7 +53,7 @@ func WebhookSwitchOptions(gardenerVersion *string) *webhookcmd.SwitchOptions {
 	return webhookcmd.NewSwitchOptions(
 		webhookcmd.Switch(extensioncontrolplanewebhook.WebhookName, controlplanewebhook.AddToManager(gardenerVersion)),
 		webhookcmd.Switch(extensioncontrolplanewebhook.ExposureWebhookName, controlplaneexposurewebhook.AddToManager),
-		webhookcmd.Switch(extensionscloudproviderwebhook.WebhookName, cloudproviderwebhook.AddToManager(gardenerVersion)),
+		webhookcmd.Switch(extensionscloudproviderwebhook.WebhookName, cloudproviderwebhook.AddToManager),
 		webhookcmd.Switch(infrastructurewebhook.WebhookName, infrastructurewebhook.AddToManager),
 	)
 }

--- a/pkg/webhook/cloudprovider/add.go
+++ b/pkg/webhook/cloudprovider/add.go
@@ -5,10 +5,8 @@
 package cloudprovider
 
 import (
-	"github.com/Masterminds/semver/v3"
 	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
 	"github.com/gardener/gardener/extensions/pkg/webhook/cloudprovider"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
@@ -16,23 +14,14 @@ import (
 )
 
 var (
-	logger                           = log.Log.WithName("openstack-cloudprovider-webhook")
-	versionConstraintGreaterEqual142 *semver.Constraints
+	logger = log.Log.WithName("openstack-cloudprovider-webhook")
 )
 
-func init() {
-	var err error
-	versionConstraintGreaterEqual142, err = semver.NewConstraint(">= 1.42")
-	utilruntime.Must(err)
-}
-
 // AddToManager creates the cloudprovider webhook and adds it to the manager.
-func AddToManager(_ *string) func(mgr manager.Manager) (*extensionswebhook.Webhook, error) {
-	return func(mgr manager.Manager) (*extensionswebhook.Webhook, error) {
-		logger.Info("adding webhook to manager")
-		return cloudprovider.New(mgr, cloudprovider.Args{
-			Provider: openstack.Type,
-			Mutator:  cloudprovider.NewMutator(mgr, logger, NewEnsurer(mgr, logger)),
-		})
-	}
+func AddToManager(mgr manager.Manager) (*extensionswebhook.Webhook, error) {
+	logger.Info("Adding webhook to manager")
+	return cloudprovider.New(mgr, cloudprovider.Args{
+		Provider: openstack.Type,
+		Mutator:  cloudprovider.NewMutator(mgr, logger, NewEnsurer(mgr, logger)),
+	})
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind cleanup
/platform openstack

**What this PR does / why we need it**:
https://github.com/gardener/gardener-extension-provider-openstack/pull/816 didn't clean up everything possible related to the change in gardener/gardener: https://github.com/gardener/gardener/pull/10027

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/9864

**Special notes for your reviewer**:
I am leaving the the param on the `WebhookSwitchOptions` as the gardenerVersion param will be used with https://github.com/gardener/gardener-extension-provider-openstack/pull/797.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
