### PR TITLE
fix an issue with share network reconciliation not calculating number…

### DIFF
--- a/pkg/controller/infrastructure/infraflow/delete.go
+++ b/pkg/controller/infrastructure/infraflow/delete.go
@@ -241,9 +241,9 @@ func (fctx *FlowContext) deleteShareNetwork(ctx context.Context) error {
 	current, err := findExisting(fctx.state.Get(IdentifierShareNetwork),
 		fctx.defaultSharedNetworkName(),
 		fctx.sharedFilesystem.GetShareNetwork,
-		func(_ string) ([]*sharenetworks.ShareNetwork, error) {
+		func(name string) ([]*sharenetworks.ShareNetwork, error) {
 			list, err := fctx.sharedFilesystem.ListShareNetworks(sharenetworks.ListOpts{
-				AllTenants:      false,
+				Name:            name,
 				NeutronNetID:    networkID,
 				NeutronSubnetID: subnetID,
 			})

--- a/pkg/controller/infrastructure/infraflow/utils.go
+++ b/pkg/controller/infrastructure/infraflow/utils.go
@@ -33,24 +33,27 @@ func findExisting[T any](id *string, name string,
 	if len(found) == 0 {
 		return nil, nil
 	}
-
-	if len(found) > 1 {
-		return nil, ErrorMultipleMatches
-	}
-
-	if len(selector) > 0 {
-		for _, item := range found {
-			if selector[0](item) {
-				return item, nil
-			}
+	if len(selector) == 0 {
+		if len(found) > 1 {
+			return nil, fmt.Errorf("%w: found matches: %v", ErrorMultipleMatches, found)
 		}
-		return nil, nil
+		return found[0], nil
 	}
-	return found[0], nil
+
+	var res *T
+	for _, item := range found {
+		if selector[0](item) {
+			if res != nil {
+				return nil, fmt.Errorf("%w: found matches: %v, %v", ErrorMultipleMatches, res, item)
+			}
+			res = item
+		}
+	}
+	return res, nil
 }
 
 func sliceToPtr[T any](slice []T) []*T {
-	res := make([]*T, len(slice))
+	res := make([]*T, 0)
 	for _, t := range slice {
 		res = append(res, &t)
 	}


### PR DESCRIPTION
… of existing share networks correctly

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/platform openstack

**What this PR does / why we need it**:


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Fix an issue with share network reconciliation not calculating number of existing share networks correctly.
```
