### PR TITLE
[GEP-25] Enable Shoot cloudProfile reference as complement to cloudProfileName

### DIFF
--- a/charts/gardener-extension-admission-openstack/charts/application/templates/rbac.yaml
+++ b/charts/gardener-extension-admission-openstack/charts/application/templates/rbac.yaml
@@ -10,6 +10,7 @@ rules:
   - core.gardener.cloud
   resources:
   - cloudprofiles
+  - namespacedcloudprofiles
   - secretbindings
   verbs:
   - get

--- a/docs/usage/usage.md
+++ b/docs/usage/usage.md
@@ -196,7 +196,8 @@ metadata:
   name: johndoe-openstack
   namespace: garden-dev
 spec:
-  cloudProfileName: openstack
+  cloudProfile:
+    name: openstack
   region: europe-1
   secretBindingName: core-openstack
   provider:

--- a/pkg/admission/validator/shoot_test.go
+++ b/pkg/admission/validator/shoot_test.go
@@ -6,6 +6,7 @@ package validator_test
 
 import (
 	"context"
+	"encoding/json"
 
 	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
 	"github.com/gardener/gardener/pkg/apis/core"
@@ -18,8 +19,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gardener/gardener-extension-provider-openstack/pkg/admission/validator"
+	apisopenstack "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack"
+	apisopenstackv1alpha "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack/v1alpha1"
+	openstackv1alpha1 "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack/v1alpha1"
 )
 
 var _ = Describe("Shoot validator", func() {
@@ -35,13 +40,20 @@ var _ = Describe("Shoot validator", func() {
 			apiReader *mockclient.MockReader
 			shoot     *core.Shoot
 
-			ctx = context.TODO()
+			ctx = context.Background()
+
+			regionName   string
+			imageName    string
+			imageVersion string
+			architecture *string
 		)
 
 		BeforeEach(func() {
 			ctrl = gomock.NewController(GinkgoT())
 
 			scheme := runtime.NewScheme()
+			Expect(apisopenstack.AddToScheme(scheme)).To(Succeed())
+			Expect(apisopenstackv1alpha.AddToScheme(scheme)).To(Succeed())
 			Expect(gardencorev1beta1.AddToScheme(scheme)).To(Succeed())
 
 			c = mockclient.NewMockClient(ctrl)
@@ -53,6 +65,11 @@ var _ = Describe("Shoot validator", func() {
 			mgr.EXPECT().GetAPIReader().Return(apiReader)
 			shootValidator = validator.NewShootValidator(mgr)
 
+			regionName = "eu-de-1"
+			imageName = "Foo"
+			imageVersion = "1.0.0"
+			architecture = ptr.To("analog")
+
 			shoot = &core.Shoot{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "foo",
@@ -60,13 +77,51 @@ var _ = Describe("Shoot validator", func() {
 				},
 				Spec: core.ShootSpec{
 					CloudProfile: &core.CloudProfileReference{
+						Kind: "CloudProfile",
 						Name: "cloudProfile",
 					},
 					Provider: core.Provider{
-						Type:    "openstack",
-						Workers: []core.Worker{},
+						Type: "openstack",
+						Workers: []core.Worker{
+							{
+								Name: "worker-1",
+								Volume: &core.Volume{
+									VolumeSize: "50Gi",
+									Type:       ptr.To("volumeType"),
+								},
+								Zones: []string{"zone1"},
+								Machine: core.Machine{
+									Image: &core.ShootMachineImage{
+										Name:    imageName,
+										Version: imageVersion,
+									},
+									Architecture: architecture,
+								},
+							},
+						},
+						InfrastructureConfig: &runtime.RawExtension{
+							Raw: encode(&openstackv1alpha1.InfrastructureConfig{
+								TypeMeta: metav1.TypeMeta{
+									APIVersion: openstackv1alpha1.SchemeGroupVersion.String(),
+									Kind:       "InfrastructureConfig",
+								},
+								Networks: openstackv1alpha1.Networks{
+									Workers: "10.250.0.0/19",
+								},
+								FloatingPoolName: "pool-1",
+							}),
+						},
+						ControlPlaneConfig: &runtime.RawExtension{
+							Raw: encode(&openstackv1alpha1.ControlPlaneConfig{
+								TypeMeta: metav1.TypeMeta{
+									APIVersion: openstackv1alpha1.SchemeGroupVersion.String(),
+									Kind:       "ControlPlaneConfig",
+								},
+								LoadBalancerProvider: "haproxy",
+							}),
+						},
 					},
-					Region: "us-west",
+					Region: "eu-de-1",
 					Networking: &core.Networking{
 						Nodes: ptr.To("10.250.0.0/16"),
 					},
@@ -84,5 +139,133 @@ var _ = Describe("Shoot validator", func() {
 				Expect(err).NotTo(HaveOccurred())
 			})
 		})
+
+		Context("Shoot creation", func() {
+			var (
+				cloudProfileKey           client.ObjectKey
+				namespacedCloudProfileKey client.ObjectKey
+
+				cloudProfile           *gardencorev1beta1.CloudProfile
+				namespacedCloudProfile *gardencorev1beta1.NamespacedCloudProfile
+			)
+
+			BeforeEach(func() {
+				cloudProfileKey = client.ObjectKey{Name: "openstack"}
+				namespacedCloudProfileKey = client.ObjectKey{Name: "openstack-nscpfl", Namespace: namespace}
+
+				cloudProfile = &gardencorev1beta1.CloudProfile{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "openstack",
+					},
+					Spec: gardencorev1beta1.CloudProfileSpec{
+						Regions: []gardencorev1beta1.Region{
+							{
+								Name: regionName,
+								Zones: []gardencorev1beta1.AvailabilityZone{
+									{
+										Name: "zone1",
+									},
+									{
+										Name: "zone2",
+									},
+								},
+							},
+						},
+						ProviderConfig: &runtime.RawExtension{
+							Raw: encode(&apisopenstackv1alpha.CloudProfileConfig{
+								TypeMeta: metav1.TypeMeta{
+									APIVersion: apisopenstackv1alpha.SchemeGroupVersion.String(),
+									Kind:       "CloudProfileConfig",
+								},
+								MachineImages: []apisopenstackv1alpha.MachineImages{
+									{
+										Name: imageName,
+										Versions: []apisopenstackv1alpha.MachineImageVersion{
+											{
+												Version: imageVersion,
+												Regions: []apisopenstackv1alpha.RegionIDMapping{
+													{
+														Name:         regionName,
+														ID:           "Bar",
+														Architecture: architecture,
+													},
+												},
+											},
+										},
+									},
+								},
+							}),
+						},
+					},
+				}
+
+				namespacedCloudProfile = &gardencorev1beta1.NamespacedCloudProfile{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "openstack-nscpfl",
+					},
+					Spec: gardencorev1beta1.NamespacedCloudProfileSpec{
+						Parent: gardencorev1beta1.CloudProfileReference{
+							Kind: "CloudProfile",
+							Name: "openstack",
+						},
+					},
+					Status: gardencorev1beta1.NamespacedCloudProfileStatus{
+						CloudProfileSpec: cloudProfile.Spec,
+					},
+				}
+			})
+
+			It("should work for CloudProfile referenced from Shoot", func() {
+				shoot.Spec.CloudProfile = &core.CloudProfileReference{
+					Kind: "CloudProfile",
+					Name: "openstack",
+				}
+				c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
+
+				err := shootValidator.Validate(ctx, shoot, nil)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should work for CloudProfile referenced from cloudProfileName", func() {
+				shoot.Spec.CloudProfileName = ptr.To("openstack")
+				shoot.Spec.CloudProfile = nil
+				c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
+
+				err := shootValidator.Validate(ctx, shoot, nil)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should work for NamespacedCloudProfile referenced from Shoot", func() {
+				shoot.Spec.CloudProfile = &core.CloudProfileReference{
+					Kind: "NamespacedCloudProfile",
+					Name: "openstack-nscpfl",
+				}
+				c.EXPECT().Get(ctx, namespacedCloudProfileKey, &gardencorev1beta1.NamespacedCloudProfile{}).SetArg(2, *namespacedCloudProfile)
+
+				err := shootValidator.Validate(ctx, shoot, nil)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should fail for a missing cloud profile provider config", func() {
+				shoot.Spec.CloudProfile = &core.CloudProfileReference{
+					Kind: "NamespacedCloudProfile",
+					Name: "openstack-nscpfl",
+				}
+				namespacedCloudProfile.Status.CloudProfileSpec.ProviderConfig = nil
+				c.EXPECT().Get(ctx, namespacedCloudProfileKey, &gardencorev1beta1.NamespacedCloudProfile{}).SetArg(2, *namespacedCloudProfile)
+
+				err := shootValidator.Validate(ctx, shoot, nil)
+				Expect(err).To(MatchError(And(
+					ContainSubstring("providerConfig is not given for cloud profile"),
+					ContainSubstring("NamespacedCloudProfile"),
+					ContainSubstring("openstack-nscpfl"),
+				)))
+			})
+		})
 	})
 })
+
+func encode(obj runtime.Object) []byte {
+	data, _ := json.Marshal(obj)
+	return data
+}

--- a/pkg/apis/openstack/helper/scheme.go
+++ b/pkg/apis/openstack/helper/scheme.go
@@ -71,9 +71,13 @@ func InfrastructureStatusFromRaw(raw *runtime.RawExtension) (*api.Infrastructure
 func CloudProfileConfigFromCluster(cluster *controller.Cluster) (*api.CloudProfileConfig, error) {
 	var cloudProfileConfig *api.CloudProfileConfig
 	if cluster != nil && cluster.CloudProfile != nil && cluster.CloudProfile.Spec.ProviderConfig != nil && cluster.CloudProfile.Spec.ProviderConfig.Raw != nil {
+		cloudProfileSpecifier := fmt.Sprintf("cloudProfile '%q'", k8sclient.ObjectKeyFromObject(cluster.CloudProfile))
+		if cluster.Shoot != nil && cluster.Shoot.Spec.CloudProfile != nil {
+			cloudProfileSpecifier = fmt.Sprintf("%s '%s/%s'", cluster.Shoot.Spec.CloudProfile.Kind, cluster.Shoot.Namespace, cluster.Shoot.Spec.CloudProfile.Name)
+		}
 		cloudProfileConfig = &api.CloudProfileConfig{}
 		if _, _, err := decoder.Decode(cluster.CloudProfile.Spec.ProviderConfig.Raw, nil, cloudProfileConfig); err != nil {
-			return nil, fmt.Errorf("could not decode providerConfig of cloudProfile for '%s': %w", k8sclient.ObjectKeyFromObject(cluster.CloudProfile), err)
+			return nil, fmt.Errorf("could not decode providerConfig of %s: %w", cloudProfileSpecifier, err)
 		}
 	}
 	return cloudProfileConfig, nil

--- a/pkg/apis/openstack/validation/controlplane.go
+++ b/pkg/apis/openstack/validation/controlplane.go
@@ -25,8 +25,8 @@ func ValidateControlPlaneConfig(controlPlaneConfig *api.ControlPlaneConfig, infr
 	loadBalancerClassPath := fldPath.Child("loadBalancerClasses")
 	allErrs = append(allErrs, ValidateLoadBalancerClasses(controlPlaneConfig.LoadBalancerClasses, loadBalancerClassPath)...)
 	for i, class := range controlPlaneConfig.LoadBalancerClasses {
-		// Do not allow that the user specify a vpn LoadBalancerClass in the controlplane config.
-		// It need to come from the CloudProfile.
+		// Do not allow that the user specifies a vpn LoadBalancerClass in the controlplane config.
+		// It needs to come from the CloudProfile.
 		if class.Purpose != nil && *class.Purpose == api.VPNLoadBalancerClass {
 			allErrs = append(allErrs, field.Invalid(loadBalancerClassPath.Index(i), class.Purpose, fmt.Sprintf("not allowed to specify a LoadBalancerClass with purpose %q", api.VPNLoadBalancerClass)))
 		}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/area usability
/kind api-change
/kind enhancement
/platform openstack

**What this PR does / why we need it**:
Make the Azure provider extension aware of the `CloudProfile` field and the option to provide `NamespacedCloudProfile` references in the `shoot.Spec.CloudProfile`.
See also [GEP-25](https://github.com/gardener/gardener/issues/9504) and [this PR](https://github.com/gardener/gardener/pull/10093).

**Which issue(s) this PR fixes**:
Related to https://github.com/gardener/gardener/issues/9504

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Enable support for the field `shoot.Spec.CloudProfile` alongside `shoot.Spec.CloudProfileName` and enable the future use of `NamespacedCloudProfile`.
```
