### PR TITLE
Allow multiple loadBalancerProviders as the default and for a region

### DIFF
--- a/docs/operations/operations.md
+++ b/docs/operations/operations.md
@@ -125,8 +125,9 @@ constraints:
 #     subnetID: "7890"
   loadBalancerProviders:
   - name: haproxy
-#   region: europe
 # - name: f5
+#   region: asia
+# - name: haproxy
 #   region: asia
 ```
 
@@ -137,6 +138,7 @@ The default behavior is that, if found, the regional (and/or domain restricted) 
 If no entry for the given region exists then the fallback value is the most matching entry (w.r.t. wildcard matching) in the list without a `region` field (or the `keystoneURL` value for the keystone URLs).
 If an additional floating pool should be selectable for a region and/or domain, you can mark it as non constraining
 with setting the optional field `nonConstraining` to `true`.
+Multiple `loadBalancerProviders` can be specified with or without a `region`, also multiple for the same `region`. If a region specific entry is found none of the default entries apply, but the same `name` can be specified with and without a `region`.
 
 The `loadBalancerClasses` field is an optional list of load balancer classes which can be when the corresponding floating pool network is choosen. The load balancer classes can be configured in the same way as in the `ControlPlaneConfig` in the `Shoot` resource, therefore see [here](../usage/usage.md#ControlPlaneConfig) for more details.
 

--- a/docs/operations/operations.md
+++ b/docs/operations/operations.md
@@ -138,7 +138,9 @@ The default behavior is that, if found, the regional (and/or domain restricted) 
 If no entry for the given region exists then the fallback value is the most matching entry (w.r.t. wildcard matching) in the list without a `region` field (or the `keystoneURL` value for the keystone URLs).
 If an additional floating pool should be selectable for a region and/or domain, you can mark it as non constraining
 with setting the optional field `nonConstraining` to `true`.
-Multiple `loadBalancerProviders` can be specified with or without a `region`, also multiple for the same `region`. If a region specific entry is found none of the default entries apply, but the same `name` can be specified with and without a `region`.
+Multiple `loadBalancerProviders` can be specified in the `CloudProfile`. Each provider may specify a region constraint for where it can be used.
+If at least once region specific entry exists in the `CloudProfile`, the shoot's specified `loadBalancerProvider` must adhere to the list of the available providers of that region. Otherwise, one of the non-regional specific providers should be used.
+Each entry in the `loadBalancerProviders` must be uniquely identified by its name and if applicable, its region.
 
 The `loadBalancerClasses` field is an optional list of load balancer classes which can be when the corresponding floating pool network is choosen. The load balancer classes can be configured in the same way as in the `ControlPlaneConfig` in the `Shoot` resource, therefore see [here](../usage/usage.md#ControlPlaneConfig) for more details.
 

--- a/docs/operations/operations.md
+++ b/docs/operations/operations.md
@@ -139,7 +139,7 @@ If no entry for the given region exists then the fallback value is the most matc
 If an additional floating pool should be selectable for a region and/or domain, you can mark it as non constraining
 with setting the optional field `nonConstraining` to `true`.
 Multiple `loadBalancerProviders` can be specified in the `CloudProfile`. Each provider may specify a region constraint for where it can be used.
-If at least once region specific entry exists in the `CloudProfile`, the shoot's specified `loadBalancerProvider` must adhere to the list of the available providers of that region. Otherwise, one of the non-regional specific providers should be used.
+If at least one region specific entry exists in the `CloudProfile`, the shoot's specified `loadBalancerProvider` must adhere to the list of the available providers of that region. Otherwise, one of the non-regional specific providers should be used.
 Each entry in the `loadBalancerProviders` must be uniquely identified by its name and if applicable, its region.
 
 The `loadBalancerClasses` field is an optional list of load balancer classes which can be when the corresponding floating pool network is choosen. The load balancer classes can be configured in the same way as in the `ControlPlaneConfig` in the `Shoot` resource, therefore see [here](../usage/usage.md#ControlPlaneConfig) for more details.

--- a/pkg/apis/openstack/validation/cloudprofile.go
+++ b/pkg/apis/openstack/validation/cloudprofile.go
@@ -79,11 +79,11 @@ func ValidateCloudProfileConfig(cloudProfile *api.CloudProfileConfig, fldPath *f
 			if len(*provider.Region) == 0 {
 				allErrs = append(allErrs, field.Required(idxPath.Child("region"), "must provide a region if key is present"))
 			}
-			combo := fmt.Sprintf("%s,%s", provider.Name, *provider.Region)
-			if regionsFound.Has(combo) {
+			providerID := fmt.Sprintf("%s,%s", provider.Name, *provider.Region)
+			if regionsFound.Has(providerID) {
 				allErrs = append(allErrs, field.Duplicate(idxPath, fmt.Sprintf("duplicate provider %q for region %q", provider.Name, *provider.Region)))
 			}
-			regionsFound.Insert(combo)
+			regionsFound.Insert(providerID)
 		}
 	}
 

--- a/pkg/apis/openstack/validation/cloudprofile.go
+++ b/pkg/apis/openstack/validation/cloudprofile.go
@@ -68,21 +68,22 @@ func ValidateCloudProfileConfig(cloudProfile *api.CloudProfileConfig, fldPath *f
 	}
 
 	regionsFound := sets.NewString()
-	for i, pool := range cloudProfile.Constraints.LoadBalancerProviders {
+	for i, provider := range cloudProfile.Constraints.LoadBalancerProviders {
 		idxPath := loadBalancerProviderPath.Index(i)
 
-		if len(pool.Name) == 0 {
+		if len(provider.Name) == 0 {
 			allErrs = append(allErrs, field.Required(idxPath.Child("name"), "must provide a name"))
 		}
 
-		if pool.Region != nil {
-			if len(*pool.Region) == 0 {
+		if provider.Region != nil {
+			if len(*provider.Region) == 0 {
 				allErrs = append(allErrs, field.Required(idxPath.Child("region"), "must provide a region if key is present"))
 			}
-			if regionsFound.Has(*pool.Region) {
-				allErrs = append(allErrs, field.Duplicate(idxPath.Child("region"), *pool.Region))
+			combo := fmt.Sprintf("%s,%s", provider.Name, *provider.Region)
+			if regionsFound.Has(combo) {
+				allErrs = append(allErrs, field.Duplicate(idxPath, fmt.Sprintf("duplicate provider %q for region %q", provider.Name, *provider.Region)))
 			}
-			regionsFound.Insert(*pool.Region)
+			regionsFound.Insert(combo)
 		}
 	}
 

--- a/pkg/apis/openstack/validation/cloudprofile_test.go
+++ b/pkg/apis/openstack/validation/cloudprofile_test.go
@@ -188,6 +188,7 @@ var _ = Describe("CloudProfileConfig validation", func() {
 					"Field": Equal("root.constraints.loadBalancerProviders[1]"),
 				}))))
 			})
+
 			It("should allow multiple providers in the same region", func() {
 				cloudProfileConfig.Constraints.LoadBalancerProviders = []api.LoadBalancerProvider{
 					{
@@ -204,6 +205,7 @@ var _ = Describe("CloudProfileConfig validation", func() {
 
 				Expect(errorList).To(BeEmpty())
 			})
+
 			It("should allow multiple default providers", func() {
 				cloudProfileConfig.Constraints.LoadBalancerProviders = []api.LoadBalancerProvider{
 					{
@@ -218,6 +220,29 @@ var _ = Describe("CloudProfileConfig validation", func() {
 
 				Expect(errorList).To(BeEmpty())
 			})
+		})
+
+		It("should allow a mixture of default and regional providers", func() {
+			cloudProfileConfig.Constraints.LoadBalancerProviders = []api.LoadBalancerProvider{
+				{
+					Name: "foo",
+				},
+				{
+					Name: "bar",
+				},
+				{
+					Name:   "foo",
+					Region: ptr.To("foo"),
+				},
+				{
+					Name:   "baz",
+					Region: ptr.To("bar"),
+				},
+			}
+
+			errorList := ValidateCloudProfileConfig(cloudProfileConfig, fldPath)
+
+			Expect(errorList).To(BeEmpty())
 		})
 
 		Context("keystone url validation", func() {

--- a/pkg/apis/openstack/validation/cloudprofile_test.go
+++ b/pkg/apis/openstack/validation/cloudprofile_test.go
@@ -169,7 +169,7 @@ var _ = Describe("CloudProfileConfig validation", func() {
 				}))))
 			})
 
-			It("should forbid duplicates regions in providers", func() {
+			It("should forbid exact duplicate name/region in providers", func() {
 				cloudProfileConfig.Constraints.LoadBalancerProviders = []api.LoadBalancerProvider{
 					{
 						Name:   "foo",
@@ -185,8 +185,38 @@ var _ = Describe("CloudProfileConfig validation", func() {
 
 				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeDuplicate),
-					"Field": Equal("root.constraints.loadBalancerProviders[1].region"),
+					"Field": Equal("root.constraints.loadBalancerProviders[1]"),
 				}))))
+			})
+			It("should allow multiple providers in the same region", func() {
+				cloudProfileConfig.Constraints.LoadBalancerProviders = []api.LoadBalancerProvider{
+					{
+						Name:   "foo",
+						Region: ptr.To("foo"),
+					},
+					{
+						Name:   "bar",
+						Region: ptr.To("foo"),
+					},
+				}
+
+				errorList := ValidateCloudProfileConfig(cloudProfileConfig, fldPath)
+
+				Expect(errorList).To(BeEmpty())
+			})
+			It("should allow multiple default providers", func() {
+				cloudProfileConfig.Constraints.LoadBalancerProviders = []api.LoadBalancerProvider{
+					{
+						Name: "foo",
+					},
+					{
+						Name: "bar",
+					},
+				}
+
+				errorList := ValidateCloudProfileConfig(cloudProfileConfig, fldPath)
+
+				Expect(errorList).To(BeEmpty())
 			})
 		})
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement
/platform openstack

**What this PR does / why we need it**:
We are adding a new openstack region that uses the OVN networking stack, and also the octavia OVN loadbalancer provider that has some worthwhile [advantages](https://docs.openstack.org/ovn-octavia-provider/latest/admin/driver.html). But since OVN is also still [missing features](https://docs.openstack.org/octavia/latest/user/feature-classification/index.html) we want to also allow the well known amphora provider in parallel.

Currently the cloudprofile/controlplane validation does not allow multiple entries for a region.

The Shoot spec validation has always required to specify a loadBalancerProvider even when there is only a single choice, the behavior for a given shoot should stay the same, and the behavior with existing cloudprofiles should also be the same until you add multiple loadBalancerProviders.

**Which issue(s) this PR fixes**:
Fixes #862

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Allow multiple loadBalancerProviders as the default and for a region
```
