### PR TITLE
fix issue with gg 1.103 with pod network being a slice

### DIFF
--- a/charts/internal/machineclass/templates/machineclass.yaml
+++ b/charts/internal/machineclass/templates/machineclass.yaml
@@ -56,7 +56,7 @@ providerSpec:
 {{- end }}
     networkID: {{ $machineClass.networkID }}
     subnetID: {{ $machineClass.subnetID }}
-    podNetworkCidr: {{ $machineClass.podNetworkCidr }}
+    podNetworkCIDRs: {{ $machineClass.podNetworkCIDRs }}
 {{- if $machineClass.rootDiskSize }}
     rootDiskSize: {{ $machineClass.rootDiskSize }}
 {{- end }}

--- a/charts/internal/machineclass/values.yaml
+++ b/charts/internal/machineclass/values.yaml
@@ -18,7 +18,8 @@ machineClasses:
   imageName: coreos-v1.0
   #imageID: 836428cd-5f98-1305-af9d-9825d4dfd0ec
   networkID: 426428cd-5e88-4005-9fad-9555d4dfd0fb
-  podNetworkCidr: 100.96.0.0/11
+  podNetworkCIDRs:
+  - 100.96.0.0/11
   # rootDiskSize: 100 # 100GB
   # rootDiskType: standard_hdd
   # serverGroupID: b35e94c1-15a7-4b54-a0f6-8789fasdf79s

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -149,7 +149,7 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 				"machineType":      pool.MachineType,
 				"keyName":          infrastructureStatus.Node.KeyName,
 				"networkID":        infrastructureStatus.Networks.ID,
-				"podNetworkCidr":   extensionscontroller.GetPodNetwork(w.cluster),
+				"podNetworkCIDRs":  extensionscontroller.GetPodNetwork(w.cluster),
 				"securityGroups":   []string{nodesSecurityGroup.Name},
 				"tags": utils.MergeStringMaps(
 					NormalizeLabelsForMachineClass(pool.Labels),

--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -417,13 +417,13 @@ var _ = Describe("Machines", func() {
 					clusterWithRegion.Shoot.Spec.Region = region
 
 					defaultMachineClass = map[string]interface{}{
-						"region":         region,
-						"machineType":    machineType,
-						"keyName":        keyName,
-						"networkID":      networkID,
-						"subnetID":       subnetID,
-						"podNetworkCidr": []string{podCIDR},
-						"securityGroups": []string{securityGroupName},
+						"region":          region,
+						"machineType":     machineType,
+						"keyName":         keyName,
+						"networkID":       networkID,
+						"subnetID":        subnetID,
+						"podNetworkCIDRs": []string{podCIDR},
+						"securityGroups":  []string{securityGroupName},
 						"tags": map[string]string{
 							fmt.Sprintf("kubernetes.io-cluster-%s", namespace): "1",
 							"kubernetes.io-role-node":                          "1",


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/platform openstack

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Depends on https://github.com/gardener/machine-controller-manager-provider-openstack/pull/177

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
