### PR TITLE
Update cloud-provider-openstack images and remove credential use from nodeserver

### DIFF
--- a/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/deployment-csi-driver-controller.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/deployment-csi-driver-controller.yaml
@@ -43,7 +43,6 @@ spec:
         imagePullPolicy: IfNotPresent
         args :
         - /bin/cinder-csi-plugin
-        - --nodeid=dummy
         - --endpoint=$(CSI_ENDPOINT)
         - --cloud-config=/etc/kubernetes/cloudprovider/cloudprovider.conf
         - --cluster={{ .Release.Namespace }}
@@ -51,6 +50,9 @@ spec:
         - --user-agent={{ $userAgentHeader }}
         {{- end }}
         - --v=3
+{{- if semverCompare ">= 1.28-0" .Capabilities.KubeVersion.Version }}
+        - --provide-node-service=false
+{{- end }}
         env:
         - name: CSI_ENDPOINT
           value: unix://{{ .Values.socketPath }}/csi.sock

--- a/charts/internal/shoot-system-components/charts/csi-driver-node/templates/daemonset.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/templates/daemonset.yaml
@@ -49,6 +49,10 @@ spec:
         {{- end }}
         - --v=2
         - --vmodule=mount*=4,nodeserver=3,utils=2,driver=4,openstack=4,client=4,server=4,controllerserver=4
+{{- if semverCompare ">= 1.28-0" .Capabilities.KubeVersion.Version }}
+        - --node-service-no-os-client=true
+        - --provide-controller-service=false
+{{- end }}
         env:
         - name: CSI_ENDPOINT
           value: unix://{{ .Values.socketPath }}

--- a/charts/internal/shoot-system-components/charts/csi-driver-node/templates/secret.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/templates/secret.yaml
@@ -1,3 +1,11 @@
+{{- define "cloud-provider-disk-config-node" -}}
+[BlockStorage]
+rescan-on-resize={{ .Values.rescanBlockStorageOnResize }}
+{{- if .Values.nodeVolumeAttachLimit }}
+node-volume-attach-limit={{ .Values.nodeVolumeAttachLimit }}
+{{- end -}}
+{{- end -}}
+
 ---
 apiVersion: v1
 kind: Secret
@@ -6,7 +14,7 @@ metadata:
   namespace: kube-system
 type: Opaque
 data:
-  cloudprovider.conf: {{ .Values.cloudProviderConfig }}
+  cloudprovider.conf: {{ include "cloud-provider-disk-config-node" . | b64enc }}
   {{- if .Values.keystoneCACert }}
   keystone-ca.crt: {{ .Values.keystoneCACert }}
   {{- end }}

--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -157,7 +157,7 @@ images:
 - name: csi-driver-cinder
   sourceRepository: github.com/kubernetes/cloud-provider-openstack
   repository: registry.k8s.io/provider-os/cinder-csi-plugin
-  tag: "v1.28.2"
+  tag: "v1.28.3"
   targetVersion: "1.28.x"
   labels:
     - name: 'gardener.cloud/cve-categorisation'
@@ -171,8 +171,22 @@ images:
 - name: csi-driver-cinder
   sourceRepository: github.com/kubernetes/cloud-provider-openstack
   repository: registry.k8s.io/provider-os/cinder-csi-plugin
-  tag: "v1.29.0"
-  targetVersion: ">= 1.29"
+  tag: "v1.29.1"
+  targetVersion: "1.29.x"
+  labels:
+    - name: 'gardener.cloud/cve-categorisation'
+      value:
+        network_exposure: 'protected'
+        authentication_enforced: false
+        user_interaction: 'end-user'
+        confidentiality_requirement: 'high'
+        integrity_requirement: 'high'
+        availability_requirement: 'low'
+- name: csi-driver-cinder
+  sourceRepository: github.com/kubernetes/cloud-provider-openstack
+  repository: registry.k8s.io/provider-os/cinder-csi-plugin
+  tag: "v1.30.1"
+  targetVersion: ">= 1.30"
   labels:
     - name: 'gardener.cloud/cve-categorisation'
       value:
@@ -228,7 +242,7 @@ images:
 - name: csi-driver-manila
   sourceRepository: github.com/kubernetes/cloud-provider-openstack
   repository: registry.k8s.io/provider-os/manila-csi-plugin
-  tag: "v1.28.2"
+  tag: "v1.28.3"
   targetVersion: "1.28.x"
   labels:
     - name: 'gardener.cloud/cve-categorisation'
@@ -242,8 +256,22 @@ images:
 - name: csi-driver-manila
   sourceRepository: github.com/kubernetes/cloud-provider-openstack
   repository: registry.k8s.io/provider-os/manila-csi-plugin
-  tag: "v1.29.0"
-  targetVersion: ">= 1.29"
+  tag: "v1.29.1"
+  targetVersion: "1.29.x"
+  labels:
+    - name: 'gardener.cloud/cve-categorisation'
+      value:
+        network_exposure: 'protected'
+        authentication_enforced: false
+        user_interaction: 'end-user'
+        confidentiality_requirement: 'high'
+        integrity_requirement: 'high'
+        availability_requirement: 'low'
+- name: csi-driver-manila
+  sourceRepository: github.com/kubernetes/cloud-provider-openstack
+  repository: registry.k8s.io/provider-os/manila-csi-plugin
+  tag: "v1.30.1"
+  targetVersion: ">= 1.30"
   labels:
     - name: 'gardener.cloud/cve-categorisation'
       value:

--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -58,7 +58,7 @@ images:
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes/cloud-provider-openstack
   repository: registry.k8s.io/provider-os/openstack-cloud-controller-manager
-  tag: "v1.28.2"
+  tag: "v1.28.3"
   targetVersion: "1.28.x"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
@@ -72,7 +72,7 @@ images:
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes/cloud-provider-openstack
   repository: registry.k8s.io/provider-os/openstack-cloud-controller-manager
-  tag: "v1.29.0"
+  tag: "v1.29.1"
   targetVersion: "1.29.x"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
@@ -86,7 +86,7 @@ images:
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes/cloud-provider-openstack
   repository: registry.k8s.io/provider-os/openstack-cloud-controller-manager
-  tag: "v1.30.0"
+  tag: "v1.30.1"
   targetVersion: ">= 1.30"
   labels:
   - name: 'gardener.cloud/cve-categorisation'

--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -16,20 +16,6 @@ images:
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes/cloud-provider-openstack
   repository: registry.k8s.io/provider-os/openstack-cloud-controller-manager
-  tag: "v1.25.6"
-  targetVersion: "1.25.x"
-  labels:
-  - name: 'gardener.cloud/cve-categorisation'
-    value:
-      network_exposure: 'protected'
-      authentication_enforced: false
-      user_interaction: 'gardener-operator'
-      confidentiality_requirement: 'high'
-      integrity_requirement: 'high'
-      availability_requirement: 'low'
-- name: cloud-controller-manager
-  sourceRepository: github.com/kubernetes/cloud-provider-openstack
-  repository: registry.k8s.io/provider-os/openstack-cloud-controller-manager
   tag: "v1.26.4"
   targetVersion: "1.26.x"
   labels:
@@ -115,20 +101,6 @@ images:
 - name: csi-driver-cinder
   sourceRepository: github.com/kubernetes/cloud-provider-openstack
   repository: registry.k8s.io/provider-os/cinder-csi-plugin
-  tag: "v1.25.6"
-  targetVersion: "1.25.x"
-  labels:
-    - name: 'gardener.cloud/cve-categorisation'
-      value:
-        network_exposure: 'protected'
-        authentication_enforced: false
-        user_interaction: 'end-user'
-        confidentiality_requirement: 'high'
-        integrity_requirement: 'high'
-        availability_requirement: 'low'
-- name: csi-driver-cinder
-  sourceRepository: github.com/kubernetes/cloud-provider-openstack
-  repository: registry.k8s.io/provider-os/cinder-csi-plugin
   tag: "v1.26.3"
   targetVersion: "1.26.x"
   labels:
@@ -197,20 +169,6 @@ images:
         integrity_requirement: 'high'
         availability_requirement: 'low'
 
-- name: csi-driver-manila
-  sourceRepository: github.com/kubernetes/cloud-provider-openstack
-  repository: registry.k8s.io/provider-os/manila-csi-plugin
-  tag: "v1.25.6"
-  targetVersion: "< 1.26"
-  labels:
-    - name: 'gardener.cloud/cve-categorisation'
-      value:
-        network_exposure: 'protected'
-        authentication_enforced: false
-        user_interaction: 'end-user'
-        confidentiality_requirement: 'high'
-        integrity_requirement: 'high'
-        availability_requirement: 'low'
 - name: csi-driver-manila
   sourceRepository: github.com/kubernetes/cloud-provider-openstack
   repository: registry.k8s.io/provider-os/manila-csi-plugin

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -325,9 +325,7 @@ var _ = Describe("ValuesProvider", func() {
 			"dhcpDomain":                  dhcpDomain,
 			"requestTimeout":              requestTimeout,
 			"useOctavia":                  useOctavia,
-			"rescanBlockStorageOnResize":  rescanBlockStorageOnResize,
 			"ignoreVolumeAZ":              ignoreVolumeAZ,
-			"nodeVolumeAttachLimit":       ptr.To[int32](nodeVoluemAttachLimit),
 			"applicationCredentialID":     "",
 			"applicationCredentialSecret": "",
 			"applicationCredentialName":   "",
@@ -742,7 +740,9 @@ var _ = Describe("ValuesProvider", func() {
 				Expect(values).To(Equal(map[string]interface{}{
 					openstack.CloudControllerManagerName: enabledTrue,
 					openstack.CSINodeName: utils.MergeMaps(enabledTrue, map[string]interface{}{
-						"vpaEnabled": true,
+						"rescanBlockStorageOnResize": rescanBlockStorageOnResize,
+						"nodeVolumeAttachLimit":      ptr.To[int32](nodeVoluemAttachLimit),
+						"vpaEnabled":                 true,
 						"podAnnotations": map[string]interface{}{
 							"checksum/secret-" + openstack.CloudProviderCSIDiskConfigName: checksums[openstack.CloudProviderCSIDiskConfigName],
 						},
@@ -767,7 +767,9 @@ var _ = Describe("ValuesProvider", func() {
 				Expect(values).To(Equal(map[string]interface{}{
 					openstack.CloudControllerManagerName: enabledTrue,
 					openstack.CSINodeName: utils.MergeMaps(enabledTrue, map[string]interface{}{
-						"vpaEnabled": true,
+						"rescanBlockStorageOnResize": rescanBlockStorageOnResize,
+						"nodeVolumeAttachLimit":      ptr.To[int32](nodeVoluemAttachLimit),
+						"vpaEnabled":                 true,
 						"podAnnotations": map[string]interface{}{
 							"checksum/secret-" + openstack.CloudProviderCSIDiskConfigName: checksums[openstack.CloudProviderCSIDiskConfigName],
 						},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement
/platform openstack

**What this PR does / why we need it**:

- Update cloudprovider images (including CSI driver images)
- Remove use of credentials from the nodeserver daemonset
- Remove deprecated v1.25 images

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Update cloud-provider-openstack images and remove credential use from nodeserver
```
