### PR TITLE
Improve confusing error message

### DIFF
--- a/pkg/controller/worker/actuator.go
+++ b/pkg/controller/worker/actuator.go
@@ -83,7 +83,7 @@ func (d *delegateFactory) WorkerDelegate(ctx context.Context, worker *extensions
 
 	openstackClient, err := openstackclient.NewOpenStackClientFromSecretRef(ctx, d.seedClient, worker.Spec.SecretRef, &keyStoneURL)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create openstack seedClient: %w", err)
+		return nil, fmt.Errorf("failed to create openstack client: %w", err)
 	}
 
 	return NewWorkerDelegate(


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind enhancement
/platform openstack

**What this PR does / why we need it**:
The error message 
```
[...]: failed to create openstack seedClient: Authentication failed
```

is confusing. There openstack client is actually an openstack client against the Shoot's infrastructure. Maybe we wanted to express a failure creating an openstack client using a seedClient (which is a K8s client)? IMO there is no need to provide such internal details.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
