### PR TITLE
Fix k8s <=v1.27 deployment of csi-driver-node

### DIFF
--- a/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/deployment-csi-driver-controller.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/deployment-csi-driver-controller.yaml
@@ -50,9 +50,9 @@ spec:
         - --user-agent={{ $userAgentHeader }}
         {{- end }}
         - --v=3
-{{- if semverCompare ">= 1.28-0" .Capabilities.KubeVersion.Version }}
+        {{- if semverCompare ">= 1.28-0" .Values.kubernetesVersion }}
         - --provide-node-service=false
-{{- end }}
+        {{- end }}
         env:
         - name: CSI_ENDPOINT
           value: unix://{{ .Values.socketPath }}/csi.sock

--- a/charts/internal/seed-controlplane/charts/csi-driver-controller/values.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-driver-controller/values.yaml
@@ -1,5 +1,6 @@
 replicas: 1
 podAnnotations: {}
+kubernetesVersion: 1.30.0
 
 images:
   csi-driver-cinder: image-repository:image-tag

--- a/charts/internal/shoot-system-components/charts/csi-driver-node/templates/secret.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/templates/secret.yaml
@@ -14,7 +14,11 @@ metadata:
   namespace: kube-system
 type: Opaque
 data:
+  {{- if semverCompare ">= 1.28-0" .Capabilities.KubeVersion.Version }}
   cloudprovider.conf: {{ include "cloud-provider-disk-config-node" . | b64enc }}
+  {{- else }}
+  cloudprovider.conf: {{ .Values.cloudProviderConfig }}
+  {{- end }}
   {{- if .Values.keystoneCACert }}
   keystone-ca.crt: {{ .Values.keystoneCACert }}
   {{- end }}

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -774,8 +774,9 @@ func getCSIControllerChartValues(
 	}
 
 	values := map[string]interface{}{
-		"enabled":  true,
-		"replicas": extensionscontroller.GetControlPlaneReplicas(cluster, scaledDown, 1),
+		"kubernetesVersion": cluster.Shoot.Spec.Kubernetes.Version,
+		"enabled":           true,
+		"replicas":          extensionscontroller.GetControlPlaneReplicas(cluster, scaledDown, 1),
 		"podAnnotations": map[string]interface{}{
 			"checksum/secret-" + openstack.CloudProviderCSIDiskConfigName: checksums[openstack.CloudProviderCSIDiskConfigName],
 		},
@@ -847,6 +848,8 @@ func (vp *valuesProvider) getControlPlaneShootChartValues(
 		caBundle                string
 	)
 
+	// TODO: remove this when v1.27 is removed. From v1.28 onwards, we do not need credentials on the csi-node.
+	// Here we copy the data from the secret in the seed namespace to create the correct cloud-provider-config in the kube-system namespace of the shoot.
 	secret := &corev1.Secret{}
 	if err := vp.client.Get(ctx, k8sclient.ObjectKey{Namespace: cp.Namespace, Name: openstack.CloudProviderCSIDiskConfigName}, secret); err != nil {
 		return nil, err

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -589,7 +589,8 @@ var _ = Describe("ValuesProvider", func() {
 					"gep19Monitoring":   false,
 				}),
 				openstack.CSIControllerName: utils.MergeMaps(enabledTrue, map[string]interface{}{
-					"replicas": 1,
+					"replicas":          1,
+					"kubernetesVersion": cluster.Shoot.Spec.Kubernetes.Version,
 					"podAnnotations": map[string]interface{}{
 						"checksum/secret-" + openstack.CloudProviderCSIDiskConfigName: checksums[openstack.CloudProviderCSIDiskConfigName],
 					},
@@ -626,7 +627,8 @@ var _ = Describe("ValuesProvider", func() {
 					"gep19Monitoring":   false,
 				}),
 				openstack.CSIControllerName: utils.MergeMaps(enabledTrue, map[string]interface{}{
-					"replicas": 1,
+					"replicas":          1,
+					"kubernetesVersion": cluster.Shoot.Spec.Kubernetes.Version,
 					"podAnnotations": map[string]interface{}{
 						"checksum/secret-" + openstack.CloudProviderCSIDiskConfigName: checksums[openstack.CloudProviderCSIDiskConfigName],
 					},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/platform openstack

**What this PR does / why we need it**:
Fix an issue after https://github.com/gardener/gardener-extension-provider-openstack/pull/864 that prevented the successful deployment of the csi-controller and csi-node on k8s <=1.27


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Fix a bug that prevented the Cinder CSI from working on shoots with kubernetes version less than v1.28.
```
