### PR TITLE
forbid disabling share networks

### DIFF
--- a/pkg/apis/openstack/validation/infrastructure_test.go
+++ b/pkg/apis/openstack/validation/infrastructure_test.go
@@ -171,13 +171,23 @@ var _ = Describe("InfrastructureConfig validation", func() {
 			}))))
 		})
 
-		It("should allow changing the share network section", func() {
+		It("should allow enabling the share network section", func() {
 			newInfrastructureConfig := infrastructureConfig.DeepCopy()
 			newInfrastructureConfig.Networks.ShareNetwork = &api.ShareNetwork{Enabled: true}
 
 			errorList := ValidateInfrastructureConfigUpdate(infrastructureConfig, newInfrastructureConfig, nilPath)
-
 			Expect(errorList).To(BeEmpty())
+		})
+		It("should forbid disabling the share network section", func() {
+			infrastructureConfig.Networks.ShareNetwork = &api.ShareNetwork{Enabled: true}
+			newInfrastructureConfig := infrastructureConfig.DeepCopy()
+			newInfrastructureConfig.Networks.ShareNetwork = nil
+
+			errorList := ValidateInfrastructureConfigUpdate(infrastructureConfig, newInfrastructureConfig, nilPath)
+			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":  Equal(field.ErrorTypeInvalid),
+				"Field": Equal("networks"),
+			}))))
 		})
 
 		It("should forbid changing the floating pool", func() {

--- a/pkg/controller/infrastructure/infraflow/delete.go
+++ b/pkg/controller/infrastructure/infraflow/delete.go
@@ -235,6 +235,10 @@ func (fctx *FlowContext) deleteSSHKeyPair(ctx context.Context) error {
 }
 
 func (fctx *FlowContext) deleteShareNetwork(ctx context.Context) error {
+	if sn := fctx.config.Networks.ShareNetwork; sn == nil || !sn.Enabled {
+		return nil
+	}
+
 	log := shared.LogFromContext(ctx)
 	networkID := ptr.Deref(fctx.state.Get(IdentifierNetwork), "")
 	subnetID := ptr.Deref(fctx.state.Get(IdentifierSubnet), "")

--- a/pkg/controller/infrastructure/infraflow/reconcile.go
+++ b/pkg/controller/infrastructure/infraflow/reconcile.go
@@ -467,8 +467,8 @@ func (fctx *FlowContext) ensureSSHKeyPair(ctx context.Context) error {
 }
 
 func (fctx *FlowContext) ensureShareNetwork(ctx context.Context) error {
-	if fctx.config.Networks.ShareNetwork == nil || !fctx.config.Networks.ShareNetwork.Enabled {
-		return fctx.deleteShareNetwork(ctx)
+	if sn := fctx.config.Networks.ShareNetwork; sn == nil || !sn.Enabled {
+		return nil
 	}
 
 	log := shared.LogFromContext(ctx)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/platform openstack

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Fix an issue where provider-openstack required permissions for share network operations even when not required by the `InfrastructureConfig`.
```
