### PR TITLE
Enforce restriction with regards to IPv6 support

### DIFF
--- a/pkg/apis/openstack/validation/shoot.go
+++ b/pkg/apis/openstack/validation/shoot.go
@@ -29,6 +29,14 @@ func ValidateNetworking(networking *core.Networking, fldPath *field.Path) field.
 		allErrs = append(allErrs, field.Required(fldPath.Child("nodes"), "a nodes CIDR must be provided for Openstack shoots"))
 	}
 
+	if core.IsIPv6SingleStack(networking.IPFamilies) {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("ipFamilies"), networking.IPFamilies, "IPv6 single-stack networking is not supported"))
+	}
+
+	if len(networking.IPFamilies) > 1 {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("ipFamilies"), networking.IPFamilies, "dual-stack networking is not supported"))
+	}
+
 	return allErrs
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/area robustness
/kind enhancement
/platform openstack

**What this PR does / why we need it**:

Enforce restriction with regards to IPv6 support

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

This check replace https://github.com/gardener/gardener/pull/10716.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Added validation to prevent IPv6-only/dual-stack clusters as they are not supported, yet.
```
