### PR TITLE
Remove the provider type predicates in webhooks

### DIFF
--- a/pkg/admission/mutator/webhook.go
+++ b/pkg/admission/mutator/webhook.go
@@ -5,13 +5,11 @@
 package mutator
 
 import (
-	extensionspredicate "github.com/gardener/gardener/extensions/pkg/predicate"
 	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	"github.com/gardener/gardener-extension-provider-openstack/pkg/openstack"
 )
@@ -28,10 +26,9 @@ func New(mgr manager.Manager) (*extensionswebhook.Webhook, error) {
 	logger.Info("Setting up webhook", "name", Name)
 
 	return extensionswebhook.New(mgr, extensionswebhook.Args{
-		Provider:   openstack.Type,
-		Name:       Name,
-		Path:       "/webhooks/mutate",
-		Predicates: []predicate.Predicate{extensionspredicate.GardenCoreProviderType(openstack.Type)},
+		Provider: openstack.Type,
+		Name:     Name,
+		Path:     "/webhooks/mutate",
 		Mutators: map[extensionswebhook.Mutator][]extensionswebhook.Type{
 			NewShootMutator(mgr): {{Obj: &gardencorev1beta1.Shoot{}}},
 		},

--- a/pkg/admission/validator/webhook.go
+++ b/pkg/admission/validator/webhook.go
@@ -5,7 +5,6 @@
 package validator
 
 import (
-	extensionspredicate "github.com/gardener/gardener/extensions/pkg/predicate"
 	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
 	"github.com/gardener/gardener/pkg/apis/core"
 	"github.com/gardener/gardener/pkg/apis/security"
@@ -13,7 +12,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	"github.com/gardener/gardener-extension-provider-openstack/pkg/openstack"
 )
@@ -32,16 +30,13 @@ func New(mgr manager.Manager) (*extensionswebhook.Webhook, error) {
 	logger.Info("Setting up webhook", "name", Name)
 
 	return extensionswebhook.New(mgr, extensionswebhook.Args{
-		Provider:   openstack.Type,
-		Name:       Name,
-		Path:       "/webhooks/validate",
-		Predicates: []predicate.Predicate{extensionspredicate.GardenCoreProviderType(openstack.Type)},
+		Provider: openstack.Type,
+		Name:     Name,
+		Path:     "/webhooks/validate",
 		Validators: map[extensionswebhook.Validator][]extensionswebhook.Type{
-			NewShootValidator(mgr):         {{Obj: &core.Shoot{}}},
-			NewCloudProfileValidator(mgr):  {{Obj: &core.CloudProfile{}}},
-			NewSecretBindingValidator(mgr): {{Obj: &core.SecretBinding{}}},
-			// TODO(dimityrmirchev): Uncomment this line once this extension uses a g/g version that contains https://github.com/gardener/gardener/pull/10499
-			// Predicates: []predicate.Predicate{predicate.Or(extensionspredicate.GardenCoreProviderType(openstack.Type), extensionspredicate.GardenSecurityProviderType(openstack.Type))},
+			NewShootValidator(mgr):              {{Obj: &core.Shoot{}}},
+			NewCloudProfileValidator(mgr):       {{Obj: &core.CloudProfile{}}},
+			NewSecretBindingValidator(mgr):      {{Obj: &core.SecretBinding{}}},
 			NewCredentialsBindingValidator(mgr): {{Obj: &security.CredentialsBinding{}}},
 		},
 		Target: extensionswebhook.TargetSeed,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind cleanup
/platform openstack

**What this PR does / why we need it**:
Cleanup the duplicate check for an object's provider type.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/10745

**Special notes for your reviewer**:
/cc @timuthy 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Remove the duplicate provider type check from the admission webhooks.
```
