### PR TITLE
fix deletion when network doesn't exist

### DIFF
--- a/pkg/controller/infrastructure/infraflow/delete.go
+++ b/pkg/controller/infrastructure/infraflow/delete.go
@@ -103,48 +103,47 @@ func (fctx *FlowContext) buildDeleteGraph() *flow.Graph {
 }
 
 func (fctx *FlowContext) deleteRouter(ctx context.Context) error {
-	log := shared.LogFromContext(ctx)
-	current, err := fctx.findExistingRouter()
-	if err != nil {
+	routerID := fctx.state.Get(IdentifierRouter)
+	if routerID == nil {
+		return nil
+	}
+
+	shared.LogFromContext(ctx).Info("deleting...", "router", *routerID)
+	if err := fctx.networking.DeleteRouter(*routerID); err != nil {
 		return err
 	}
-	if current != nil {
-		log.Info("deleting...", "router", current.ID)
-		if err := fctx.networking.DeleteRouter(current.ID); err != nil {
-			return err
-		}
-	}
+
+	fctx.state.Set(IdentifierRouter, "")
 	return nil
 }
 
 func (fctx *FlowContext) deleteNetwork(ctx context.Context) error {
-	log := shared.LogFromContext(ctx)
-	current, err := fctx.findExistingNetwork()
-	if err != nil {
+	networkID := fctx.state.Get(IdentifierNetwork)
+	if networkID == nil {
+		return nil
+	}
+
+	shared.LogFromContext(ctx).Info("deleting...", "network", *networkID)
+	if err := fctx.networking.DeleteNetwork(*networkID); err != nil {
 		return err
 	}
-	if current != nil {
-		log.Info("deleting...", "network", current.ID)
-		if err := fctx.networking.DeleteNetwork(current.ID); err != nil {
-			return err
-		}
-	}
+
 	fctx.state.Set(NameNetwork, "")
+	fctx.state.Set(IdentifierNetwork, "")
 	return nil
 }
 
 func (fctx *FlowContext) deleteSubnet(ctx context.Context) error {
-	log := shared.LogFromContext(ctx)
-	current, err := fctx.findExistingSubnet()
-	if err != nil {
+	subnetID := fctx.state.Get(IdentifierSubnet)
+	if subnetID == nil {
+		return nil
+	}
+
+	shared.LogFromContext(ctx).Info("deleting...", "subnet", *subnetID)
+	if err := fctx.networking.DeleteSubnet(*subnetID); err != nil {
 		return err
 	}
-	if current != nil {
-		log.Info("deleting...", "subnet", current.ID)
-		if err := fctx.networking.DeleteSubnet(current.ID); err != nil {
-			return err
-		}
-	}
+	fctx.state.Set(IdentifierSubnet, "")
 	return nil
 }
 

--- a/pkg/controller/infrastructure/infraflow/reconcile.go
+++ b/pkg/controller/infrastructure/infraflow/reconcile.go
@@ -314,7 +314,7 @@ func (fctx *FlowContext) findExistingSubnet() (*subnets.Subnet, error) {
 		return nil, err
 	}
 	if networkID == nil {
-		return nil, fmt.Errorf("network not found")
+		return nil, nil
 	}
 	getByName := func(name string) ([]*subnets.Subnet, error) {
 		return fctx.access.GetSubnetByName(*networkID, name)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/platform openstack

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #https://github.com/gardener/gardener-extension-provider-openstack/issues/890

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Fix an issue where the deletion with the flow reconciler would fail if the network was already deleted.
```
