### PR TITLE
update csi images

### DIFF
--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -86,7 +86,7 @@ images:
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes/cloud-provider-openstack
   repository: registry.k8s.io/provider-os/openstack-cloud-controller-manager
-  tag: "v1.30.1"
+  tag: "v1.30.2"
   targetVersion: "1.30.x"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
@@ -100,7 +100,7 @@ images:
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes/cloud-provider-openstack
   repository: registry.k8s.io/provider-os/openstack-cloud-controller-manager
-  tag: "v1.31.1"
+  tag: "v1.31.2"
   targetVersion: ">= 1.31"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
@@ -199,10 +199,22 @@ images:
 - name: csi-driver-cinder
   sourceRepository: github.com/kubernetes/cloud-provider-openstack
   repository: registry.k8s.io/provider-os/cinder-csi-plugin
-  # TODO(AndreasBurger,kon-angelo): Use v1.31.x image for Kubernetes 1.31
-  # when there is a patch release including a fix for https://github.com/kubernetes/cloud-provider-openstack/issues/2677.
-  tag: "v1.30.1"
-  targetVersion: ">= 1.30"
+  tag: "v1.30.2"
+  targetVersion: "1.30.x"
+  labels:
+    - name: 'gardener.cloud/cve-categorisation'
+      value:
+        network_exposure: 'protected'
+        authentication_enforced: false
+        user_interaction: 'end-user'
+        confidentiality_requirement: 'high'
+        integrity_requirement: 'high'
+        availability_requirement: 'low'
+- name: csi-driver-cinder
+  sourceRepository: github.com/kubernetes/cloud-provider-openstack
+  repository: registry.k8s.io/provider-os/cinder-csi-plugin
+  tag: "v1.31.2"
+  targetVersion: ">= 1.31"
   labels:
     - name: 'gardener.cloud/cve-categorisation'
       value:
@@ -286,7 +298,7 @@ images:
 - name: csi-driver-manila
   sourceRepository: github.com/kubernetes/cloud-provider-openstack
   repository: registry.k8s.io/provider-os/manila-csi-plugin
-  tag: "v1.30.1"
+  tag: "v1.30.2"
   targetVersion: "1.30.x"
   labels:
     - name: 'gardener.cloud/cve-categorisation'
@@ -300,7 +312,7 @@ images:
 - name: csi-driver-manila
   sourceRepository: github.com/kubernetes/cloud-provider-openstack
   repository: registry.k8s.io/provider-os/manila-csi-plugin
-  tag: "v1.31.1"
+  tag: "v1.31.2"
   targetVersion: ">= 1.31"
   labels:
     - name: 'gardener.cloud/cve-categorisation'


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/platform openstack

**What this PR does / why we need it**:
Updates CSI images with the new release that fixes https://github.com/kubernetes/cloud-provider-openstack/issues/2677

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Update Cinder CSI `v1.30.1` -> `v1.30.2` for shoots on v1.30.x
```
```other operator
Update Cinder CSI `v1.30.1` -> `v1.31.2` for shoots on v1.31.x
```
