### PR TITLE
infraflow: Improve "error multiple matches" message

### DIFF
--- a/pkg/controller/infrastructure/infraflow/utils.go
+++ b/pkg/controller/infrastructure/infraflow/utils.go
@@ -33,7 +33,7 @@ func findExisting[T any](id *string, name string,
 		return nil, nil
 	}
 	if len(found) > 1 {
-		return nil, fmt.Errorf("%w: found matches: %v", ErrorMultipleMatches, found)
+		return nil, fmt.Errorf("%w: found %d matches for name %q", ErrorMultipleMatches, len(found), name)
 	}
 	return found[0], nil
 }

--- a/pkg/controller/infrastructure/infraflow/utils.go
+++ b/pkg/controller/infrastructure/infraflow/utils.go
@@ -13,15 +13,14 @@ var ErrorMultipleMatches = fmt.Errorf("error multiple matches")
 
 func findExisting[T any](id *string, name string,
 	getter func(id string) (*T, error),
-	finder func(name string) ([]*T, error),
-	selector ...func(item *T) bool) (*T, error) {
+	finder func(name string) ([]*T, error)) (*T, error) {
 
 	if id != nil {
 		found, err := getter(*id)
 		if err != nil {
 			return nil, err
 		}
-		if found != nil && (len(selector) == 0 || selector[0](found)) {
+		if found != nil {
 			return found, nil
 		}
 	}
@@ -33,23 +32,10 @@ func findExisting[T any](id *string, name string,
 	if len(found) == 0 {
 		return nil, nil
 	}
-	if len(selector) == 0 {
-		if len(found) > 1 {
-			return nil, fmt.Errorf("%w: found matches: %v", ErrorMultipleMatches, found)
-		}
-		return found[0], nil
+	if len(found) > 1 {
+		return nil, fmt.Errorf("%w: found matches: %v", ErrorMultipleMatches, found)
 	}
-
-	var res *T
-	for _, item := range found {
-		if selector[0](item) {
-			if res != nil {
-				return nil, fmt.Errorf("%w: found matches: %v, %v", ErrorMultipleMatches, res, item)
-			}
-			res = item
-		}
-	}
-	return res, nil
+	return found[0], nil
 }
 
 func sliceToPtr[T any](slice []T) []*T {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind cleanup
/platform openstack

**What this PR does / why we need it**:

Cleanup the infraflow error message if multiple matches are found for a name. 

The findExisting helper has a filter parameter, which however is never used. Thus drop it and clean up the error message.
The old code resulted in an error like the following:
`error reconciling infrastructure: 1 error occurred:\n\t* failed to \"ensure security group\": error multiple matches: found matches: [0x123456 0x23456]`. With the change this becomes `error reconciling infrastructure: 1 error occurred:\n\t* failed to \"ensure security group\": error multiple matches: found 2 matches for name "shoot--example--example"`.
