### PR TITLE
Readd support for deploying admission controller in local extensions setup

### DIFF
--- a/charts/gardener-extension-admission-openstack/charts/application/templates/serviceaccount.yaml
+++ b/charts/gardener-extension-admission-openstack/charts/application/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.gardener.virtualCluster.serviceAccount.name }}
+{{- if and .Values.gardener.virtualCluster.enabled ( not .Values.gardener.virtualCluster.serviceAccount.name ) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/gardener-extension-admission-openstack/charts/application/values.yaml
+++ b/charts/gardener-extension-admission-openstack/charts/application/values.yaml
@@ -1,5 +1,6 @@
 gardener:
   virtualCluster:
+    enabled: true
     serviceAccount: {}
 #     name: extension-admission-provider-openstack
 #     namespace: kube-system

--- a/charts/gardener-extension-admission-openstack/charts/runtime/templates/deployment.yaml
+++ b/charts/gardener-extension-admission-openstack/charts/runtime/templates/deployment.yaml
@@ -38,8 +38,12 @@ spec:
         command:
         - /gardener-extension-admission-openstack
         - --webhook-config-server-port={{ .Values.webhookConfig.serverPort }}
+        {{- if .Values.gardener.virtualCluster.enabled }}
         - --webhook-config-mode=url
         - --webhook-config-url={{ printf "%s.%s" (include "name" .) (.Release.Namespace) }}
+        {{- else }}
+        - --webhook-config-mode=service
+        {{- end }}
         - --webhook-config-namespace={{ .Release.Namespace }}
         {{- if .Values.gardener.virtualCluster.namespace }}
         - --webhook-config-owner-namespace={{ .Values.gardener.virtualCluster.namespace }}
@@ -74,8 +78,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        {{- if .Values.gardener.virtualCluster.enabled }}
         - name: SOURCE_CLUSTER
           value: enabled
+        {{- end }}
         ports:
         - name: webhook-server
           containerPort: {{ .Values.webhookConfig.serverPort }}

--- a/charts/gardener-extension-admission-openstack/charts/runtime/values.yaml
+++ b/charts/gardener-extension-admission-openstack/charts/runtime/values.yaml
@@ -30,6 +30,7 @@ service:
 
 gardener:
   virtualCluster:
+    enabled: true
     serviceAccount: {}
   #     name: extension-admission-provider-openstack
   #     namespace: kube-system


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind task
/platform openstack

**What this PR does / why we need it**:
The PR #901 removed the support for deploying the admission controller in the local `provider-extensions` setup.
It is enabled again similar as for the provider-aws.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Follow-up of #901

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
