### PR TITLE
fix: use UDP for upstream DNS by default

### DIFF
--- a/pkg/admission/mutator/shoot.go
+++ b/pkg/admission/mutator/shoot.go
@@ -15,6 +15,7 @@ import (
 	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
@@ -127,6 +128,18 @@ func (s *shoot) Mutate(_ context.Context, newObj, oldObj client.Object) error {
 			Raw: modifiedJSON,
 		}
 	}
+
+	// Disable TCP to upstream DNS queries by default on OpenStack. DNS over TCP may cause performance issues on larger clusters.
+	if shoot.Spec.SystemComponents != nil {
+		if shoot.Spec.SystemComponents.NodeLocalDNS != nil {
+			if shoot.Spec.SystemComponents.NodeLocalDNS.Enabled {
+				if shoot.Spec.SystemComponents.NodeLocalDNS.ForceTCPToUpstreamDNS == nil {
+					shoot.Spec.SystemComponents.NodeLocalDNS.ForceTCPToUpstreamDNS = ptr.To(false)
+				}
+			}
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/admission/mutator/shoot_test.go
+++ b/pkg/admission/mutator/shoot_test.go
@@ -271,5 +271,37 @@ var _ = Describe("Shoot mutator", func() {
 				Expect(shoot).To(DeepEqual(shootExpected))
 			})
 		})
+
+		Context("Mutate shoot NodeLocalDNS default for ForceTCPToUpstreamDNS property", func() {
+			BeforeEach(func() {
+				shoot.Spec.SystemComponents = &gardencorev1beta1.SystemComponents{
+					NodeLocalDNS: &gardencorev1beta1.NodeLocalDNS{
+						Enabled: true,
+					},
+				}
+			})
+
+			It("should not touch the ForceTCPToUpstreamDNS property if NodeLocalDNS is disabled", func() {
+				shoot.Spec.SystemComponents.NodeLocalDNS.Enabled = false
+				err := shootMutator.Mutate(ctx, shoot, nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(shoot.Spec.SystemComponents.NodeLocalDNS.ForceTCPToUpstreamDNS).To(BeNil())
+			})
+
+			It("should not touch the ForceTCPToUpstreamDNS property if it is already set", func() {
+				shoot.Spec.SystemComponents.NodeLocalDNS.ForceTCPToUpstreamDNS = ptr.To(true)
+				err := shootMutator.Mutate(ctx, shoot, nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(shoot.Spec.SystemComponents.NodeLocalDNS.ForceTCPToUpstreamDNS).ToNot(BeNil())
+				Expect(*shoot.Spec.SystemComponents.NodeLocalDNS.ForceTCPToUpstreamDNS).To(BeTrue())
+			})
+
+			It("should set the ForceTCPToUpstreamDNS property to false by default", func() {
+				err := shootMutator.Mutate(ctx, shoot, nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(shoot.Spec.SystemComponents.NodeLocalDNS.ForceTCPToUpstreamDNS).ToNot(BeNil())
+				Expect(*shoot.Spec.SystemComponents.NodeLocalDNS.ForceTCPToUpstreamDNS).To(BeFalse())
+			})
+		})
 	})
 })


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement
/platform openstack

**What this PR does / why we need it**:

In the past there have been issues with using TCP for upstream DNS requests on OpenStack. The infrastructure does not handle lots of TCP connections for DNS queries well and the cluster may run into rate throttling leading to "connection timeout" issues during DNS resolution.

To avoid users having to manually set the `spec.SystemComponents.NodeLocalDNS.ForceTCPToUpstreamDNS` property for OpenStack, this PR sets a default value (false) if the property is not set on the shoot. This will make the shoot use UDP for upstream DNS by default and should prevent the issue from the start.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
Shoots with NodeLocalDNS enabled will use UDP instead of TCP for upstream DNS queries by default to avoid performance issues on Azure.
```
