### PR TITLE
filter terraform output routerIP for v4 addresses only

### DIFF
--- a/pkg/internal/infrastructure/templates/main.tpl.tf
+++ b/pkg/internal/infrastructure/templates/main.tpl.tf
@@ -227,6 +227,12 @@ openstack_networking_network_v2.cluster.name
 data.openstack_networking_network_v2.cluster.name
 {{ end -}}
 {{- end -}}
+
+// Openstack API could return an IPv6 external IP even for v4-only clusters see
+// https://github.com/gardener/gardener-extension-provider-openstack/issues/897
+// We filter for IPs that match the v4 pattern (4 numbers seperated by dots)
+// and only return one just in case there are mulitple as the rest of the
+// codebase is currently expecting a single v4 IP
 {{- define "router-ip" -}}
 {{ if .create.router -}}
 one([for external_fixed_ip in openstack_networking_router_v2.router.external_fixed_ip : external_fixed_ip.ip_address if can(regex("^(?:[0-9]{1,3}\\.){3}[0-9]{1,3}$", external_fixed_ip.ip_address))])

--- a/pkg/internal/infrastructure/templates/main.tpl.tf
+++ b/pkg/internal/infrastructure/templates/main.tpl.tf
@@ -229,8 +229,8 @@ data.openstack_networking_network_v2.cluster.name
 {{- end -}}
 {{- define "router-ip" -}}
 {{ if .create.router -}}
-openstack_networking_router_v2.router.external_fixed_ip[0].ip_address
+one([for external_fixed_ip in openstack_networking_router_v2.router.external_fixed_ip : external_fixed_ip.ip_address if can(regex("^(?:[0-9]{1,3}\\.){3}[0-9]{1,3}$", external_fixed_ip.ip_address))])
 {{ else -}}
-data.openstack_networking_router_v2.router.external_fixed_ip[0].ip_address
+one([for external_fixed_ip in data.openstack_networking_router_v2.router.external_fixed_ip : external_fixed_ip.ip_address if can(regex("^(?:[0-9]{1,3}\\.){3}[0-9]{1,3}$", external_fixed_ip.ip_address))])
 {{ end -}}
 {{- end -}}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug
/platform openstack

**What this PR does / why we need it**:
As described in the issue, openstack routers expose a list of external IPs, and those could be v6 even if the rest of the networking stack is v4 only. This will filter terraform output `routerIP` for v4 addresses only and return only one of them just in case there could still be multiple, since the rest of the code currently expects a single v4 IP

**Which issue(s) this PR fixes**:
Fixes #897

**Special notes for your reviewer**:
I purposefully avoided changing the API and properly handling and forwarding lists of IPs for now. I expect there is a proper v6/dualstack PR coming anyway that will need to handle this cleanly. This minimal change unblocks us for further gardener upgrades, so I wanted to share it. I can see why you would not want to merge it in favor of a proper solution. I'm happy to give this PR a little bit more love with feedback, but I don't want to waste anybodies time if this is not the right direction long-term, which I could totally understand.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
