### PR TITLE
fix(worker): select computeClient based on region

### DIFF
--- a/pkg/controller/worker/machine_dependencies.go
+++ b/pkg/controller/worker/machine_dependencies.go
@@ -30,7 +30,7 @@ func (w *workerDelegate) CleanupMachineDependencies(_ context.Context) error {
 
 // PreReconcileHook implements genericactuator.WorkerDelegate.
 func (w *workerDelegate) PreReconcileHook(ctx context.Context) error {
-	computeClient, err := w.openstackClient.Compute()
+	computeClient, err := w.openstackClient.Compute(osclient.WithRegion(w.worker.Spec.Region))
 	if err != nil {
 		return err
 	}
@@ -119,7 +119,7 @@ func (w *workerDelegate) PostDeleteHook(ctx context.Context) error {
 // Refactor this so that PostDeleteHook executes only the handling for Worker being deleted and PostReconcileHook executes only
 // the handling for Worker reconciled (not being deleted).
 func (w *workerDelegate) cleanupMachineDependencies(ctx context.Context) error {
-	computeClient, err := w.openstackClient.Compute()
+	computeClient, err := w.openstackClient.Compute(osclient.WithRegion(w.worker.Spec.Region))
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/worker/machine_dependencies_test.go
+++ b/pkg/controller/worker/machine_dependencies_test.go
@@ -76,7 +76,7 @@ var _ = Describe("#MachineDependencies", func() {
 					Namespace: namespace,
 				},
 			}
-			osFactory.EXPECT().Compute().AnyTimes().Return(computeClient, nil)
+			osFactory.EXPECT().Compute(gomock.Any()).AnyTimes().Return(computeClient, nil)
 		})
 
 		Context("#PreReconcileHook", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area os
/kind bug
/platform openstack

**What this PR does / why we need it**:
Worker controller should select compute endpoints based on Region instead of picking the first `public` endpoint.

**Which issue(s) this PR fixes**:
Fixes #801 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Correctly select endpoints in multi-region OpenStack environments
```
