### PR TITLE
Switch Slack references to Gardener workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,9 @@ Static code checks and tests can be executed by running `make verify`. We are us
 
 ## Feedback and Support
 
-Feedback and contributions are always welcome. Please report bugs or suggestions as [GitHub issues](https://github.com/gardener/gardener-extension-provider-openstack/issues) or join our [Slack channel #gardener](https://kubernetes.slack.com/messages/gardener) (please invite yourself to the Kubernetes workspace [here](http://slack.k8s.io)).
+Feedback and contributions are always welcome!
+
+Please report bugs or suggestions as [GitHub issues](https://github.com/gardener/gardener-extension-provider-openstack/issues) or reach out on [Slack](https://gardener-cloud.slack.com/) (join the workspace [here](https://gardener.cloud/community/community-bio/)).
 
 ## Learn more!
 


### PR DESCRIPTION
/kind enhancement
/area open-source

**What this PR does / why we need it**:

This PR switches all Slack references to the dedicated Gardener Project workspace.

**Which issue(s) this PR fixes**:

Part of https://github.com/gardener/documentation/issues/606

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
