### PR TITLE
Fix cloudProfile validation

### DIFF
--- a/pkg/apis/openstack/validation/cloudprofile.go
+++ b/pkg/apis/openstack/validation/cloudprofile.go
@@ -239,17 +239,21 @@ func validateMachineImageMapping(machineImages []core.MachineImage, cpConfig *ap
 					))
 					continue
 				}
-				// validate that machine image version with architecture x exists in cpConfig
-				architecturesMap := utils.CreateMapFromSlice(imageVersion.Regions, func(re api.RegionIDMapping) string {
-					return ptr.Deref(re.Architecture, v1beta1constants.ArchitectureAMD64)
-				})
-				architectures := slices.Collect(maps.Keys(architecturesMap))
-				if !slices.Contains(architectures, expectedArchitecture) {
-					allErrs = append(allErrs, field.Required(machineImageVersionPath,
-						fmt.Sprintf("missing providerConfig mapping for machine image version %s@%s and architecture: %s",
-							machineImage.Name, version.Version, expectedArchitecture),
-					))
-					continue
+
+				// Regions is an optional field
+				if len(imageVersion.Regions) > 0 {
+					// validate that machine image version with architecture x exists in cpConfig
+					architecturesMap := utils.CreateMapFromSlice(imageVersion.Regions, func(re api.RegionIDMapping) string {
+						return ptr.Deref(re.Architecture, v1beta1constants.ArchitectureAMD64)
+					})
+					architectures := slices.Collect(maps.Keys(architecturesMap))
+					if !slices.Contains(architectures, expectedArchitecture) {
+						allErrs = append(allErrs, field.Required(machineImageVersionPath,
+							fmt.Sprintf("missing providerConfig mapping for machine image version %s@%s and architecture: %s",
+								machineImage.Name, version.Version, expectedArchitecture),
+						))
+						continue
+					}
 				}
 			}
 		}

--- a/pkg/apis/openstack/validation/cloudprofile_test.go
+++ b/pkg/apis/openstack/validation/cloudprofile_test.go
@@ -361,6 +361,12 @@ var _ = Describe("CloudProfileConfig validation", func() {
 				Expect(errorList).To(BeEmpty())
 			})
 
+			It("should pass validation even without regions in the machineImage version", func() {
+				cloudProfileConfig.MachineImages[0].Versions[0].Regions = nil
+				errorList := ValidateCloudProfileConfig(cloudProfileConfig, machineImages, fldPath)
+				Expect(errorList).To(BeEmpty())
+			})
+
 			It("should enforce that at least one machine image has been defined", func() {
 				cloudProfileConfig.MachineImages = []api.MachineImages{}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug
/platform openstack

**What this PR does / why we need it**:
The `CloudProfileConfig.machineImages[].versions[].regions[]` field is optional and can be empty.
We need to adjust our validation. 

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener-extension-provider-openstack/issues/1021

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fix CloudProfile validation in case `CloudProfileConfig.machineImages[].versions[].regions[]` is empty
```
