### PR TITLE
Add `CCM` and `csi-driver-{cinder,manila}` v1.32.0 images

### DIFF
--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -73,7 +73,21 @@ images:
   sourceRepository: github.com/kubernetes/cloud-provider-openstack
   repository: registry.k8s.io/provider-os/openstack-cloud-controller-manager
   tag: "v1.31.3"
-  targetVersion: ">= 1.31"
+  targetVersion: "1.31.x"
+  labels:
+  - name: 'gardener.cloud/cve-categorisation'
+    value:
+      network_exposure: 'protected'
+      authentication_enforced: false
+      user_interaction: 'gardener-operator'
+      confidentiality_requirement: 'high'
+      integrity_requirement: 'high'
+      availability_requirement: 'low'
+- name: cloud-controller-manager
+  sourceRepository: github.com/kubernetes/cloud-provider-openstack
+  repository: registry.k8s.io/provider-os/openstack-cloud-controller-manager
+  tag: "v1.32.0"
+  targetVersion: ">= 1.32"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:
@@ -158,7 +172,21 @@ images:
   sourceRepository: github.com/kubernetes/cloud-provider-openstack
   repository: registry.k8s.io/provider-os/cinder-csi-plugin
   tag: "v1.31.3"
-  targetVersion: ">= 1.31"
+  targetVersion: "1.31.x"
+  labels:
+    - name: 'gardener.cloud/cve-categorisation'
+      value:
+        network_exposure: 'protected'
+        authentication_enforced: false
+        user_interaction: 'end-user'
+        confidentiality_requirement: 'high'
+        integrity_requirement: 'high'
+        availability_requirement: 'low'
+- name: csi-driver-cinder
+  sourceRepository: github.com/kubernetes/cloud-provider-openstack
+  repository: registry.k8s.io/provider-os/cinder-csi-plugin
+  tag: "v1.32.0"
+  targetVersion: ">= 1.32"
   labels:
     - name: 'gardener.cloud/cve-categorisation'
       value:
@@ -229,7 +257,21 @@ images:
   sourceRepository: github.com/kubernetes/cloud-provider-openstack
   repository: registry.k8s.io/provider-os/manila-csi-plugin
   tag: "v1.31.3"
-  targetVersion: ">= 1.31"
+  targetVersion: "1.31.x"
+  labels:
+    - name: 'gardener.cloud/cve-categorisation'
+      value:
+        network_exposure: 'protected'
+        authentication_enforced: false
+        user_interaction: 'end-user'
+        confidentiality_requirement: 'high'
+        integrity_requirement: 'high'
+        availability_requirement: 'low'
+- name: csi-driver-manila
+  sourceRepository: github.com/kubernetes/cloud-provider-openstack
+  repository: registry.k8s.io/provider-os/manila-csi-plugin
+  tag: "v1.32.0"
+  targetVersion: ">= 1.32"
   labels:
     - name: 'gardener.cloud/cve-categorisation'
       value:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->

/area open-source usability
/kind enhancement
/platform openstack
/exp intermediate
/topology shoot
/merge squash

**What this PR does / why we need it**:
When the [PR to add support for Kubernetes 1.32](https://github.com/gardener/gardener-extension-provider-openstack/pull/969) was added, the CCM and `csi-driver-{cinder,manila}` v1.32.0 images were still not released.
In the end they were never added to the `images.yaml` file. 

This PR adds the expected v1.32.0 versions of these components

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/11020

**Special notes for your reviewer**:
I will rerun the tests that were done in https://github.com/gardener/gardener-extension-provider-openstack/pull/969

- [x] Create new clusters with versions < 1.32
- [x] Create new clusters with version = 1.32
- [x] Upgrade old clusters from version 1.31 to version 1.32
- [x] Delete clusters with versions < 1.32
- [x] Delete clusters with version = 1.32
 
**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The provider-openstack extension now deploys the openstack `cloud-controller-manager`, `csi-driver-cinder` and `csi-driver-manila` images with version `v1.32.0` for shoot clusters with Kubernetes version 1.32+.
```
