### PR TITLE
Fix auth with ApplicationCredential Name

### DIFF
--- a/pkg/openstack/client/client.go
+++ b/pkg/openstack/client/client.go
@@ -33,10 +33,15 @@ func NewOpenstackClientFromCredentials(ctx context.Context, credentials *os.Cred
 		AllowReauth: true,
 	}
 
+	// according to: https://docs.openstack.org/keystone/2023.1/user/application_credentials.html#using-application-credentials
 	if credentials.ApplicationCredentialID != "" {
 		authOpts.ApplicationCredentialID = credentials.ApplicationCredentialID
+		authOpts.ApplicationCredentialSecret = credentials.ApplicationCredentialSecret
+	} else if credentials.ApplicationCredentialName != "" {
 		authOpts.ApplicationCredentialName = credentials.ApplicationCredentialName
 		authOpts.ApplicationCredentialSecret = credentials.ApplicationCredentialSecret
+		authOpts.Username = credentials.Username
+		authOpts.DomainName = credentials.DomainName
 	} else {
 		authOpts.Username = credentials.Username
 		authOpts.Password = credentials.Password


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind regression
/platform openstack

**What this PR does / why we need it**:
Enable appCredential authentication using AppName in addition to appID.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener-extension-provider-openstack/issues/1069

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Enable appCredential authentication using AppName in addition to appID
```
