### PR TITLE
Fix failure because of race conditions for `update-resolv-conf.service`

### DIFF
--- a/pkg/webhook/controlplane/ensurer.go
+++ b/pkg/webhook/controlplane/ensurer.go
@@ -239,6 +239,8 @@ StartLimitIntervalSec=0
 [Service]
 Type=oneshot
 ExecStart=/opt/bin/update-resolv-conf.sh
+RestartForceExitStatus=10
+RestartSec=15
 `
 	)
 
@@ -283,6 +285,10 @@ is_systemd_resolved_system()
       return 1
     fi
 }
+
+if grep -q "# No DNS servers known." /run/systemd/resolve/resolv.conf; then
+  exit 10
+fi
 
 rm -f "$tmp"
 if is_systemd_resolved_system; then

--- a/pkg/webhook/controlplane/ensurer.go
+++ b/pkg/webhook/controlplane/ensurer.go
@@ -239,7 +239,7 @@ StartLimitIntervalSec=0
 [Service]
 Type=oneshot
 ExecStart=/opt/bin/update-resolv-conf.sh
-RestartForceExitStatus=10
+RestartForceExitStatus=78
 RestartSec=15
 `
 	)
@@ -287,7 +287,7 @@ is_systemd_resolved_system()
 }
 
 if ! grep -Eq "^nameserver\s+" /run/systemd/resolve/resolv.conf; then
-  exit 10
+  exit 78
 fi
 
 rm -f "$tmp"

--- a/pkg/webhook/controlplane/ensurer.go
+++ b/pkg/webhook/controlplane/ensurer.go
@@ -286,7 +286,7 @@ is_systemd_resolved_system()
     fi
 }
 
-if grep -q "# No DNS servers known." /run/systemd/resolve/resolv.conf; then
+if ! grep -Eq "^nameserver\s+" /run/systemd/resolve/resolv.conf; then
   exit 10
 fi
 

--- a/pkg/webhook/controlplane/ensurer_test.go
+++ b/pkg/webhook/controlplane/ensurer_test.go
@@ -56,7 +56,7 @@ is_systemd_resolved_system()
 }
 
 if ! grep -Eq "^nameserver\s+" /run/systemd/resolve/resolv.conf; then
-  exit 10
+  exit 78
 fi
 
 rm -f "$tmp"
@@ -354,7 +354,7 @@ StartLimitIntervalSec=0
 [Service]
 Type=oneshot
 ExecStart=/opt/bin/update-resolv-conf.sh
-RestartForceExitStatus=10
+RestartForceExitStatus=78
 RestartSec=15
 `
 

--- a/pkg/webhook/controlplane/ensurer_test.go
+++ b/pkg/webhook/controlplane/ensurer_test.go
@@ -55,7 +55,7 @@ is_systemd_resolved_system()
     fi
 }
 
-if grep -q "# No DNS servers known." /run/systemd/resolve/resolv.conf; then
+if ! grep -Eq "^nameserver\s+" /run/systemd/resolve/resolv.conf; then
   exit 10
 fi
 

--- a/pkg/webhook/controlplane/ensurer_test.go
+++ b/pkg/webhook/controlplane/ensurer_test.go
@@ -55,6 +55,10 @@ is_systemd_resolved_system()
     fi
 }
 
+if grep -q "# No DNS servers known." /run/systemd/resolve/resolv.conf; then
+  exit 10
+fi
+
 rm -f "$tmp"
 if is_systemd_resolved_system; then
   if [ "$line" = "" ]; then
@@ -350,6 +354,8 @@ StartLimitIntervalSec=0
 [Service]
 Type=oneshot
 ExecStart=/opt/bin/update-resolv-conf.sh
+RestartForceExitStatus=10
+RestartSec=15
 `
 
 			customPathContent = `[Path]


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind bug
/platform openstack

**What this PR does / why we need it**:
The starting of `update-resolv-conf.path` can happen after the update of `/run/systemd/resolve/resolv.conf` with the valid configuration. The following has been observed where the file has been updated 4 sec before the start of `update-resolv-conf.path`:
```
cat /etc/resolv-for-kubelet.conf
# This is /run/systemd/resolve/resolv.conf managed by man:systemd-resolved(8).
# Do not edit.
#
# This file might be symlinked as /etc/resolv.conf. If you're looking at
# /etc/resolv.conf and seeing this text, you have followed the symlink.
#
# This is a dynamic resolv.conf file for connecting local clients directly to
# all known uplink DNS servers. This file lists all configured search domains.
#
# Third party programs should typically not access this file directly, but only
# through the symlink at /etc/resolv.conf. To manage man:resolv.conf(5) in a
# different way, replace this symlink by a static file or a different symlink.
#
# See man:systemd-resolved.service(8) for details about the supported modes of
# operation for /etc/resolv.conf.

# No DNS servers known.
search .

# updated by update-resolv-conf.service (installed by gardener-extension-provider-openstack)
options rotate timeout:1
```
instead of:
```
cat /etc/resolv.conf
# This is /run/systemd/resolve/resolv.conf managed by man:systemd-resolved(8).
# Do not edit.
#
# This file might be symlinked as /etc/resolv.conf. If you're looking at
# /etc/resolv.conf and seeing this text, you have followed the symlink.
#
# This is a dynamic resolv.conf file for connecting local clients directly to
# all known uplink DNS servers. This file lists all configured search domains.
#
# Third party programs should typically not access this file directly, but only
# through the symlink at /etc/resolv.conf. To manage man:resolv.conf(5) in a
# different way, replace this symlink by a static file or a different symlink.
#
# See man:systemd-resolved.service(8) for details about the supported modes of
# operation for /etc/resolv.conf.

nameserver 10.191.8.2
nameserver 10.191.8.3
search <name>

# updated by update-resolv-conf.service (installed by gardener-extension-provider-openstack)
options rotate timeout:1
```
This can lead to calico and other components' downtime because of faulty DNS resolution.

**Which issue(s) this PR fixes**:
Fixes #782 

**Special notes for your reviewer**:
/cc @Kostov6 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
