### PR TITLE
swap defaults for flow

### DIFF
--- a/pkg/webhook/infrastructure/mutator.go
+++ b/pkg/webhook/infrastructure/mutator.go
@@ -37,7 +37,7 @@ func New(mgr manager.Manager, logger logr.Logger) extensionswebhook.Mutator {
 
 // Mutate mutates the given object on creation and adds the annotation `openstack.provider.extensions.gardener.cloud/use-flow=true`
 // if the seed has the label `openstack.provider.extensions.gardener.cloud/use-flow` == `new`.
-func (m *mutator) Mutate(ctx context.Context, newObj, oldObj client.Object) error {
+func (m *mutator) Mutate(ctx context.Context, newObj, _ client.Object) error {
 	if newObj.GetDeletionTimestamp() != nil {
 		return nil
 	}
@@ -79,14 +79,10 @@ func (m *mutator) Mutate(ctx context.Context, newObj, oldObj client.Object) erro
 	} else if v, ok := cluster.Shoot.Annotations[openstack.AnnotationKeyUseFlow]; ok {
 		newInfra.Annotations[openstack.AnnotationKeyUseFlow] = v
 		mutated = true
-	} else if oldObj == nil && cluster.Seed.Annotations[openstack.SeedAnnotationKeyUseFlow] == openstack.SeedAnnotationUseFlowValueNew {
-		newInfra.Annotations[openstack.AnnotationKeyUseFlow] = "true"
-		mutated = true
-	} else if v := cluster.Seed.Annotations[openstack.SeedAnnotationKeyUseFlow]; strings.EqualFold(v, "true") {
+	} else if v := cluster.Seed.Annotations[openstack.SeedAnnotationKeyUseFlow]; !strings.EqualFold(v, "false") {
 		newInfra.Annotations[openstack.AnnotationKeyUseFlow] = "true"
 		mutated = true
 	}
-
 	if mutated {
 		extensionswebhook.LogMutation(logger, newInfra.Kind, newInfra.Namespace, newInfra.Name)
 	}

--- a/pkg/webhook/infrastructure/mutator_test.go
+++ b/pkg/webhook/infrastructure/mutator_test.go
@@ -158,8 +158,8 @@ var _ = Describe("Mutate", func() {
 		})
 
 		Context("update", func() {
-			It("should do nothing if seed annotation use-flow is only for new shoots", func() {
-				cluster.Seed.Annotations[openstack.SeedAnnotationKeyUseFlow] = openstack.SeedAnnotationUseFlowValueNew
+			It("should not mutate the seed if seed annotation is set to false", func() {
+				cluster.Seed.Annotations[openstack.SeedAnnotationKeyUseFlow] = "false"
 				newInfra := &extensionsv1alpha1.Infrastructure{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "dummy",
@@ -169,6 +169,17 @@ var _ = Describe("Mutate", func() {
 				err := mutator.Mutate(ctx, newInfra, newInfra)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(newInfra.Annotations[openstack.AnnotationKeyUseFlow]).To(Equal(""))
+			})
+			It("should mutate the seed if seed annotation is not set to false", func() {
+				newInfra := &extensionsv1alpha1.Infrastructure{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "dummy",
+						Namespace: shootNamespace,
+					},
+				}
+				err := mutator.Mutate(ctx, newInfra, newInfra)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(newInfra.Annotations[openstack.AnnotationKeyUseFlow]).To(Equal("true"))
 			})
 
 			It("should mutate if seed annotation is set to all shoots", func() {

--- a/test/integration/infrastructure/infrastructure_test.go
+++ b/test/integration/infrastructure/infrastructure_test.go
@@ -59,6 +59,7 @@ const (
 	reconcilerMigrateTF    string = "migrate"
 	reconcilerUseFlow      string = "flow"
 	reconcilerRecoverState string = "recover"
+	kindInfrastructure            = "Infrastructure"
 )
 
 const (
@@ -76,7 +77,7 @@ var (
 	appID            = flag.String("app-id", "", "Application Credential ID for openstack")
 	appName          = flag.String("app-name", "", "Application Credential Name for openstack")
 	appSecret        = flag.String("app-secret", "", "Application Credential Secret for openstack")
-	reconciler       = flag.String("reconciler", reconcilerUseTF, "Set annotation to use flow for reconciliation")
+	reconciler       = flag.String("reconciler", reconcilerUseFlow, "Set annotation to use flow for reconciliation")
 
 	floatingPoolID string
 )
@@ -468,7 +469,7 @@ func runTest(
 		c,
 		log,
 		infra,
-		"Infrastucture",
+		kindInfrastructure,
 		10*time.Second,
 		6*time.Minute,
 		16*time.Minute,
@@ -478,7 +479,7 @@ func runTest(
 	// Update the infra resource to trigger a migration.
 	oldState := infra.Status.State.DeepCopy()
 	switch *reconciler {
-	case reconcilerUseTF:
+	case reconcilerMigrateTF:
 		By("verifying terraform migration")
 		patch := client.MergeFrom(infra.DeepCopy())
 		metav1.SetMetaDataAnnotation(&infra.ObjectMeta, v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile)
@@ -507,7 +508,7 @@ func runTest(
 		c,
 		log,
 		infra,
-		"Infrastucture",
+		kindInfrastructure,
 		10*time.Second,
 		30*time.Second,
 		16*time.Minute,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement
/platform openstack

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
Update the defaults for the infrastructure controller. Unless opted out per shoot or per seed, the infrastructure controller will now by default reconcile using the flow implementation. In future release v1.50.0 we will disable reconciliation via terraform. 
```
