### PR TITLE
trust pullrequest based on `reviewed/ok-to-test`-label

### DIFF
--- a/.github/workflows/non-release.yaml
+++ b/.github/workflows/non-release.yaml
@@ -2,9 +2,16 @@ name: Build
 on:
   push:
   pull_request_target:
+    types:
+      - labeled
 
 jobs:
   build:
+    # only run if run was triggered by either:
+    # - head-update (push to local branch)
+    # - pullrequest-label `reviewed/ok-to-test` was added
+    # (the latter label is hardcoded in gardener/cc-utils's trusted-checkout action)
+    if: ${{ github.event.action != 'labeled' || github.event.label.name == 'reviewed/ok-to-test' }}
     uses: ./.github/workflows/build.yaml
     with:
       mode: snapshot
@@ -13,6 +20,7 @@ jobs:
       contents: write
       packages: write
       id-token: write
+      pull-requests: write
 
   component-descriptor:
     uses: gardener/cc-utils/.github/workflows/post-build.yaml@master


### PR DESCRIPTION
In order to allow running pullrequests w/ elevated privileges (pushing images + triggering test-machinery-runs), switch trigger for pullrequests to `labeled`-event.

As a result, pullrequests will only be run after the `reviewed/ok-to-test`-label has been set. However, this will happen, regardless of pullrequest-author's association (e.g. also for first-time-contributors).

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area TODO
/kind TODO
/platform openstack

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
