### PR TITLE
Remove deprecated storage class nsf-constraint-<zone>

### DIFF
--- a/charts/internal/shoot-system-components/charts/csi-driver-manila/templates/storageclass.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-manila/templates/storageclass.yaml
@@ -82,38 +82,3 @@ parameters:
   csi.storage.k8s.io/controller-expand-secret-name: manila-csi-plugin
   csi.storage.k8s.io/controller-expand-secret-namespace: {{ $.Release.Namespace }}
 {{ end }}
-
-{{- range .Values.openstack.availabilityZones }}
----
-apiVersion: storage.k8s.io/v1
-kind: StorageClass
-metadata:
-  annotations:
-    resources.gardener.cloud/delete-on-invalid-update: "true"
-  name: csi-manila-nfs-constrain-{{ . }}
-provisioner: nfs.manila.csi.openstack.org
-allowVolumeExpansion: true
-volumeBindingMode: WaitForFirstConsumer
-{{- if $.Values.csimanila.mountOptions }}
-mountOptions:
-{{ toYaml $.Values.csimanila.mountOptions | indent 2 }}
-{{- end }}
-allowedTopologies:
-- matchLabelExpressions:
-  - key: topology.manila.csi.openstack.org/zone
-    values:
-      - "{{ . }}"
-parameters:
-  type: default
-  availability: {{ required "openstack.availabilityZones needs to be set" . }}
-  shareNetworkID: {{ $.Values.openstack.shareNetworkID }}
-  nfs-shareClient: {{ required "openstack.shareClient needs to be set" $.Values.openstack.shareClient }}
-  csi.storage.k8s.io/provisioner-secret-name: manila-csi-plugin
-  csi.storage.k8s.io/provisioner-secret-namespace: {{ $.Release.Namespace }}
-  csi.storage.k8s.io/node-stage-secret-name: manila-csi-plugin
-  csi.storage.k8s.io/node-stage-secret-namespace: {{ $.Release.Namespace }}
-  csi.storage.k8s.io/node-publish-secret-name: manila-csi-plugin
-  csi.storage.k8s.io/node-publish-secret-namespace: {{ $.Release.Namespace }}
-  csi.storage.k8s.io/controller-expand-secret-name: manila-csi-plugin
-  csi.storage.k8s.io/controller-expand-secret-namespace: {{ $.Release.Namespace }}
-{{ end }}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind cleanup
/platform openstack

**What this PR does / why we need it**:
Remove deprecated storage class nsf-constraint-<zone> for manila-csi-driver.
They were a workaround to like auto before the feature was available.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Remove deprecated storage class nsf-constraint-<zone> for manila-csi-driver
```
