### PR TITLE
Add Manila Storage Classes documentation

### DIFF
--- a/docs/usage/usage.md
+++ b/docs/usage/usage.md
@@ -138,8 +138,16 @@ If you don't want to configure anything for the `cloudControllerManager` simply 
 
 The optional `storage.csiManila.enabled` field is used to enable the deployment of the CSI Manila driver to support NFS persistent volumes.
 In this case, please ensure to set `networks.shareNetwork.enabled=true` in the `InfrastructureConfig`, too.
-Additionally, if CSI Manila driver is enabled, for each availability zone a NFS `StorageClass` will be created on the shoot 
-named like `csi-manila-nfs-<zone>`.
+Additionally, if CSI Manila driver is enabled, several StorageClasses are deployed:
+- `csi-manila-nfs`: 
+  - Useful if you don’t care about which AZ the volume lands in, e.g. small clusters or test workloads.
+  - This StorageClass is not tied to a specific availability zone.
+- `csi-manila-nfs-auto`:
+  - `autoTopology: "true"` -> Driver automatically decides AZ.
+  - Similar to `csi-manila-nfs`, but the CSI driver automatically chooses the best availability zone based on where the pod is scheduled.
+- `csi-manila-nfs-<zone>`:
+  - `availability: <zone>` -> Each AZ gets its own StorageClass.
+  - Useful for workloads that should live in a specific AZ for performance, latency, or regulatory reasons.
 
 ## `WorkerConfig`
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind enhancement
/platform openstack

**What this PR does / why we need it**:
If CSI Manila driver is enabled several Storage Classes are deployd.
We should document them.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other doc
Add CSI Manila driver storage classes documentation
```
