### PR TITLE
Only check systemd resolv.conf if it exists

### DIFF
--- a/pkg/webhook/controlplane/ensurer.go
+++ b/pkg/webhook/controlplane/ensurer.go
@@ -286,12 +286,12 @@ is_systemd_resolved_system()
     fi
 }
 
-if ! grep -Eq "^nameserver\s+" /run/systemd/resolve/resolv.conf; then
-  exit 78
-fi
-
 rm -f "$tmp"
 if is_systemd_resolved_system; then
+  if ! grep -Eq "^nameserver\s+" /run/systemd/resolve/resolv.conf; then
+    echo "/run/systemd/resolve/resolv.conf does not contain a nameserver line, delaying update..."
+    exit 78
+  fi
   if [ "$line" = "" ]; then
     ln -s /run/systemd/resolve/resolv.conf "$tmp"
   else

--- a/pkg/webhook/controlplane/ensurer_test.go
+++ b/pkg/webhook/controlplane/ensurer_test.go
@@ -55,12 +55,12 @@ is_systemd_resolved_system()
     fi
 }
 
-if ! grep -Eq "^nameserver\s+" /run/systemd/resolve/resolv.conf; then
-  exit 78
-fi
-
 rm -f "$tmp"
 if is_systemd_resolved_system; then
+  if ! grep -Eq "^nameserver\s+" /run/systemd/resolve/resolv.conf; then
+    echo "/run/systemd/resolve/resolv.conf does not contain a nameserver line, delaying update..."
+    exit 78
+  fi
   if [ "$line" = "" ]; then
     ln -s /run/systemd/resolve/resolv.conf "$tmp"
   else


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind enhancement
/platform openstack

**What this PR does / why we need it**:

Only check systemd resolv.conf if it exists.

#1085 introduced the nameserver check unconditionally. However, the script supposedly also works without systemd. Hence, the check should only happen if the configuration file exists.

Furthermore, this adds a log entry in case no nameserver is found.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
