### PR TITLE
Adapt the retry logic for the resolv.conf copy script to deal with ancient systemd releases.

### DIFF
--- a/pkg/webhook/controlplane/ensurer.go
+++ b/pkg/webhook/controlplane/ensurer.go
@@ -239,8 +239,6 @@ StartLimitIntervalSec=0
 [Service]
 Type=oneshot
 ExecStart=/opt/bin/update-resolv-conf.sh
-RestartForceExitStatus=78
-RestartSec=15
 `
 	)
 
@@ -288,10 +286,10 @@ is_systemd_resolved_system()
 
 rm -f "$tmp"
 if is_systemd_resolved_system; then
-  if ! grep -Eq "^nameserver\s+" /run/systemd/resolve/resolv.conf; then
+  while ! grep -Eq "^nameserver\s+" /run/systemd/resolve/resolv.conf; do
     echo "/run/systemd/resolve/resolv.conf does not contain a nameserver line, delaying update..."
-    exit 78
-  fi
+    sleep 15
+  done
   if [ "$line" = "" ]; then
     ln -s /run/systemd/resolve/resolv.conf "$tmp"
   else

--- a/pkg/webhook/controlplane/ensurer_test.go
+++ b/pkg/webhook/controlplane/ensurer_test.go
@@ -57,10 +57,10 @@ is_systemd_resolved_system()
 
 rm -f "$tmp"
 if is_systemd_resolved_system; then
-  if ! grep -Eq "^nameserver\s+" /run/systemd/resolve/resolv.conf; then
+  while ! grep -Eq "^nameserver\s+" /run/systemd/resolve/resolv.conf; do
     echo "/run/systemd/resolve/resolv.conf does not contain a nameserver line, delaying update..."
-    exit 78
-  fi
+    sleep 15
+  done
   if [ "$line" = "" ]; then
     ln -s /run/systemd/resolve/resolv.conf "$tmp"
   else
@@ -354,8 +354,6 @@ StartLimitIntervalSec=0
 [Service]
 Type=oneshot
 ExecStart=/opt/bin/update-resolv-conf.sh
-RestartForceExitStatus=78
-RestartSec=15
 `
 
 			customPathContent = `[Path]


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement
/platform openstack

**What this PR does / why we need it**:

Adapt the retry logic for the resolv.conf copy script to deal with ancient systemd releases.

Some dated linux distributions use old systemd releases, which do not allow units to specify RestartForceExitStatus and Type=oneshot to be set at the same time. To allow the systemd unit to be executed also in those systems we use the less elegant solution using a loop.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

The corresponding error message from a node prior to this change:

```
# journalctl -u update-resolv-conf.service
Sep 25 14:01:08 shoot--my-project--shoot-worker-r4575-z1-79dd4-j8dsl systemd[1]: update-resolv-conf.service: Service has RestartForceExitStatus= set, which isn't allowed for Type=oneshot services. Refusing.
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
