### PR TITLE
[release-v1.49] Automated cherry pick of #1161: Adapt the retry logic for the resolv.conf copy script to deal with ancient systemd releases.

### DIFF
--- a/pkg/webhook/controlplane/ensurer.go
+++ b/pkg/webhook/controlplane/ensurer.go
@@ -239,8 +239,6 @@ StartLimitIntervalSec=0
 [Service]
 Type=oneshot
 ExecStart=/opt/bin/update-resolv-conf.sh
-RestartForceExitStatus=78
-RestartSec=15
 `
 	)
 
@@ -288,10 +286,10 @@ is_systemd_resolved_system()
 
 rm -f "$tmp"
 if is_systemd_resolved_system; then
-  if ! grep -Eq "^nameserver\s+" /run/systemd/resolve/resolv.conf; then
+  while ! grep -Eq "^nameserver\s+" /run/systemd/resolve/resolv.conf; do
     echo "/run/systemd/resolve/resolv.conf does not contain a nameserver line, delaying update..."
-    exit 78
-  fi
+    sleep 15
+  done
   if [ "$line" = "" ]; then
     ln -s /run/systemd/resolve/resolv.conf "$tmp"
   else

--- a/pkg/webhook/controlplane/ensurer_test.go
+++ b/pkg/webhook/controlplane/ensurer_test.go
@@ -57,10 +57,10 @@ is_systemd_resolved_system()
 
 rm -f "$tmp"
 if is_systemd_resolved_system; then
-  if ! grep -Eq "^nameserver\s+" /run/systemd/resolve/resolv.conf; then
+  while ! grep -Eq "^nameserver\s+" /run/systemd/resolve/resolv.conf; do
     echo "/run/systemd/resolve/resolv.conf does not contain a nameserver line, delaying update..."
-    exit 78
-  fi
+    sleep 15
+  done
   if [ "$line" = "" ]; then
     ln -s /run/systemd/resolve/resolv.conf "$tmp"
   else
@@ -354,8 +354,6 @@ StartLimitIntervalSec=0
 [Service]
 Type=oneshot
 ExecStart=/opt/bin/update-resolv-conf.sh
-RestartForceExitStatus=78
-RestartSec=15
 `
 
 			customPathContent = `[Path]


### PR DESCRIPTION
/area networking
/kind enhancement

Cherry pick of #1161 on release-v1.49.

#1161: Adapt the retry logic for the resolv.conf copy script to deal with ancient systemd releases.

**Release Notes:**
```other operator

```