### PR TITLE
Configure QPS + burst for CSI components

### DIFF
--- a/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/deployment-csi-driver-controller.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/deployment-csi-driver-controller.yaml
@@ -51,6 +51,8 @@ spec:
         {{- end }}
         - --v=3
         - --provide-node-service=false
+        - --kube-api-qps=100
+        - --kube-api-burst=200
         env:
         - name: CSI_ENDPOINT
           value: unix://{{ .Values.socketPath }}/csi.sock
@@ -99,6 +101,8 @@ spec:
         - --leader-election-namespace=kube-system
         - --timeout={{ .Values.timeout }}
         - --v=5
+        - --kube-api-qps=100
+        - --kube-api-burst=200
         env:
         - name: ADDRESS
           value: {{ .Values.socketPath }}/csi.sock
@@ -126,6 +130,8 @@ spec:
         - --timeout={{ .Values.timeout }}
         - --v=5
         - --max-entries={{ .Values.maxEntries }}
+        - --kube-api-qps=100
+        - --kube-api-burst=200
         env:
         - name: ADDRESS
           value: {{ .Values.socketPath }}/csi.sock
@@ -152,6 +158,8 @@ spec:
         - --leader-election-namespace=kube-system
         - --timeout={{ .Values.timeout }}
         - --snapshot-name-prefix={{ .Release.Namespace }}
+        - --kube-api-qps=100
+        - --kube-api-burst=200
         env:
         - name: CSI_ENDPOINT
           value: {{ .Values.socketPath }}/csi.sock
@@ -179,6 +187,8 @@ spec:
         - --timeout={{ .Values.timeout }}
         - --handle-volume-inuse-error=false
         - --v=5
+        - --kube-api-qps=100
+        - --kube-api-burst=200
         env:
         - name: ADDRESS
           value: {{ .Values.socketPath }}/csi.sock

--- a/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/deployment-csi-snapshot-controller.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/deployment-csi-snapshot-controller.yaml
@@ -38,6 +38,8 @@ spec:
         - --kubeconfig=/var/run/secrets/gardener.cloud/shoot/generic-kubeconfig/kubeconfig
         - --leader-election=true
         - --leader-election-namespace=kube-system
+        - --kube-api-qps=100
+        - --kube-api-burst=200
 {{- if .Values.csiSnapshotController.resources }}
         resources:
 {{ toYaml .Values.csiSnapshotController.resources | indent 10 }}

--- a/charts/internal/seed-controlplane/charts/csi-driver-manila-controller/templates/deployment-controller.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-driver-manila-controller/templates/deployment-controller.yaml
@@ -58,6 +58,8 @@ spec:
             {{- range $userAgentHeader := .Values.userAgentHeaders }}
             - --user-agent={{ $userAgentHeader }}
             {{- end }}
+            - --kube-api-qps=100
+            - --kube-api-burst=200
           env:
             - name: DRIVER_NAME
               value: nfs.manila.csi.openstack.org
@@ -153,6 +155,8 @@ spec:
             - --leader-election
             - --leader-election-namespace=kube-system
             - --timeout={{ .Values.timeout }}
+            - --kube-api-qps=100
+            - --kube-api-burst=200
             - v=5
 {{- if .Values.resources.provisioner }}
           resources:
@@ -176,6 +180,8 @@ spec:
             - --leader-election-namespace=kube-system
             - --timeout={{ .Values.timeout }}
             - --snapshot-name-prefix={{ .Release.Namespace }}
+            - --kube-api-qps=100
+            - --kube-api-burst=200
 {{- if .Values.resources.snapshotter }}
           resources:
 {{ toYaml .Values.resources.snapshotter | indent 12 }}
@@ -199,6 +205,8 @@ spec:
             - --timeout={{ .Values.timeout }}
             - --handle-volume-inuse-error=false
             - --v=3
+            - --kube-api-qps=100
+            - --kube-api-burst=200
 {{- if .Values.resources.resizer }}
           resources:
 {{ toYaml .Values.resources.resizer | indent 12 }}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area performance
/kind enhancement
/platform openstack

**What this PR does / why we need it**:

To avoid client-side throttling in clusters with a high amount of disk operations, the kube-api-qps and kube-api-burst parameters are increased. As these are global controllers per cluster, increasing the throughput to the kube-apiserver improves scalability. There is still API priority & fairness on the server-side to balance incoming requests.

The openstack-specific controller for both Cinder and Manila seem to support such configuration: https://github.com/kubernetes/cloud-provider-openstack/blob/da130f1ce7cff84cca550e754902da4e72c4fd39/pkg/csi/csi.go#L82-L83

Other controllers offer such configuration as well:
- https://github.com/kubernetes-csi/external-resizer/blob/099f11219d9d60080ce81dc5782cb4d2ee3ce709/cmd/csi-resizer/main.go#L89-L90
- https://github.com/kubernetes-csi/external-snapshotter/blob/20bb89ad6fe0ab86fb1f30e97026ef5d019060cd/cmd/csi-snapshotter/main.go#L93-L94
- https://github.com/kubernetes-csi/external-snapshotter/blob/20bb89ad6fe0ab86fb1f30e97026ef5d019060cd/cmd/snapshot-controller/main.go#L77-L78
- https://github.com/kubernetes-csi/external-attacher/blob/3a057e780fb51b10c54ae292e06b2fa3d8540a43/cmd/csi-attacher/main.go#L93-L94
- https://github.com/kubernetes-csi/external-provisioner/blob/43696470c2f436871083561036f1740185f2d542/cmd/csi-provisioner/csi-provisioner.go#L111-L112

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

/invite @hebelsan @kon-angelo 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Configure QPS + burst for CSI components
```
