### PR TITLE
optional manila endpoint

### DIFF
--- a/pkg/controller/infrastructure/infraflow/context.go
+++ b/pkg/controller/infrastructure/infraflow/context.go
@@ -77,17 +77,17 @@ type Opts struct {
 
 // FlowContext contains the logic to reconcile or delete the infrastructure.
 type FlowContext struct {
-	state              shared.Whiteboard
-	client             client.Client
-	log                logr.Logger
-	infra              *extensionsv1alpha1.Infrastructure
-	config             *openstackapi.InfrastructureConfig
-	cloudProfileConfig *openstackapi.CloudProfileConfig
-	networking         osclient.Networking
-	loadbalancing      osclient.Loadbalancing
-	sharedFilesystem   osclient.SharedFilesystem
-	access             access.NetworkingAccess
-	compute            osclient.Compute
+	state                  shared.Whiteboard
+	client                 client.Client
+	openstackClientFactory osclient.Factory
+	log                    logr.Logger
+	infra                  *extensionsv1alpha1.Infrastructure
+	config                 *openstackapi.InfrastructureConfig
+	cloudProfileConfig     *openstackapi.CloudProfileConfig
+	networking             osclient.Networking
+	loadbalancing          osclient.Loadbalancing
+	access                 access.NetworkingAccess
+	compute                osclient.Compute
 
 	*shared.BasicFlowContext
 }
@@ -115,11 +115,6 @@ func NewFlowContext(opts Opts) (*FlowContext, error) {
 	if err != nil {
 		return nil, err
 	}
-	sharedFilesytem, err := opts.ClientFactory.SharedFilesystem(osclient.WithRegion(opts.Infrastructure.Spec.Region))
-	if err != nil {
-		return nil, err
-	}
-
 	infraConfig, err := helper.InfrastructureConfigFromInfrastructure(opts.Infrastructure)
 	if err != nil {
 		return nil, err
@@ -130,17 +125,17 @@ func NewFlowContext(opts Opts) (*FlowContext, error) {
 	}
 
 	flowContext := &FlowContext{
-		state:              whiteboard,
-		infra:              opts.Infrastructure,
-		config:             infraConfig,
-		cloudProfileConfig: cloudProfileConfig,
-		networking:         networking,
-		loadbalancing:      loadbalancing,
-		access:             access,
-		compute:            compute,
-		sharedFilesystem:   sharedFilesytem,
-		log:                opts.Log,
-		client:             opts.Client,
+		state:                  whiteboard,
+		infra:                  opts.Infrastructure,
+		config:                 infraConfig,
+		cloudProfileConfig:     cloudProfileConfig,
+		networking:             networking,
+		loadbalancing:          loadbalancing,
+		access:                 access,
+		compute:                compute,
+		log:                    opts.Log,
+		client:                 opts.Client,
+		openstackClientFactory: opts.ClientFactory,
 	}
 	return flowContext, nil
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/platform openstack

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #https://github.com/gardener/gardener-extension-provider-openstack/issues/1170

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Fix an issue preventing OpenStack installations without manila endpoints. Flow reconciler will now do lazy instantiation of the manila client. 
```
