### PR TITLE
Add k8s check before enabling qps flags on csi driver controller

### DIFF
--- a/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/deployment-csi-driver-controller.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/deployment-csi-driver-controller.yaml
@@ -51,8 +51,10 @@ spec:
         {{- end }}
         - --v=3
         - --provide-node-service=false
+        {{- if .Values.highQpsMode }}
         - --kube-api-qps=100
         - --kube-api-burst=200
+        {{- end }}
         env:
         - name: CSI_ENDPOINT
           value: unix://{{ .Values.socketPath }}/csi.sock

--- a/charts/internal/seed-controlplane/charts/csi-driver-controller/values.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-driver-controller/values.yaml
@@ -59,3 +59,8 @@ csiSnapshotController:
     requests:
       cpu: 11m
       memory: 32Mi
+
+# if enabled add the flags --kube-api-qps=100 and --kube-api-burst=200 to the csi-driver-controller
+# only supported for Kubernetes versions >= 1.32
+# TODO @hebelsan: remove highQpsMode can be removed when Gardener removes support for Kubernetes versions 1.31
+highQpsMode: false

--- a/charts/internal/seed-controlplane/charts/csi-driver-manila-controller/templates/deployment-controller.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-driver-manila-controller/templates/deployment-controller.yaml
@@ -58,8 +58,10 @@ spec:
             {{- range $userAgentHeader := .Values.userAgentHeaders }}
             - --user-agent={{ $userAgentHeader }}
             {{- end }}
+            {{- if .Values.highQpsMode }}
             - --kube-api-qps=100
             - --kube-api-burst=200
+            {{- end }}
           env:
             - name: DRIVER_NAME
               value: nfs.manila.csi.openstack.org

--- a/charts/internal/seed-controlplane/charts/csi-driver-manila-controller/values.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-driver-manila-controller/values.yaml
@@ -66,3 +66,8 @@ csimanila:
   # You may set ID of the cluster where manila-csi is deployed. This value will be appended
   # to share metadata in newly provisioned shares as `manila.csi.openstack.org/cluster=<cluster ID>`.
   clusterID: ""
+
+# if enabled add the flags --kube-api-qps=100 and --kube-api-burst=200 to the csi-driver-controller
+# only supported for Kubernetes versions >= 1.32
+# TODO @hebelsan remove highQpsMode can be removed when Gardener removes support for Kubernetes versions 1.31
+highQpsMode: false


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug
/platform openstack

**What this PR does / why we need it**:
The qps flags that got introduced with https://github.com/gardener/gardener-extension-provider-openstack/pull/1178 are only available starting with k8s 1.32 for the csi driver controllers cinder and manila.
As can one can see here:
https://github.com/kubernetes/cloud-provider-openstack/blob/release-1.32/pkg/csi/csi.go
https://github.com/kubernetes/cloud-provider-openstack/blob/release-1.31/pkg/csi/csi.go

This PR introduces a flag that check the kubernetes version before adding these flags.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```operator operator
NONE
```
