### PR TITLE
NodeTemplate inherits attributes from pool and now supports VirtualCapacity for virtual extended resources

### DIFF
--- a/docs/usage/usage.md
+++ b/docs/usage/usage.md
@@ -161,9 +161,13 @@ serverGroup:
   policy: soft-anti-affinity
 # nodeTemplate: # (to be specified only if the node capacity would be different from cloudprofile info during runtime)
 #   capacity:
-#     cpu: 2
-#     gpu: 0
-#     memory: 50Gi
+#     cpu: 2 # inherited from pool's machine type if un-specified
+#     gpu: 0 # inherited from pool's machine type if un-specified
+#     memory: 50Gi # inherited from pool's machine type if un-specified
+#    ephemeral-storage: 10Gi # override to specify explicit ephemeral-storage for scale from zero
+#    resource.com/dongle: 4 # example of a custom, extended resource.
+#    virtualCapacity:
+#      subdomain.domain.com/resource-name: 1234567 # should be hot-updated in worker pool's node.Status.Capacity without rollout
 # machineLabels:
 #  - name: my-label
 #    value: foo

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	go.uber.org/atomic v1.11.0
 	go.uber.org/mock v0.6.0
 	golang.org/x/tools v0.38.0
+	gopkg.in/inf.v0 v0.9.1
 	k8s.io/api v0.33.5
 	k8s.io/apiextensions-apiserver v0.33.5
 	k8s.io/apimachinery v0.33.5
@@ -179,7 +180,6 @@ require (
 	google.golang.org/grpc v1.75.0 // indirect
 	google.golang.org/protobuf v1.36.10 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
-	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	helm.sh/helm/v3 v3.18.6 // indirect

--- a/pkg/controller/worker/actuator.go
+++ b/pkg/controller/worker/actuator.go
@@ -86,7 +86,8 @@ func (d *delegateFactory) WorkerDelegate(ctx context.Context, worker *extensions
 	)
 }
 
-type workerDelegate struct {
+// WorkerDelegate is a delegate for the worker actuator that contains all information needed to reconcile a worker.
+type WorkerDelegate struct {
 	seedClient client.Client
 	scheme     *runtime.Scheme
 	decoder    runtime.Decoder
@@ -120,7 +121,7 @@ func NewWorkerDelegate(
 		return nil, err
 	}
 
-	return &workerDelegate{
+	return &WorkerDelegate{
 		seedClient: seedClient,
 		scheme:     scheme,
 		decoder:    serializer.NewCodecFactory(scheme, serializer.EnableStrict).UniversalDecoder(),
@@ -132,4 +133,10 @@ func NewWorkerDelegate(
 		worker:             worker,
 		openstackClient:    openstackClient,
 	}, nil
+}
+
+// GetMachineClasses returns the slice of machine classes contained inside the worker delegate.
+// Introduced for Unit-testing.
+func (w *WorkerDelegate) GetMachineClasses() []map[string]any {
+	return w.machineClasses
 }

--- a/pkg/controller/worker/helper.go
+++ b/pkg/controller/worker/helper.go
@@ -16,7 +16,7 @@ import (
 	"github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack/v1alpha1"
 )
 
-func (w *workerDelegate) decodeWorkerProviderStatus() (*api.WorkerStatus, error) {
+func (w *WorkerDelegate) decodeWorkerProviderStatus() (*api.WorkerStatus, error) {
 	workerStatus := &api.WorkerStatus{}
 
 	if w.worker.Status.ProviderStatus == nil {
@@ -34,7 +34,7 @@ func (w *workerDelegate) decodeWorkerProviderStatus() (*api.WorkerStatus, error)
 	return workerStatus, nil
 }
 
-func (w *workerDelegate) updateWorkerProviderStatus(ctx context.Context, workerStatus *api.WorkerStatus) error {
+func (w *WorkerDelegate) updateWorkerProviderStatus(ctx context.Context, workerStatus *api.WorkerStatus) error {
 	var workerStatusV1alpha1 = &v1alpha1.WorkerStatus{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: v1alpha1.SchemeGroupVersion.String(),
@@ -51,7 +51,7 @@ func (w *workerDelegate) updateWorkerProviderStatus(ctx context.Context, workerS
 	return w.seedClient.Status().Patch(ctx, w.worker, patch)
 }
 
-func (w *workerDelegate) updateMachineDependenciesStatus(ctx context.Context, workerStatus *api.WorkerStatus, serverGroupDependencies []api.ServerGroupDependency, err error) error {
+func (w *WorkerDelegate) updateMachineDependenciesStatus(ctx context.Context, workerStatus *api.WorkerStatus, serverGroupDependencies []api.ServerGroupDependency, err error) error {
 	workerStatus.ServerGroupDependencies = serverGroupDependencies
 	if statusUpdateErr := w.updateWorkerProviderStatus(ctx, workerStatus); statusUpdateErr != nil {
 		if err != nil {
@@ -65,6 +65,6 @@ func (w *workerDelegate) updateMachineDependenciesStatus(ctx context.Context, wo
 }
 
 // ClusterTechnicalName returns the technical name of the cluster this worker belongs.
-func (w *workerDelegate) ClusterTechnicalName() string {
+func (w *WorkerDelegate) ClusterTechnicalName() string {
 	return w.cluster.ObjectMeta.Name
 }

--- a/pkg/controller/worker/machine_dependencies.go
+++ b/pkg/controller/worker/machine_dependencies.go
@@ -18,18 +18,18 @@ import (
 
 // DeployMachineDependencies implements genericactuator.WorkerDelegate.
 // Deprecated: Do not use this func. It is deprecated in genericactuator.WorkerDelegate.
-func (w *workerDelegate) DeployMachineDependencies(_ context.Context) error {
+func (w *WorkerDelegate) DeployMachineDependencies(_ context.Context) error {
 	return nil
 }
 
 // CleanupMachineDependencies implements genericactuator.WorkerDelegate.
 // Deprecated: Do not use this func. It is deprecated in genericactuator.WorkerDelegate.
-func (w *workerDelegate) CleanupMachineDependencies(_ context.Context) error {
+func (w *WorkerDelegate) CleanupMachineDependencies(_ context.Context) error {
 	return nil
 }
 
 // PreReconcileHook implements genericactuator.WorkerDelegate.
-func (w *workerDelegate) PreReconcileHook(ctx context.Context) error {
+func (w *WorkerDelegate) PreReconcileHook(ctx context.Context) error {
 	computeClient, err := w.openstackClient.Compute(osclient.WithRegion(w.worker.Spec.Region))
 	if err != nil {
 		return err
@@ -44,7 +44,7 @@ func (w *workerDelegate) PreReconcileHook(ctx context.Context) error {
 	return w.updateMachineDependenciesStatus(ctx, workerStatus, serverGroupDepSet.extract(), err)
 }
 
-func (w *workerDelegate) reconcileServerGroups(ctx context.Context, computeClient osclient.Compute, workerStatus *api.WorkerStatus) (serverGroupDependencySet, error) {
+func (w *WorkerDelegate) reconcileServerGroups(ctx context.Context, computeClient osclient.Compute, workerStatus *api.WorkerStatus) (serverGroupDependencySet, error) {
 	serverGroupDepSet := newServerGroupDependencySet(workerStatus.ServerGroupDependencies)
 	for _, pool := range w.worker.Spec.Pools {
 		serverGroupDependencyStatus, err := w.reconcilePoolServerGroup(ctx, computeClient, pool, serverGroupDepSet)
@@ -56,7 +56,7 @@ func (w *workerDelegate) reconcileServerGroups(ctx context.Context, computeClien
 	return serverGroupDepSet, nil
 }
 
-func (w *workerDelegate) reconcilePoolServerGroup(ctx context.Context, computeClient osclient.Compute, pool extensionsv1alpha1.WorkerPool, set serverGroupDependencySet) (*api.ServerGroupDependency, error) {
+func (w *WorkerDelegate) reconcilePoolServerGroup(ctx context.Context, computeClient osclient.Compute, pool extensionsv1alpha1.WorkerPool, set serverGroupDependencySet) (*api.ServerGroupDependency, error) {
 	poolProviderConfig, err := helper.WorkerConfigFromRawExtension(pool.ProviderConfig)
 	if err != nil {
 		return nil, err
@@ -97,17 +97,17 @@ func (w *workerDelegate) reconcilePoolServerGroup(ctx context.Context, computeCl
 }
 
 // PostReconcileHook implements genericactuator.WorkerDelegate.
-func (w *workerDelegate) PostReconcileHook(ctx context.Context) error {
+func (w *WorkerDelegate) PostReconcileHook(ctx context.Context) error {
 	return w.cleanupMachineDependencies(ctx)
 }
 
 // PreDeleteHook implements genericactuator.WorkerDelegate.
-func (w *workerDelegate) PreDeleteHook(_ context.Context) error {
+func (w *WorkerDelegate) PreDeleteHook(_ context.Context) error {
 	return nil
 }
 
 // PostDeleteHook implements genericactuator.WorkerDelegate.
-func (w *workerDelegate) PostDeleteHook(ctx context.Context) error {
+func (w *WorkerDelegate) PostDeleteHook(ctx context.Context) error {
 	return w.cleanupMachineDependencies(ctx)
 }
 
@@ -118,7 +118,7 @@ func (w *workerDelegate) PostDeleteHook(ctx context.Context) error {
 // deleted (logic applicable for PostDeleteHook) and is not being deleted (logic applicable for PostReconcileHook).
 // Refactor this so that PostDeleteHook executes only the handling for Worker being deleted and PostReconcileHook executes only
 // the handling for Worker reconciled (not being deleted).
-func (w *workerDelegate) cleanupMachineDependencies(ctx context.Context) error {
+func (w *WorkerDelegate) cleanupMachineDependencies(ctx context.Context) error {
 	computeClient, err := w.openstackClient.Compute(osclient.WithRegion(w.worker.Spec.Region))
 	if err != nil {
 		return err
@@ -141,7 +141,7 @@ func (w *workerDelegate) cleanupMachineDependencies(ctx context.Context) error {
 // b) worker pool is deleted
 // c) worker pool's server group configuration (e.g. policy) changed
 // d) worker pool no longer requires use of server groups
-func (w *workerDelegate) cleanupServerGroupDependencies(ctx context.Context, computeClient osclient.Compute, set serverGroupDependencySet) error {
+func (w *WorkerDelegate) cleanupServerGroupDependencies(ctx context.Context, computeClient osclient.Compute, set serverGroupDependencySet) error {
 	groups, err := computeClient.ListServerGroups(ctx)
 	if err != nil {
 		return err

--- a/pkg/controller/worker/machine_images.go
+++ b/pkg/controller/worker/machine_images.go
@@ -17,7 +17,8 @@ import (
 	"github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack/helper"
 )
 
-func (w *workerDelegate) UpdateMachineImagesStatus(ctx context.Context) error {
+// UpdateMachineImagesStatus updates the machine images inside the worker status. It generates the machine images if not yet generated.
+func (w *WorkerDelegate) UpdateMachineImagesStatus(ctx context.Context) error {
 	if w.machineImages == nil {
 		if err := w.generateMachineConfig(ctx); err != nil {
 			return fmt.Errorf("unable to generate the machine config: %w", err)
@@ -38,7 +39,7 @@ func (w *workerDelegate) UpdateMachineImagesStatus(ctx context.Context) error {
 	return nil
 }
 
-func (w *workerDelegate) findMachineImage(name, version, architecture string) (*api.MachineImage, error) {
+func (w *WorkerDelegate) findMachineImage(name, version, architecture string) (*api.MachineImage, error) {
 	image, err := helper.FindImageFromCloudProfile(w.cloudProfileConfig, name, version, w.cluster.Shoot.Spec.Region, architecture)
 	if err == nil {
 		return image, nil


### PR DESCRIPTION
…nded resources

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind enhancement
/platform openstack

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #1208

**Special notes for your reviewer**:
It appears that openstack worker pool hash is still using `v1` hash and that (unlike aws extension provider). Also, `generateWorkerPoolHash`  at https://github.com/gardener/gardener-extension-provider-openstack/blob/edd46e48dd8753df739fee334a2e8ef06bf5f460/pkg/controller/worker/machines.go#L281 apparently sets `pool.ProviderConfig = nil`, so there is never a rollout if the provider config changes. Is this understanding right ?

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Support specification of extended resources in provider config nodeTemplate.Capacity without re-specifying core resources.
Support virtual extended resources in provider config nodeTemplate.VirtualCapacity which should hot-update the node.Status.Capacity.
```
