### PR TITLE
update dependabot-config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,7 @@ updates:
       - "github.com/gophercloud/*"
   ignore:
   - dependency-name: "k8s.io/*"
+  - dependency-name: "sigs.k8s.io/*"
   - dependency-name: "github.com/gardener/etcd-druid/*"
 - package-ecosystem: "docker"
   directory: "/"


### PR DESCRIPTION
Group SDK updates and ignore k8s.io and etcd, as both need to be kept in sync with Gardener.