### PR TITLE
fix: Fix finding machine images when no architecture is defined in th…

### DIFF
--- a/pkg/apis/openstack/helper/helper.go
+++ b/pkg/apis/openstack/helper/helper.go
@@ -177,7 +177,7 @@ func findMachineImageFlavor(
 			// No capability definitions means legacy format, so we match Architecture field of region
 			if len(capabilityDefinitions) == 0 {
 				for _, mapping := range version.Regions {
-					if region == mapping.Name && ptr.Equal(arch, mapping.Architecture) {
+					if region == mapping.Name && *arch == ptr.Deref(mapping.Architecture, v1beta1constants.ArchitectureAMD64) {
 						return &api.MachineImageFlavor{
 							Image:        version.Image,
 							Regions:      []api.RegionIDMapping{mapping},

--- a/pkg/apis/openstack/helper/helper_test.go
+++ b/pkg/apis/openstack/helper/helper_test.go
@@ -321,6 +321,7 @@ var _ = Describe("Helper", func() {
 			Entry("profile entry not found (version does not exist)", makeProfileMachineImages("ubuntu", "2", region, "0", ptr.To("amd64"), imageCapabilities), "ubuntu", "1", region, ptr.To("amd64"), ""),
 			Entry("profile entry not found (architecture does not exist)", makeProfileMachineImages("ubuntu", "1", region, "0", ptr.To("amd64"), imageCapabilities), "ubuntu", "1", region, ptr.To("arm64"), ""),
 			Entry("profile entry", makeProfileMachineImages("ubuntu", "1", region, "id-1234", ptr.To("amd64"), imageCapabilities), "ubuntu", "1", region, ptr.To("amd64"), "id-1234"),
+			Entry("profile entry (architecture not defined)", makeProfileMachineImages("ubuntu", "1", region, "id-1234", nil, imageCapabilities), "ubuntu", "1", region, ptr.To("amd64"), "id-1234"),
 			Entry("profile non matching region", makeProfileMachineImages("ubuntu", "1", region, "id-1234", ptr.To("amd64"), imageCapabilities), "ubuntu", "1", "china", ptr.To("amd64"), ""),
 		)
 


### PR DESCRIPTION
…e cloud profile

<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/platform openstack

**What this PR does / why we need it**:

When no architecture is defined for an image version in the cloud profile, it was no longer correctly found after merging #1222

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
