### PR TITLE
Add input validation for DNS provider secrets referenced in the shoot spec

### DIFF
--- a/pkg/admission/validator/credentialsbinding.go
+++ b/pkg/admission/validator/credentialsbinding.go
@@ -11,6 +11,7 @@ import (
 	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
 	"github.com/gardener/gardener/pkg/apis/security"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
@@ -55,7 +56,7 @@ func (cb *credentialsBinding) Validate(ctx context.Context, newObj, oldObj clien
 			return err
 		}
 
-		return openstackvalidation.ValidateCloudProviderSecret(secret)
+		return openstackvalidation.ValidateCloudProviderSecret(secret, field.NewPath("secret"), false).ToAggregate()
 	default:
 		return fmt.Errorf("unsupported credentials reference: version %q, kind %q", credentialsBinding.CredentialsRef.APIVersion, credentialsBinding.CredentialsRef.Kind)
 	}

--- a/pkg/admission/validator/secretbinding.go
+++ b/pkg/admission/validator/secretbinding.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gardener/gardener/pkg/apis/core"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
@@ -59,5 +60,5 @@ func (sb *secretBinding) Validate(ctx context.Context, newObj, oldObj client.Obj
 		return err
 	}
 
-	return openstackvalidation.ValidateCloudProviderSecret(secret)
+	return openstackvalidation.ValidateCloudProviderSecret(secret, field.NewPath("secret"), false).ToAggregate()
 }

--- a/pkg/admission/validator/secrets.go
+++ b/pkg/admission/validator/secrets.go
@@ -11,6 +11,7 @@ import (
 	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	openstackvalidation "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack/validation"
@@ -41,5 +42,5 @@ func (s *secret) Validate(_ context.Context, newObj, oldObj client.Object) error
 		}
 	}
 
-	return openstackvalidation.ValidateCloudProviderSecret(secret)
+	return openstackvalidation.ValidateCloudProviderSecret(secret, field.NewPath("secret"), false).ToAggregate()
 }

--- a/pkg/apis/openstack/validation/secrets.go
+++ b/pkg/apis/openstack/validation/secrets.go
@@ -10,55 +10,291 @@ import (
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/utils/ptr"
 
 	"github.com/gardener/gardener-extension-provider-openstack/pkg/openstack"
 )
 
-const (
-	tenantNameMaxLen = 64
-)
+// ValidateCloudProviderSecret validates OpenStack credentials in a secret for both infrastructure and DNS use cases.
+// It checks required fields (domainName, tenantName), validates authentication methods (username/password or application credentials),
+// and ensures all field values meet format requirements. When allowDNSKeys is true, DNS-specific key aliases (e.g., OS_DOMAIN_NAME) are accepted.
+func ValidateCloudProviderSecret(secret *corev1.Secret, fldPath *field.Path, allowDNSKeys bool) field.ErrorList {
+	allErrs := field.ErrorList{}
+	dataPath := fldPath.Child("data")
 
-// ValidateCloudProviderSecret checks whether the given secret contains a valid OpenStack credentials.
-func ValidateCloudProviderSecret(secret *corev1.Secret) error {
-	credentials, err := openstack.ExtractCredentials(secret, false)
+	// DNS specific keys
+	var (
+		domainNameDNSKey, tenantNameDNSKey, userNameDNSKey, passwordDNSKey *string
+		appCredIDDNSKey, appCredNameDNSKey, appCredSecretDNSKey            *string
+		authURLDNSKey, caBundleDNSKey                                      *string
+	)
+
+	// expected keys to ensure no unexpected keys are present
+	var expectedKeys []string
+	expectedKeys = []string{openstack.DomainName, openstack.TenantName, openstack.UserName, openstack.Password,
+		openstack.ApplicationCredentialID, openstack.ApplicationCredentialName, openstack.ApplicationCredentialSecret,
+		openstack.AuthURL, openstack.CACert, openstack.Insecure}
+
+	// set DNS key variables if allowed
+	if allowDNSKeys {
+		domainNameDNSKey = ptr.To(openstack.DNSDomainName)
+		tenantNameDNSKey = ptr.To(openstack.DNSTenantName)
+		userNameDNSKey = ptr.To(openstack.DNSUserName)
+		passwordDNSKey = ptr.To(openstack.DNSPassword)
+		appCredIDDNSKey = ptr.To(openstack.DNSApplicationCredentialID)
+		appCredNameDNSKey = ptr.To(openstack.DNSApplicationCredentialName)
+		appCredSecretDNSKey = ptr.To(openstack.DNSApplicationCredentialSecret)
+		authURLDNSKey = ptr.To(openstack.DNSAuthURL)
+		caBundleDNSKey = ptr.To(openstack.DNS_CA_Bundle)
+
+		// extend expected keys with DNS keys
+		expectedKeys = append(expectedKeys, openstack.DNSDomainName, openstack.DNSTenantName,
+			openstack.DNSUserName, openstack.DNSPassword, openstack.DNSApplicationCredentialID,
+			openstack.DNSApplicationCredentialName, openstack.DNSApplicationCredentialSecret,
+			openstack.DNSAuthURL, openstack.DNS_CA_Bundle)
+	}
+
+	// validate required fields (domainName, tenantName)
+	domainName, domainNameKey, errs := validateRequiredField(secret, dataPath, openstack.DomainName, domainNameDNSKey)
+	allErrs = append(allErrs, errs...)
+	allErrs = append(allErrs, validateDomainName(domainName, dataPath.Key(domainNameKey))...)
+
+	tenantName, tenantNameKey, errs := validateRequiredField(secret, dataPath, openstack.TenantName, tenantNameDNSKey)
+	allErrs = append(allErrs, errs...)
+	allErrs = append(allErrs, validateTenantName(tenantName, dataPath.Key(tenantNameKey))...)
+
+	// get optional fields
+	userName, userNameKey, errs := getOptionalField(secret, dataPath, openstack.UserName, userNameDNSKey)
+	allErrs = append(allErrs, errs...)
+	allErrs = append(allErrs, validateUserName(userName, dataPath.Key(userNameKey))...)
+
+	password, passwordKey, errs := getOptionalField(secret, dataPath, openstack.Password, passwordDNSKey)
+	allErrs = append(allErrs, errs...)
+	allErrs = append(allErrs, validatePassword(password, dataPath.Key(passwordKey))...)
+
+	appCredID, appCredIDKey, errs := getOptionalField(secret, dataPath, openstack.ApplicationCredentialID, appCredIDDNSKey)
+	allErrs = append(allErrs, errs...)
+	allErrs = append(allErrs, validateAppCredentialID(appCredID, dataPath.Key(appCredIDKey))...)
+
+	appCredName, appCredNameKey, errs := getOptionalField(secret, dataPath, openstack.ApplicationCredentialName, appCredNameDNSKey)
+	allErrs = append(allErrs, errs...)
+	allErrs = append(allErrs, validateAppCredentialName(appCredName, dataPath.Key(appCredNameKey))...)
+
+	appCredSecret, appCredSecretKey, errs := getOptionalField(secret, dataPath, openstack.ApplicationCredentialSecret, appCredSecretDNSKey)
+	allErrs = append(allErrs, errs...)
+	allErrs = append(allErrs, validateAppCredentialSecret(appCredSecret, dataPath.Key(appCredSecretKey))...)
+
+	// authURL is required for DNS secrets, optional for infrastructure secrets
+	var authURL, authURLKey string
+	if allowDNSKeys {
+		authURL, authURLKey, errs = validateRequiredField(secret, dataPath, openstack.AuthURL, authURLDNSKey)
+		allErrs = append(allErrs, errs...)
+	} else {
+		authURL, authURLKey, errs = getOptionalField(secret, dataPath, openstack.AuthURL, authURLDNSKey)
+		allErrs = append(allErrs, errs...)
+	}
+	allErrs = append(allErrs, validateHTTPURL(authURL, dataPath.Key(authURLKey))...)
+
+	caCert, caCertKey, errs := getOptionalField(secret, dataPath, openstack.CACert, caBundleDNSKey)
+	allErrs = append(allErrs, errs...)
+	allErrs = append(allErrs, validateCACert(caCert, dataPath.Key(caCertKey))...)
+
+	insecure, insecureKey, errs := getOptionalField(secret, dataPath, openstack.Insecure, nil)
+	allErrs = append(allErrs, errs...)
+	allErrs = append(allErrs, validateInsecure(insecure, dataPath.Key(insecureKey))...)
+
+	// ensure valid authentication method is available
+	allErrs = append(allErrs, validateAuthCombination(
+		userName, userNameKey, password, passwordKey,
+		appCredID, appCredIDKey, appCredName, appCredNameKey, appCredSecret, appCredSecretKey, dataPath)...)
+
+	// make sure that only expected keys exist
+	allErrs = append(allErrs, validateNoUnexpectedKeys(secret, dataPath, expectedKeys)...)
+
+	return allErrs
+}
+
+// validateRequiredField checks if a required field exists in the secret and is non-empty.
+// It first looks for the standard key, then falls back to the DNS key if provided and allowDNSKeys is true.
+// Returns the field value, the actual key used (standard or DNS), and any validation errors.
+func validateRequiredField(secret *corev1.Secret, fldPath *field.Path, key string, dnsKey *string) (string, string, field.ErrorList) {
+	allErrs := field.ErrorList{}
+
+	value, ok := secret.Data[key]
+	actualKey := key
+	if !ok && dnsKey != nil {
+		actualKey = *dnsKey
+		value, ok = secret.Data[actualKey]
+	}
+
+	if !ok {
+		allErrs = append(allErrs, field.Required(fldPath.Key(key), fmt.Sprintf("missing required field %q", key)))
+		return "", key, allErrs
+	}
+
+	if ok && len(value) == 0 {
+		allErrs = append(allErrs, field.Invalid(fldPath.Key(actualKey), "", fmt.Sprintf("field %q cannot be empty", actualKey)))
+	}
+
+	return string(value), actualKey, allErrs
+}
+
+// getOptionalField extracts an optional field value from the secret.
+// It first checks for the standard key, then falls back to the DNS key if provided.
+// Returns the field value (empty string if not found) and the actual key used.
+// Returns an error if the key is used but no value provided.
+func getOptionalField(secret *corev1.Secret, fldPath *field.Path, key string, dnsKey *string) (string, string, field.ErrorList) {
+	allErrs := field.ErrorList{}
+
+	value, ok := secret.Data[key]
+	actualKey := key
+	if !ok && dnsKey != nil {
+		actualKey = *dnsKey
+		if value, ok = secret.Data[*dnsKey]; !ok {
+			return "", key, allErrs
+		}
+	}
+
+	if ok && len(value) == 0 {
+		allErrs = append(allErrs, field.Invalid(fldPath.Key(actualKey), "", fmt.Sprintf("field %q cannot be empty when key is set", actualKey)))
+	}
+
+	return string(value), actualKey, allErrs
+}
+
+// validateAuthCombination ensures that exactly one valid authentication method is provided.
+// Valid methods are:
+// (1) applicationCredentialID + applicationCredentialSecret
+// (2) username + domainName + applicationCredentialName + applicationCredentialSecret
+// (3) username + password + domainName + tenantName
+// Note: domainName and tenantName are validated separately as always-required fields.
+// It also prevents mixing password-based and application credential authentication.
+// See https://docs.openstack.org/python-openstackclient/latest/cli/authentication.html
+// and https://docs.openstack.org/keystone/latest/user/application_credentials.html#using-application-credentials
+func validateAuthCombination(
+	userName, userNameKey, pw, pwKey,
+	appCredID, appCredIDKey, appCredName, appCredNameKey,
+	appCredSecret, appCredSecretKey string, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	// Check for invalid mixing of password and application credentials
+	if pw != "" && appCredSecret != "" {
+		return field.ErrorList{field.Invalid(fldPath, "",
+			fmt.Sprintf("cannot specify both %s and %s", pwKey, appCredSecretKey))}
+	}
+
+	// Determine which authentication method is being used
+	if appCredID != "" {
+		// Method 1: Application Credential ID
+		if appCredSecret == "" {
+			allErrs = append(allErrs, field.Required(
+				fldPath.Child(openstack.ApplicationCredentialSecret),
+				fmt.Sprintf("%s is required when %s is provided", appCredSecretKey, appCredIDKey)))
+		}
+		return allErrs
+	}
+
+	if appCredName != "" {
+		// Method 2: Application Credential Name (requires username and domainName)
+		if appCredSecret == "" {
+			allErrs = append(allErrs, field.Required(
+				fldPath.Child(openstack.ApplicationCredentialSecret),
+				fmt.Sprintf("%s is required when %s is provided", appCredSecretKey, appCredNameKey)))
+		}
+		if userName == "" {
+			allErrs = append(allErrs, field.Required(
+				fldPath.Child(openstack.UserName),
+				fmt.Sprintf("%s is required when %s is provided", userNameKey, appCredNameKey)))
+		}
+		return allErrs
+	}
+
+	if pw != "" {
+		// Method 3: Username/Password authentication (requires domainName and tenantName)
+		if userName == "" {
+			allErrs = append(allErrs, field.Required(
+				fldPath.Child(openstack.UserName),
+				fmt.Sprintf("%s is required when %s is provided", userNameKey, pwKey)))
+		}
+		return allErrs
+	}
+
+	// No valid authentication method provided
+	return field.ErrorList{field.Required(fldPath,
+		fmt.Sprintf("must provide one of the following authentication methods: "+
+			"(1) %s + %s, "+
+			"(2) %s + %s + %s, "+
+			"(3) %s + %s",
+			appCredIDKey, appCredSecretKey,
+			userNameKey, appCredNameKey, appCredSecretKey,
+			userNameKey, pwKey))}
+}
+
+// validateNoUnexpectedKeys ensures that the secret contains only expected keys.
+// Any key not in the expectedKeys list is reported as a forbidden field.
+func validateNoUnexpectedKeys(secret *corev1.Secret, fldPath *field.Path, expectedKeys []string) field.ErrorList {
+	allErrs := field.ErrorList{}
+	expectedKeysSet := sets.NewString(expectedKeys...)
+
+	for k := range secret.Data {
+		if !expectedKeysSet.Has(k) {
+			allErrs = append(allErrs, field.Forbidden(fldPath.Key(k),
+				fmt.Sprintf("unexpected field %q", k)))
+		}
+	}
+
+	return allErrs
+}
+
+// validateHTTPURL validates that a string is a valid HTTP or HTTPS URL
+func validateHTTPURL(urlStr string, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if urlStr == "" {
+		return allErrs
+	}
+
+	parsedURL, err := url.Parse(urlStr)
 	if err != nil {
-		return err
+		allErrs = append(allErrs, field.Invalid(fldPath, urlStr, "must be a valid URL"))
+		return allErrs
 	}
 
-	secretKey := fmt.Sprintf("%s/%s", secret.Namespace, secret.Name)
-
-	// domainName, tenantName, and userName must not contain leading or trailing whitespace
-	for key, value := range map[string]string{
-		openstack.DomainName:                  credentials.DomainName,
-		openstack.TenantName:                  credentials.TenantName,
-		openstack.UserName:                    credentials.Username,
-		openstack.ApplicationCredentialID:     credentials.ApplicationCredentialID,
-		openstack.ApplicationCredentialName:   credentials.ApplicationCredentialName,
-		openstack.ApplicationCredentialSecret: credentials.ApplicationCredentialSecret,
-	} {
-		if strings.TrimSpace(value) != value {
-			return fmt.Errorf("field %q in secret %s must not contain leading or traling whitespace", key, secretKey)
-		}
+	if parsedURL.Scheme != "https" && parsedURL.Scheme != "http" {
+		allErrs = append(allErrs, field.Invalid(fldPath, urlStr, "must use http:// or https:// scheme"))
 	}
 
-	// tenantName must not be longer than 64 characters, see https://docs.openstack.org/api-ref/identity/v3/?expanded=show-project-details-detail
-	if len(credentials.TenantName) > tenantNameMaxLen {
-		return fmt.Errorf("field %q in secret %s cannot be longer than %d characters", openstack.TenantName, secretKey, tenantNameMaxLen)
+	if parsedURL.Host == "" {
+		allErrs = append(allErrs, field.Invalid(fldPath, urlStr, "must include a host"))
 	}
 
-	// password must not contain leading or trailing new lines, as they are known to cause issues
-	// Other whitespace characters such as spaces are intentionally not checked for,
-	// since there is no documentation indicating that they would not be valid
-	if strings.Trim(credentials.Password, "\n\r") != credentials.Password {
-		return fmt.Errorf("field %q in secret %s must not contain leading or traling new lines", openstack.Password, secretKey)
+	return allErrs
+}
+
+// validateCACert validates that a CA certificate is in valid PEM format.
+// It checks for the presence of PEM certificate header and footer markers.
+// This field is optional, so empty values are allowed.
+func validateCACert(cert string, fldPath *field.Path) field.ErrorList {
+	if cert == "" {
+		return nil // Optional field
 	}
 
-	// authURL must be a valid URL if present
-	if credentials.AuthURL != "" {
-		if _, err := url.Parse(credentials.AuthURL); err != nil {
-			return fmt.Errorf("field %q in secret %s must be a valid URL when present: %v", openstack.AuthURL, secretKey, err)
-		}
+	allErrs := field.ErrorList{}
+
+	const (
+		pemHeader = "-----BEGIN CERTIFICATE-----"
+		pemFooter = "-----END CERTIFICATE-----"
+	)
+
+	if !strings.Contains(cert, pemHeader) {
+		allErrs = append(allErrs, field.Invalid(fldPath, "", "must contain '-----BEGIN CERTIFICATE-----'"))
 	}
 
-	return nil
+	if !strings.Contains(cert, pemFooter) {
+		allErrs = append(allErrs, field.Invalid(fldPath, "", "must contain '-----END CERTIFICATE-----'"))
+	}
+
+	return allErrs
 }


### PR DESCRIPTION
* Validate openstack-designate provider secrets in shoot spec
* Refactor secret validation to use openstack credential requirements and field.ErrorList
* Add unit tests for secret and shoot DNS validation

<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement
/platform openstack

**What this PR does / why we need it**:
This PR adds input validation for the primary DNS provider secret for the `openstack-designate` provider added in the shoots spec
```yaml
...
  dns:
    domain: crazy-botany.core.my-custom-domain.com
    # Provider configuration required if custom shoot domain is configured.
    providers:
    - type: openstack-designate
      secretName: my-custom-domain-secret
...
```
It complements [PR1155](https://github.com/gardener/gardener-extension-provider-openstack/pull/1155).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Add input validation for primary DNS provider secret referenced in the shoot spec.
```
