### PR TITLE
fix: Select correct subnet when creating router

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,11 @@ require (
 )
 
 require (
+	github.com/MichaelTJones/walk v0.0.0-20161122175330-4748e29d5718 // indirect
+	github.com/mgutz/str v1.2.0 // indirect
+)
+
+require (
 	cel.dev/expr v0.24.0 // indirect
 	cloud.google.com/go/compute/metadata v0.9.0 // indirect
 	dario.cat/mergo v1.0.2 // indirect
@@ -183,6 +188,7 @@ require (
 	google.golang.org/grpc v1.76.0 // indirect
 	google.golang.org/protobuf v1.36.10 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
+	gopkg.in/godo.v2 v2.0.9
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	helm.sh/helm/v3 v3.19.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -59,6 +59,8 @@ github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/Masterminds/sprig/v3 v3.3.0 h1:mQh0Yrg1XPo6vjYXgtf5OtijNAKJRNcTdOOGZe3tPhs=
 github.com/Masterminds/sprig/v3 v3.3.0/go.mod h1:Zy1iXRYNqNLUolqCpL4uhk6SHUMAOSCzdgBfDb35Lz0=
+github.com/MichaelTJones/walk v0.0.0-20161122175330-4748e29d5718 h1:FSsoaa1q4jAaeiAUxf9H0PgFP7eA/UL6c3PdJH+nMN4=
+github.com/MichaelTJones/walk v0.0.0-20161122175330-4748e29d5718/go.mod h1:VVwKsx9Dc8rNG55BWqogoJzGubjKnRoXdUvpGbWqeCc=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
@@ -393,6 +395,8 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mfridman/tparse v0.18.0 h1:wh6dzOKaIwkUGyKgOntDW4liXSo37qg5AXbIhkMV3vE=
 github.com/mfridman/tparse v0.18.0/go.mod h1:gEvqZTuCgEhPbYk/2lS3Kcxg1GmTxxU7kTC8DvP0i/A=
+github.com/mgutz/str v1.2.0 h1:4IzWSdIz9qPQWLfKZ0rJcV0jcUDpxvP4JVZ4GXQyvSw=
+github.com/mgutz/str v1.2.0/go.mod h1:w1v0ofgLaJdoD0HpQ3fycxKD1WtxpjSo151pK/31q6w=
 github.com/miekg/dns v1.1.68 h1:jsSRkNozw7G/mnmXULynzMNIsgY2dHC8LO6U6Ij2JEA=
 github.com/miekg/dns v1.1.68/go.mod h1:fujopn7TB3Pu3JM69XaawiU0wqjpL9/8xGop5UrTPps=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
@@ -831,6 +835,8 @@ gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/evanphx/json-patch.v4 v4.13.0 h1:czT3CmqEaQ1aanPc5SdlgQrrEIb8w/wwCvWWnfEbYzo=
 gopkg.in/evanphx/json-patch.v4 v4.13.0/go.mod h1:p8EYWUEYMpynmqDbY58zCKCFZw8pRWMG4EsWvDvM72M=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
+gopkg.in/godo.v2 v2.0.9 h1:jnbznTzXVk0JDKOxN3/LJLDPYJzIl0734y+Z0cEJb4A=
+gopkg.in/godo.v2 v2.0.9/go.mod h1:wgvPPKLsWN0hPIJ4JyxvFGGbIW3fJMSrXhdvSuZ1z/8=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/ini.v1 v1.67.0 h1:Dgnx+6+nfE+IfzjUEISNeydPJh9AXNNsWbGP9KzCsOA=

--- a/pkg/apis/openstack/types_cloudprofile.go
+++ b/pkg/apis/openstack/types_cloudprofile.go
@@ -74,7 +74,7 @@ type FloatingPool struct {
 	Region *string
 	// Domain is the domain name.
 	Domain *string
-	// DefaultFloatingSubnet is the default floating subnet for the floating pool.
+	// DefaultFloatingSubnet is the name of a subnet or a pattern to select a subnet that will be used by default for the floating pool.
 	DefaultFloatingSubnet *string
 	// NonConstraining specifies whether this floating pool is not constraining, that means additionally available independent of other FP constraints.
 	NonConstraining *bool
@@ -102,7 +102,7 @@ type LoadBalancerClass struct {
 	FloatingSubnetID *string
 	// FloatingSubnetTags is a list of tags which can be used to select subnets in the floating network pool.
 	FloatingSubnetTags *string
-	// FloatingSubnetName is can either be a name or a name pattern of a subnet in the floating network pool.
+	// FloatingSubnetName can either be a name or a name pattern of a subnet in the floating network pool.
 	FloatingSubnetName *string
 	// FloatingNetworkID is the network ID of the floating network pool.
 	FloatingNetworkID *string

--- a/pkg/controller/infrastructure/infraflow/access/access_suite_test.go
+++ b/pkg/controller/infrastructure/infraflow/access/access_suite_test.go
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package access_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestAccess(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Infraflow Access Suite")
+}

--- a/pkg/controller/infrastructure/infraflow/access/networking_access_test.go
+++ b/pkg/controller/infrastructure/infraflow/access/networking_access_test.go
@@ -1,0 +1,152 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package access_test
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/subnets"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/gardener/gardener-extension-provider-openstack/pkg/controller/infrastructure/infraflow/access"
+	"github.com/gardener/gardener-extension-provider-openstack/pkg/openstack/client"
+)
+
+type fakeNetworking struct {
+	client.Networking
+
+	listSubnetsFn func(ctx context.Context, opts subnets.ListOpts) ([]subnets.Subnet, error)
+}
+
+func (f *fakeNetworking) ListSubnets(ctx context.Context, opts subnets.ListOpts) ([]subnets.Subnet, error) {
+	if f.listSubnetsFn == nil {
+		return nil, fmt.Errorf("listSubnetsFn not set")
+	}
+	return f.listSubnetsFn(ctx, opts)
+}
+
+func newNetworkingAccessWithSubnets(returned []subnets.Subnet) access.NetworkingAccess {
+	a, err := access.NewNetworkingAccess(&fakeNetworking{
+		listSubnetsFn: func(_ context.Context, opts subnets.ListOpts) ([]subnets.Subnet, error) {
+			Expect(opts.NetworkID).To(Equal("net-1"))
+			return returned, nil
+		},
+	}, logr.Discard())
+	Expect(err).NotTo(HaveOccurred())
+	return a
+}
+
+var _ = Describe("LookupFloatingPoolSubnetIDs", func() {
+	It("propagates errors from ListSubnets", func() {
+		ctx := context.Background()
+		sentinelErr := fmt.Errorf("network error")
+
+		a, err := access.NewNetworkingAccess(&fakeNetworking{
+			listSubnetsFn: func(_ context.Context, opts subnets.ListOpts) ([]subnets.Subnet, error) {
+				Expect(opts.NetworkID).To(Equal("net-1"))
+				return nil, sentinelErr
+			},
+		}, logr.Discard())
+		Expect(err).NotTo(HaveOccurred())
+
+		ids, err := a.LookupFloatingPoolSubnetIDs(ctx, "net-1", "ext-*")
+		Expect(ids).To(BeNil())
+		Expect(err).To(MatchError(sentinelErr))
+	})
+
+	It("returns all subnet IDs when the pattern is empty", func() {
+		ctx := context.Background()
+		a := newNetworkingAccessWithSubnets([]subnets.Subnet{
+			{ID: "s-1", Name: ""},
+			{ID: "s-2", Name: "ext-a"},
+			{ID: "s-3", Name: "int-a"},
+		})
+
+		ids, err := a.LookupFloatingPoolSubnetIDs(ctx, "net-1", "")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ids).To(Equal([]string{"s-1", "s-2", "s-3"}))
+	})
+
+	It("matches by glob pattern against the full subnet name", func() {
+		ctx := context.Background()
+		a := newNetworkingAccessWithSubnets([]subnets.Subnet{
+			{ID: "s-1", Name: "ext-a"},
+			{ID: "s-2", Name: "ext-b"},
+			{ID: "s-3", Name: "internal"},
+			{ID: "s-4", Name: ""},
+		})
+
+		ids, err := a.LookupFloatingPoolSubnetIDs(ctx, "net-1", "ext-*")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ids).To(Equal([]string{"s-1", "s-2"}))
+	})
+
+	It("requires regexp matches to cover the whole subnet name", func() {
+		ctx := context.Background()
+		a := newNetworkingAccessWithSubnets([]subnets.Subnet{
+			{ID: "s-1", Name: "ext-a"},
+			{ID: "s-2", Name: "ext-b"},
+			{ID: "s-3", Name: "internal"},
+		})
+
+		_, err := a.LookupFloatingPoolSubnetIDs(ctx, "net-1", "~ext")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("no subnet found matching"))
+
+		ids, err := a.LookupFloatingPoolSubnetIDs(ctx, "net-1", "~ext-.*")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ids).To(Equal([]string{"s-1", "s-2"}))
+	})
+
+	It("supports negation patterns and still skips unnamed subnets", func() {
+		ctx := context.Background()
+		a := newNetworkingAccessWithSubnets([]subnets.Subnet{
+			{ID: "s-1", Name: "ext-a"},
+			{ID: "s-2", Name: "int-a"},
+			{ID: "s-3", Name: ""},
+		})
+
+		ids, err := a.LookupFloatingPoolSubnetIDs(ctx, "net-1", "!ext-*")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ids).To(Equal([]string{"s-2"}))
+	})
+
+	It("supports combined negation and regexp patterns", func() {
+		ctx := context.Background()
+		a := newNetworkingAccessWithSubnets([]subnets.Subnet{
+			{ID: "s-1", Name: "ext-a"},
+			{ID: "s-2", Name: "int-a"},
+			{ID: "s-3", Name: "internal"},
+			{ID: "s-4", Name: ""},
+			{ID: "s-5", Name: "ext-b"},
+		})
+
+		ids, err := a.LookupFloatingPoolSubnetIDs(ctx, "net-1", "!~ext-.*")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ids).To(Equal([]string{"s-2", "s-3"}))
+	})
+
+	It("returns an error for invalid regexp patterns", func() {
+		ctx := context.Background()
+		a := newNetworkingAccessWithSubnets([]subnets.Subnet{{ID: "s-1", Name: "ext-a"}})
+
+		_, err := a.LookupFloatingPoolSubnetIDs(ctx, "net-1", "~[")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("invalid subnet regexp pattern"))
+	})
+
+	It("returns a helpful error when no subnets match", func() {
+		ctx := context.Background()
+		a := newNetworkingAccessWithSubnets([]subnets.Subnet{{ID: "s-1", Name: "int-a"}})
+
+		pat := "ext-*"
+		_, err := a.LookupFloatingPoolSubnetIDs(ctx, "net-1", pat)
+		Expect(err).To(HaveOccurred())
+		Expect(err).To(MatchError(ContainSubstring(pat)))
+	})
+})


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/platform openstack

**What this PR does / why we need it**:

Without this fix a glob pattern created an invalid regexp and a random subnet was selected instead.

**Which issue(s) this PR fixes**:
Fixes #1260

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fixed an issue, where a router was not always created in the correct floating pool subnet if it was specified with a wildcard `*`.
```
