### PR TITLE
Fix command line argument for verbosity flag

### DIFF
--- a/charts/internal/seed-controlplane/charts/csi-driver-manila-controller/templates/deployment-controller.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-driver-manila-controller/templates/deployment-controller.yaml
@@ -159,7 +159,7 @@ spec:
             - --timeout={{ .Values.timeout }}
             - --kube-api-qps=100
             - --kube-api-burst=200
-            - v=5
+            - --v=5
 {{- if .Values.resources.provisioner }}
           resources:
 {{ toYaml .Values.resources.provisioner | indent 12 }}


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/platform openstack

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
fix verbosity flag in manila csi-provider chart
```
