### PR TITLE
Prevent Calico from setting the NetworkUnavailable condition on nodes…

### DIFF
--- a/charts/internal/shoot-system-components/charts/calico-mutating-admission-policy/Chart.yaml
+++ b/charts/internal/shoot-system-components/charts/calico-mutating-admission-policy/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+description: Mutating admission policy to control NetworkUnavailable condition set by Calico CNI plugin.
+name: calico-mutating-admission-policy
+version: 0.1.0

--- a/charts/internal/shoot-system-components/charts/calico-mutating-admission-policy/templates/mutating-admission-policy.yaml
+++ b/charts/internal/shoot-system-components/charts/calico-mutating-admission-policy/templates/mutating-admission-policy.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.enabled }}
+---
+apiVersion: admissionregistration.k8s.io/v1alpha1
+kind: MutatingAdmissionPolicyBinding
+metadata:
+  name: block-calico-network-unavailable-binding
+spec:
+  policyName: block-calico-network-unavailable
+---
+# MutatingAdmissionPolicy to block Calico from setting the NetworkUnavailable condition on nodes.
+apiVersion: admissionregistration.k8s.io/v1alpha1
+kind: MutatingAdmissionPolicy
+metadata:
+  name: block-calico-network-unavailable
+spec:
+  failurePolicy: Fail
+  reinvocationPolicy: IfNeeded
+  matchConstraints:
+    resourceRules:
+    - apiGroups: [""]
+      apiVersions: ["v1"]
+      operations: ["UPDATE"]
+      resources: ["nodes/status"]
+  matchConditions:
+    # Only apply to requests from the calico-node service account
+    - name: is-calico-node
+      expression: >-
+        request.userInfo.username == "system:serviceaccount:kube-system:calico-node"
+    # Only apply if calico is trying to set/modify NetworkUnavailable condition
+    - name: has-network-unavailable-in-request
+      expression: >-
+        object.status.conditions.exists(c, c.type == 'NetworkUnavailable')
+  variables:
+    # Extract the current NetworkUnavailable condition from the old object
+    - name: oldNetworkUnavailableCondition
+      expression: >-
+        has(oldObject.status) && has(oldObject.status.conditions) ? 
+        oldObject.status.conditions.filter(c, c.type == 'NetworkUnavailable') : []
+    # Remove NetworkUnavailable from the new conditions
+    - name: conditionsWithoutNetworkUnavailable
+      expression: >-
+        object.status.conditions.filter(c, c.type != 'NetworkUnavailable')
+    # Reconstruct final conditions
+    - name: finalConditions
+      expression: >-
+        variables.oldNetworkUnavailableCondition.size() > 0 ?
+        variables.conditionsWithoutNetworkUnavailable + variables.oldNetworkUnavailableCondition :
+        variables.conditionsWithoutNetworkUnavailable
+  mutations:
+    # Replace the entire conditions array with the reconstructed version
+    - patchType: JSONPatch
+      jsonPatch:
+        expression: |
+          [
+            JSONPatch{
+              op: "replace",
+              path: "/status/conditions",
+              value: variables.finalConditions
+            }
+          ]
+{{- end }}

--- a/charts/internal/shoot-system-components/charts/calico-mutating-admission-policy/values.yaml
+++ b/charts/internal/shoot-system-components/charts/calico-mutating-admission-policy/values.yaml
@@ -1,0 +1,1 @@
+enabled: false

--- a/go.mod
+++ b/go.mod
@@ -68,7 +68,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.39.1 // indirect
-	github.com/aws/smithy-go v1.23.2 // indirect
+	github.com/aws/smithy-go v1.24.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/bmatcuk/doublestar/v4 v4.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -128,8 +128,8 @@ github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.5 h1:OWs0/j2UYR5LOGi88sD5/lhN
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.5/go.mod h1:klO+ejMvYsB4QATfEOIXk8WAEwN4N0aBfJpvC+5SZBo=
 github.com/aws/aws-sdk-go-v2/service/sts v1.39.1 h1:mLlUgHn02ue8whiR4BmxxGJLR2gwU6s6ZzJ5wDamBUs=
 github.com/aws/aws-sdk-go-v2/service/sts v1.39.1/go.mod h1:E19xDjpzPZC7LS2knI9E6BaRFDK43Eul7vd6rSq2HWk=
-github.com/aws/smithy-go v1.23.2 h1:Crv0eatJUQhaManss33hS5r40CG3ZFH+21XSkqMrIUM=
-github.com/aws/smithy-go v1.23.2/go.mod h1:LEj2LM3rBRQJxPZTB4KuzZkaZYnZPnvgIhb4pu07mx0=
+github.com/aws/smithy-go v1.24.0 h1:LpilSUItNPFr1eY85RYgTIg5eIEPtvFbskaFcmmIUnk=
+github.com/aws/smithy-go v1.24.0/go.mod h1:LEj2LM3rBRQJxPZTB4KuzZkaZYnZPnvgIhb4pu07mx0=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=

--- a/pkg/controller/controlplane/actuator.go
+++ b/pkg/controller/controlplane/actuator.go
@@ -1,0 +1,193 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package controlplane
+
+import (
+	"context"
+	"fmt"
+
+	extensionsconfigv1alpha1 "github.com/gardener/gardener/extensions/pkg/apis/config/v1alpha1"
+	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
+	"github.com/gardener/gardener/extensions/pkg/controller/controlplane"
+	"github.com/gardener/gardener/extensions/pkg/util"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	networking "github.com/gardener/gardener-extension-provider-openstack/pkg/utils/networking"
+)
+
+const (
+	// NetworkUnavailableConditionType is the type of the NetworkUnavailable condition.
+	NetworkUnavailableConditionType = "NetworkUnavailable"
+	// CalicoIsUpReason is the reason set by Calico when it sets the NetworkUnavailable condition to indicate Calico is up.
+	CalicoIsUpReason = "CalicoIsUp"
+	// CalicoIsDownReason is the reason set by Calico when it sets the NetworkUnavailable condition to indicate Calico is down.
+	CalicoIsDownReason = "CalicoIsDown"
+	// AnnotationCalicoCleanupCompleted indicates that Calico condition cleanup has been completed.
+	AnnotationCalicoCleanupCompleted = "openstack.provider.extensions.gardener.cloud/calico-cleanup-completed"
+)
+
+// NewActuator creates a new Actuator that wraps the generic actuator and adds cleanup logic.
+func NewActuator(mgr manager.Manager, a controlplane.Actuator) controlplane.Actuator {
+	return &actuator{
+		Actuator: a,
+		client:   mgr.GetClient(),
+	}
+}
+
+// actuator is an Actuator that acts upon and updates the status of ControlPlane resources.
+type actuator struct {
+	controlplane.Actuator
+	client client.Client
+}
+
+func (a *actuator) Reconcile(
+	ctx context.Context,
+	log logr.Logger,
+	cp *extensionsv1alpha1.ControlPlane,
+	cluster *extensionscontroller.Cluster,
+) (bool, error) {
+	ok, err := a.Actuator.Reconcile(ctx, log, cp, cluster)
+	if err != nil {
+		return ok, err
+	}
+
+	overlayEnabled, err := networking.IsOverlayEnabled(cluster.Shoot.Spec.Networking)
+	if err != nil {
+		log.Error(err, "Failed to determine if overlay is enabled")
+		return ok, err
+	}
+
+	// Clean up NetworkUnavailable conditions set by Calico only when overlay is disabled
+	// Only run cleanup if it hasn't been completed yet (annotation not present)
+	if !overlayEnabled && cp.Annotations[AnnotationCalicoCleanupCompleted] != "true" {
+		if err := a.cleanupCalicoNetworkUnavailableConditions(ctx, log, cp.Namespace, cluster); err != nil {
+			log.Error(err, "Failed to cleanup Calico NetworkUnavailable conditions")
+			return ok, err
+		} else {
+			// Mark cleanup as completed
+			if err := a.markCleanupCompleted(ctx, cp); err != nil {
+				log.Error(err, "Failed to mark cleanup as completed")
+				return ok, err
+			}
+		}
+	}
+
+	// Remove cleanup annotation when overlay is enabled so cleanup can run again if overlay is disabled later
+	if overlayEnabled && cp.Annotations[AnnotationCalicoCleanupCompleted] == "true" {
+		if err := a.removeCleanupAnnotation(ctx, cp); err != nil {
+			log.Error(err, "Failed to remove cleanup annotation")
+			return ok, err
+		}
+	}
+
+	return ok, nil
+}
+
+// cleanupCalicoNetworkUnavailableConditions removes NetworkUnavailable conditions from nodes
+// that were set by Calico for example "CalicoIsUp" or "CalicoIsDown".
+func (a *actuator) cleanupCalicoNetworkUnavailableConditions(
+	ctx context.Context,
+	log logr.Logger,
+	namespace string,
+	cluster *extensionscontroller.Cluster,
+) error {
+	if extensionscontroller.IsHibernated(cluster) {
+		return nil
+	}
+
+	_, shootClient, err := util.NewClientForShoot(ctx, a.client, namespace, client.Options{}, extensionsconfigv1alpha1.RESTOptions{})
+	if err != nil {
+		return fmt.Errorf("could not create shoot client: %w", err)
+	}
+
+	nodes := &corev1.NodeList{}
+	if err := shootClient.List(ctx, nodes); err != nil {
+		return fmt.Errorf("could not list nodes in shoot cluster: %w", err)
+	}
+
+	for _, node := range nodes.Items {
+		if err := a.cleanupNodeNetworkUnavailableCondition(ctx, log, shootClient, &node); err != nil {
+			log.Error(err, "Failed to cleanup NetworkUnavailable condition from node", "node", node.Name)
+			return err
+		}
+	}
+
+	return nil
+}
+
+// cleanupNodeNetworkUnavailableCondition removes the NetworkUnavailable condition from a node
+// if it was set by Calico.
+func (a *actuator) cleanupNodeNetworkUnavailableCondition(
+	ctx context.Context,
+	log logr.Logger,
+	shootClient client.Client,
+	node *corev1.Node,
+) error {
+	// Check if the node has a NetworkUnavailable condition set by Calico
+	hasCondition := false
+	for _, condition := range node.Status.Conditions {
+		if condition.Type == NetworkUnavailableConditionType &&
+			(condition.Reason == CalicoIsUpReason || condition.Reason == CalicoIsDownReason) {
+			hasCondition = true
+			break
+		}
+	}
+
+	if !hasCondition {
+		return nil
+	}
+
+	// Remove the NetworkUnavailable condition
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		// Get the latest version of the node
+		currentNode := &corev1.Node{}
+		if err := shootClient.Get(ctx, client.ObjectKey{Name: node.Name}, currentNode); err != nil {
+			return err
+		}
+
+		// Filter out the NetworkUnavailable condition set by Calico
+		var newConditions []corev1.NodeCondition
+		removed := false
+		for _, condition := range currentNode.Status.Conditions {
+			if condition.Type == NetworkUnavailableConditionType &&
+				(condition.Reason == CalicoIsUpReason || condition.Reason == CalicoIsDownReason) {
+				removed = true
+				log.Info("Removing NetworkUnavailable condition set by Calico", "node", currentNode.Name, "reason", condition.Reason)
+				continue
+			}
+			newConditions = append(newConditions, condition)
+		}
+
+		// Only update if we actually removed a condition
+		if !removed {
+			return nil
+		}
+
+		currentNode.Status.Conditions = newConditions
+		return shootClient.Status().Update(ctx, currentNode)
+	})
+}
+
+// markCleanupCompleted marks the cleanup as completed by adding an annotation to the ControlPlane resource.
+func (a *actuator) markCleanupCompleted(ctx context.Context, cp *extensionsv1alpha1.ControlPlane) error {
+	patch := client.MergeFrom(cp.DeepCopy())
+	if cp.Annotations == nil {
+		cp.Annotations = make(map[string]string)
+	}
+	cp.Annotations[AnnotationCalicoCleanupCompleted] = "true"
+	return a.client.Patch(ctx, cp, patch)
+}
+
+// removeCleanupAnnotation removes the cleanup completion annotation from the ControlPlane resource.
+func (a *actuator) removeCleanupAnnotation(ctx context.Context, cp *extensionsv1alpha1.ControlPlane) error {
+	patch := client.MergeFrom(cp.DeepCopy())
+	delete(cp.Annotations, AnnotationCalicoCleanupCompleted)
+	return a.client.Patch(ctx, cp, patch)
+}

--- a/pkg/controller/controlplane/add.go
+++ b/pkg/controller/controlplane/add.go
@@ -48,8 +48,11 @@ func AddToManagerWithOptions(ctx context.Context, mgr manager.Manager, opts AddO
 		return err
 	}
 
+	// Wrap the generic actuator with our custom actuator for cleanup logic
+	wrappedActuator := NewActuator(mgr, genericActuator)
+
 	return controlplane.Add(mgr, controlplane.AddArgs{
-		Actuator:          genericActuator,
+		Actuator:          wrappedActuator,
 		ControllerOptions: opts.Controller,
 		Predicates:        controlplane.DefaultPredicates(ctx, mgr, opts.IgnoreOperationAnnotation),
 		Type:              openstack.Type,

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -714,7 +714,8 @@ var _ = Describe("ValuesProvider", func() {
 						"nodeVolumeAttachLimit":      ptr.To[int32](nodeVoluemAttachLimit),
 						"userAgentHeaders":           []string{domainName, tenantName, technicalID},
 					}),
-					openstack.CSIDriverManila: enabledFalse,
+					openstack.CSIDriverManila:          enabledFalse,
+					"calico-mutating-admission-policy": enabledFalse,
 				}))
 			})
 
@@ -752,6 +753,7 @@ var _ = Describe("ValuesProvider", func() {
 							"caCert":                      "",
 						},
 					}),
+					"calico-mutating-admission-policy": enabledFalse,
 				}))
 			})
 		})

--- a/pkg/utils/networking/overlay.go
+++ b/pkg/utils/networking/overlay.go
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package networking
+
+import (
+	"encoding/json"
+	"fmt"
+
+	v1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+)
+
+// IsOverlayEnabled inspects a Shoot Networking providerConfig and returns whether overlay is enabled
+func IsOverlayEnabled(network *v1beta1.Networking) (bool, error) {
+	if network == nil || network.ProviderConfig == nil || len(network.ProviderConfig.Raw) == 0 {
+		return true, nil
+	}
+
+	var networkConfig map[string]interface{}
+	if err := json.Unmarshal(network.ProviderConfig.Raw, &networkConfig); err != nil {
+		return false, err
+	}
+
+	if overlay, ok := networkConfig["overlay"].(map[string]interface{}); ok {
+		if enabled, ok2 := overlay["enabled"].(bool); ok2 {
+			return enabled, nil
+		}
+		return false, fmt.Errorf("overlay.enabled is not a boolean")
+	}
+
+	return true, nil
+}


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement
/platform openstack

**What this PR does / why we need it**:
This PR implements a solution to prevent Calico from setting the `NetworkUnavailable` condition on nodes when overlay networking gets disabled, and ensures cleanup of existing Calico-set conditions.

**Which issue(s) this PR fixes**:
During a migration from overlay network to native routing in calico the `calico-node` pods shutting down might still have the old `configmap` value for the backend and thus patch the `NetworkUnavailable` condition of the nodes to `true` when shutting down. See attached screenshot, this leads to the node getting deleted as the condition is set to `true`. To resolve this issue calico updates on the `NetworkUnavailable` condition of the node need to be blocked.

<img width="1419" height="114" alt="image" src="https://github.com/user-attachments/assets/61522565-7436-4a7b-91cd-b8de2745dee0" />

**Special notes for your reviewer**:
Similar to: https://github.com/gardener/gardener-extension-provider-gcp/pull/1309 and https://github.com/gardener/gardener-extension-provider-aws/pull/1703

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Prevent Calico from setting the `NetworkUnavailable` condition on nodes when overlay networking gets disabled, and ensures cleanup of existing Calico-set conditions.
```
