### PR TITLE
Feature/cloud profile storage type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,8 @@ TODO
 # GitGuardian
 .cache_ggshield
 .gitguardian.yaml
+
+# AI coding agents
+# Claude
+.claude/
+/skills-lock.json

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -210,6 +210,20 @@ func (w *WorkerDelegate) generateMachineConfig(ctx context.Context) error {
 			// specifying the volume type requires a custom volume size to be specified too.
 			if pool.Volume != nil && pool.Volume.Type != nil {
 				machineClassSpec["rootDiskType"] = *pool.Volume.Type
+			} else if machineTypeFromCloudProfile.Storage != nil &&
+				machineTypeFromCloudProfile.Storage.Type != "" &&
+				machineTypeFromCloudProfile.Storage.Type != "default" {
+				// Use the storage type from the cloud profile as the default if not explicitly set in the shoot spec.
+				// This is required e.g. for KVM machines that need a "premium" disk type for boot disks.
+				machineClassSpec["rootDiskType"] = machineTypeFromCloudProfile.Storage.Type
+				if machineTypeFromCloudProfile.Storage.StorageSize != nil {
+					cloudProfileVolumeSize, err := worker.DiskSize(machineTypeFromCloudProfile.Storage.StorageSize.String())
+					if err == nil && cloudProfileVolumeSize > 0 {
+						if _, alreadySet := machineClassSpec["rootDiskSize"]; !alreadySet {
+							machineClassSpec["rootDiskSize"] = cloudProfileVolumeSize
+						}
+					}
+				}
 			}
 
 			if machineImage.ID != "" {

--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -6,6 +6,7 @@ package worker_test
 
 import (
 	"context"
+	"embed"
 	"encoding/json"
 	"fmt"
 	"path/filepath"
@@ -1373,6 +1374,69 @@ var _ = Describe("Machines", func() {
 				Expect(result[1].ClusterAutoscalerAnnotations[extensionsv1alpha1.ScaleDownUnneededTimeAnnotation]).To(Equal("2m0s"))
 				Expect(result[1].ClusterAutoscalerAnnotations[extensionsv1alpha1.ScaleDownUnreadyTimeAnnotation]).To(Equal("3m0s"))
 				Expect(result[1].ClusterAutoscalerAnnotations[extensionsv1alpha1.ScaleDownUtilizationThresholdAnnotation]).To(Equal("0.5"))
+			})
+
+			It("should use storage type and size from cloud profile machine type as default when no pool volume is specified", func() {
+				premiumStorageSize := resource.MustParse("64Gi")
+				clusterWithPremiumMachineType := &extensionscontroller.Cluster{
+					CloudProfile: cluster.CloudProfile.DeepCopy(),
+					Shoot:        cluster.Shoot,
+					Seed:         cluster.Seed,
+				}
+				clusterWithPremiumMachineType.CloudProfile.Spec.MachineTypes = []gardencorev1beta1.MachineType{
+					{
+						Name:         machineType,
+						Capabilities: capabilitiesAmd,
+						Storage: &gardencorev1beta1.MachineTypeStorage{
+							Class:       "standard",
+							StorageSize: &premiumStorageSize,
+							Type:        "premium",
+						},
+					},
+					{
+						Name:         machineTypeArm,
+						Architecture: ptr.To(archARM),
+						Capabilities: capabilitiesArm,
+					},
+				}
+
+				workerDelegate, _ = NewWorkerDelegate(c, scheme, chartApplier, w, clusterWithPremiumMachineType, nil)
+
+				var capturedMachineClasses []map[string]interface{}
+				expectedUserDataSecretRefRead()
+				chartApplier.
+					EXPECT().
+					ApplyFromEmbeddedFS(
+						ctx,
+						charts.InternalChart,
+						filepath.Join("internal", "machineclass"),
+						namespace,
+						"machineclass",
+						gomock.AssignableToTypeOf(kubernetes.Values(nil)),
+					).
+					DoAndReturn(func(_ context.Context, _ embed.FS, _, _, _ string, opts ...kubernetes.ApplyOption) error {
+						applyOpts := &kubernetes.ApplyOptions{}
+						for _, o := range opts {
+							o.MutateApplyOptions(applyOpts)
+						}
+						if values, ok := applyOpts.Values.(map[string]interface{}); ok {
+							if classes, ok := values["machineClasses"].([]map[string]interface{}); ok {
+								capturedMachineClasses = classes
+							}
+						}
+						return nil
+					})
+
+				err := workerDelegate.DeployMachineClasses(ctx)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(capturedMachineClasses).NotTo(BeEmpty())
+				for _, class := range capturedMachineClasses {
+					if class["machineType"] == machineType {
+						Expect(class).To(HaveKeyWithValue("rootDiskType", "premium"), "expected rootDiskType to be set from cloud profile storage type")
+						Expect(class).To(HaveKeyWithValue("rootDiskSize", 64), "expected rootDiskSize to be set from cloud profile storage size")
+					}
+				}
 			})
 		},
 			Entry("with capabilities and using imageIDs", true, false),


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area quality
/kind enhancement
/platform openstack

**What this PR does / why we need it**:
This PR adjusts the default values for the machineclass values `rootDiskType` and `rootDiskSize`.
These will now be derived from the cloudProfile machineType spec which looks the following:
```yaml
spec:
  machineTypes:
  - architecture: amd64
    cpu: "4"
    gpu: "0"
    memory: 8Gi
    name: g_k_c4_m8_v2
    storage:
      class: standard
      size: "64"
      type: premium
    usable: true
```
If the storage section of the machineType is not set or the type is set to default the machinclass fields for `rootDiskType` and `rootDiskSize` will be empty so the openstack defaults will be used.
It's still possible to overwrite the default disk type and size by setting the shoot fields.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener-extension-provider-openstack/issues/1316

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
Behavioral change: rootDiskType and rootDiskSize now derived from cloud profile machine type storage.
Previously, if a worker pool did not explicitly configure volume.type / volume.size, the generated MachineClass omitted rootDiskType and rootDiskSize entirely, leaving the choice to OpenStack's infrastructure defaults.
With this change, if the cloud profile's MachineType.Storage defines a type (other than "default") and optionally a storageSize, those values are now used as defaults in the generated MachineClass.
Impact: Shoots using machine types whose cloud profile entry has a non-"default" Storage.Type will now have an explicit rootDiskType (and potentially rootDiskSize) set in their MachineClass. If this differs from the OpenStack infrastructure's previous default, the root disk type of newly created nodes will change.
Action required: Review the Storage field on machine types in affected cloud profiles. If the Storage.Type was set for informational purposes only and should not influence disk provisioning, set it to "default" to preserve the previous behavior.
```
