### PR TITLE
`feature:` add managed default VolumeSnapshotClass for Cinder

### DIFF
--- a/charts/internal/shoot-storageclasses/templates/volumesnapshotclass.yaml
+++ b/charts/internal/shoot-storageclasses/templates/volumesnapshotclass.yaml
@@ -1,0 +1,11 @@
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshotClass
+metadata:
+  annotations:
+    resources.gardener.cloud/delete-on-invalid-update: "true"
+    {{- if .Values.managedDefaultVolumeSnapshotClass }}
+    snapshot.storage.kubernetes.io/is-default-class: "true"
+    {{- end }}
+  name: csi-cinder
+driver: cinder.csi.openstack.org
+deletionPolicy: Delete

--- a/charts/internal/shoot-storageclasses/values.yaml
+++ b/charts/internal/shoot-storageclasses/values.yaml
@@ -14,3 +14,5 @@
 #  - name: default
 #    default: true
 #    provisioner: cinder.csi.openstack.org
+
+managedDefaultVolumeSnapshotClass: true

--- a/docs/usage/usage.md
+++ b/docs/usage/usage.md
@@ -296,6 +296,21 @@ Every OpenStack shoot cluster will be deployed with the OpenStack Cinder CSI dri
 It is compatible with the legacy in-tree volume provisioner that was deprecated by the Kubernetes community and will be removed in future versions of Kubernetes.
 End-users might want to update their custom `StorageClass`es to the new `cinder.csi.openstack.org` provisioner.
 
+### VolumeSnapshotClass
+
+Every OpenStack shoot cluster is deployed with a managed `VolumeSnapshotClass` named `csi-cinder` for the Cinder CSI driver:
+
+```yaml
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshotClass
+metadata:
+  name: csi-cinder
+driver: cinder.csi.openstack.org
+deletionPolicy: Delete
+```
+
+By default, this class is annotated as the cluster-wide default (`snapshot.storage.kubernetes.io/is-default-class: "true"`), so `VolumeSnapshot` objects that do not explicitly reference a snapshot class will use it automatically.
+
 ## Kubernetes Versions per Worker Pool
 
 This extension supports `gardener/gardener`'s `WorkerPoolKubernetesVersion` feature gate, i.e., having [worker pools with overridden Kubernetes versions](https://github.com/gardener/gardener/blob/8a9c88866ec5fce59b5acf57d4227eeeb73669d7/example/90-shoot.yaml#L69-L70) since `gardener-extension-provider-openstack@v1.23`.


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area quality
/kind enhancement
/platform openstack

**What this PR does / why we need it**:
This PR adds managed default VolumeSnapshotClass for Cinder.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener-extension-provider-openstack/issues/1318

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Add managed default VolumeSnapshotClass for Cinder
```
