### PR TITLE
`feature:` support for additional security groups in worker configuration

### DIFF
--- a/docs/usage/usage.md
+++ b/docs/usage/usage.md
@@ -214,6 +214,8 @@ serverGroup:
 #  - name: my-rolling-label
 #    value: bar
 #    triggerRollingOnUpdate: true # means any change of the machine label value will trigger rolling of all machines of the worker pool
+# additionalSecurityGroups:
+# - my-existing-security-group
 ```
 
 ### ServerGroups
@@ -233,6 +235,11 @@ Please note the following restrictions when deploying workers with server groups
 The `machineLabels` section in the worker group configuration allows to specify additional machine labels. These labels are added to the machine
 instances only, but not to the node object. Additionally, they have an optional `triggerRollingOnUpdate` field. If it is set to `true`, changing the label value
 will trigger a rolling of all machines of this worker pool.
+
+### AdditionalSecurityGroups
+The `additionalSecurityGroups` field allows attaching one or more pre-existing OpenStack security groups to every node in the worker pool, in addition to the security group that is automatically managed by the infrastructure reconciler. The security groups are referenced by name and must already exist in OpenStack before the worker pool is reconciled.
+
+Any change to the list of additional security groups (adding, removing, or renaming entries) will trigger a rolling replacement of all machines in the worker pool. Reordering the list without changing the entries does not trigger a roll.
 
 ### Node Templates
 Node templates allow users to override the capacity of the nodes as defined by the server flavor specified in the `CloudProfile`'s `machineTypes`. This is useful for certain dynamic scenarios as it allows users to customize cluster-autoscaler's behavior for these workergroup with their provided values.

--- a/example/30-worker.yaml
+++ b/example/30-worker.yaml
@@ -114,3 +114,5 @@ spec:
 #          cpu: 2
 #          gpu: 0
 #          memory: 50Gi
+#      additionalSecurityGroups:
+#      - my-existing-security-group

--- a/hack/api-reference/api.md
+++ b/hack/api-reference/api.md
@@ -2189,6 +2189,20 @@ OpenStack provider extension will try to create a new server group for instances
 <p>MachineLabels define key value pairs to add to machines.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>additionalSecurityGroups</code></br>
+<em>
+[]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>AdditionalSecurityGroups is a list of names of pre-existing OpenStack security
+groups to attach to every node in this worker pool, in addition to the
+auto-managed &ldquo;nodes&rdquo; security group.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <hr/>

--- a/pkg/apis/openstack/types_worker.go
+++ b/pkg/apis/openstack/types_worker.go
@@ -69,6 +69,12 @@ type WorkerConfig struct {
 
 	// MachineLabels define key value pairs to add to machines.
 	MachineLabels []MachineLabel
+
+	// AdditionalSecurityGroups is a list of names of pre-existing OpenStack security
+	// groups to attach to every node in this worker pool, in addition to the
+	// auto-managed "nodes" security group.
+	// +optional
+	AdditionalSecurityGroups []string
 }
 
 // MachineLabel define key value pair to label machines.

--- a/pkg/apis/openstack/v1alpha1/types_worker.go
+++ b/pkg/apis/openstack/v1alpha1/types_worker.go
@@ -72,6 +72,12 @@ type WorkerConfig struct {
 
 	// MachineLabels define key value pairs to add to machines.
 	MachineLabels []MachineLabel `json:"machineLabels,omitempty"`
+
+	// AdditionalSecurityGroups is a list of names of pre-existing OpenStack security
+	// groups to attach to every node in this worker pool, in addition to the
+	// auto-managed "nodes" security group.
+	// +optional
+	AdditionalSecurityGroups []string `json:"additionalSecurityGroups,omitempty"`
 }
 
 // MachineLabel define key value pair to label machines.

--- a/pkg/apis/openstack/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/openstack/v1alpha1/zz_generated.conversion.go
@@ -1232,6 +1232,7 @@ func autoConvert_v1alpha1_WorkerConfig_To_openstack_WorkerConfig(in *WorkerConfi
 	out.NodeTemplate = (*extensionsv1alpha1.NodeTemplate)(unsafe.Pointer(in.NodeTemplate))
 	out.ServerGroup = (*openstack.ServerGroup)(unsafe.Pointer(in.ServerGroup))
 	out.MachineLabels = *(*[]openstack.MachineLabel)(unsafe.Pointer(&in.MachineLabels))
+	out.AdditionalSecurityGroups = *(*[]string)(unsafe.Pointer(&in.AdditionalSecurityGroups))
 	return nil
 }
 
@@ -1244,6 +1245,7 @@ func autoConvert_openstack_WorkerConfig_To_v1alpha1_WorkerConfig(in *openstack.W
 	out.NodeTemplate = (*extensionsv1alpha1.NodeTemplate)(unsafe.Pointer(in.NodeTemplate))
 	out.ServerGroup = (*ServerGroup)(unsafe.Pointer(in.ServerGroup))
 	out.MachineLabels = *(*[]MachineLabel)(unsafe.Pointer(&in.MachineLabels))
+	out.AdditionalSecurityGroups = *(*[]string)(unsafe.Pointer(&in.AdditionalSecurityGroups))
 	return nil
 }
 

--- a/pkg/apis/openstack/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/openstack/v1alpha1/zz_generated.deepcopy.go
@@ -966,6 +966,11 @@ func (in *WorkerConfig) DeepCopyInto(out *WorkerConfig) {
 		*out = make([]MachineLabel, len(*in))
 		copy(*out, *in)
 	}
+	if in.AdditionalSecurityGroups != nil {
+		in, out := &in.AdditionalSecurityGroups, &out.AdditionalSecurityGroups
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/apis/openstack/validation/worker.go
+++ b/pkg/apis/openstack/validation/worker.go
@@ -22,6 +22,7 @@ func ValidateWorkerConfig(worker *core.Worker, workerConfig *api.WorkerConfig, c
 	allErrs = append(allErrs, ValidateServerGroup(worker, workerConfig.ServerGroup, cloudProfileConfig, fldPath.Child("serverGroup"))...)
 	allErrs = append(allErrs, ValidateNodeTemplate(workerConfig.NodeTemplate, fldPath.Child("nodeTemplate"))...)
 	allErrs = append(allErrs, ValidateMachineLabels(worker, workerConfig, fldPath.Child("machineLabels"))...)
+	allErrs = append(allErrs, ValidateAdditionalSecurityGroups(workerConfig.AdditionalSecurityGroups, fldPath.Child("additionalSecurityGroups"))...)
 
 	return allErrs
 }
@@ -129,5 +130,16 @@ func ValidateMachineLabels(worker *core.Worker, workerConfig *api.WorkerConfig, 
 		}
 	}
 
+	return allErrs
+}
+
+// ValidateAdditionalSecurityGroups validates the additionalSecurityGroups list of a WorkerConfig.
+func ValidateAdditionalSecurityGroups(names []string, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	for i, name := range names {
+		if name == "" {
+			allErrs = append(allErrs, field.Required(fldPath.Index(i), "security group name must not be empty"))
+		}
+	}
 	return allErrs
 }

--- a/pkg/apis/openstack/validation/worker.go
+++ b/pkg/apis/openstack/validation/worker.go
@@ -136,9 +136,16 @@ func ValidateMachineLabels(worker *core.Worker, workerConfig *api.WorkerConfig, 
 // ValidateAdditionalSecurityGroups validates the additionalSecurityGroups list of a WorkerConfig.
 func ValidateAdditionalSecurityGroups(names []string, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
+	seen := make(map[string]int, len(names))
 	for i, name := range names {
 		if name == "" {
 			allErrs = append(allErrs, field.Required(fldPath.Index(i), "security group name must not be empty"))
+			continue
+		}
+		if j, ok := seen[name]; ok {
+			allErrs = append(allErrs, field.Invalid(fldPath.Index(i), name, fmt.Sprintf("duplicate security group, already listed at index %d", j)))
+		} else {
+			seen[name] = i
 		}
 	}
 	return allErrs

--- a/pkg/apis/openstack/validation/worker_test.go
+++ b/pkg/apis/openstack/validation/worker_test.go
@@ -328,6 +328,15 @@ var _ = Describe("ValidateWorkerConfig", func() {
 				})),
 			))
 		})
+
+		It("should return an error for duplicate security group names", func() {
+			Expect(ValidateAdditionalSecurityGroups([]string{"sg-1", "sg-2", "sg-1"}, fldPath.Child("additionalSecurityGroups"))).To(ConsistOf(
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("config.additionalSecurityGroups[2]"),
+				})),
+			))
+		})
 	})
 
 	Describe("#ValidateNodeTemplate", func() {

--- a/pkg/apis/openstack/validation/worker_test.go
+++ b/pkg/apis/openstack/validation/worker_test.go
@@ -309,6 +309,27 @@ var _ = Describe("ValidateWorkerConfig", func() {
 		})
 	})
 
+	Describe("#ValidateAdditionalSecurityGroups", func() {
+		var fldPath = field.NewPath("config")
+
+		It("should return no errors for an empty list", func() {
+			Expect(ValidateAdditionalSecurityGroups(nil, fldPath.Child("additionalSecurityGroups"))).To(BeEmpty())
+		})
+
+		It("should return no errors for valid names", func() {
+			Expect(ValidateAdditionalSecurityGroups([]string{"sg-1", "my-security-group"}, fldPath.Child("additionalSecurityGroups"))).To(BeEmpty())
+		})
+
+		It("should return an error for an empty string entry", func() {
+			Expect(ValidateAdditionalSecurityGroups([]string{"sg-1", ""}, fldPath.Child("additionalSecurityGroups"))).To(ConsistOf(
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeRequired),
+					"Field": Equal("config.additionalSecurityGroups[1]"),
+				})),
+			))
+		})
+	})
+
 	Describe("#ValidateNodeTemplate", func() {
 		var (
 			fldPath      = field.NewPath("config")

--- a/pkg/apis/openstack/zz_generated.deepcopy.go
+++ b/pkg/apis/openstack/zz_generated.deepcopy.go
@@ -966,6 +966,11 @@ func (in *WorkerConfig) DeepCopyInto(out *WorkerConfig) {
 		*out = make([]MachineLabel, len(*in))
 		copy(*out, *in)
 	}
+	if in.AdditionalSecurityGroups != nil {
+		in, out := &in.AdditionalSecurityGroups, &out.AdditionalSecurityGroups
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -182,6 +182,7 @@ func (w *WorkerDelegate) generateMachineConfig(ctx context.Context) error {
 
 		for zoneIndex, zone := range pool.Zones {
 			zoneIdx := int32(zoneIndex) // #nosec: G115 - We validate if num pool zones exceeds max_int32.
+			securityGroups := append([]string{nodesSecurityGroup.Name}, workerConfig.AdditionalSecurityGroups...)
 			machineClassSpec := map[string]interface{}{
 				"region":           w.worker.Spec.Region,
 				"availabilityZone": zone,
@@ -189,7 +190,7 @@ func (w *WorkerDelegate) generateMachineConfig(ctx context.Context) error {
 				"keyName":          infrastructureStatus.Node.KeyName,
 				"networkID":        infrastructureStatus.Networks.ID,
 				"podNetworkCIDRs":  extensionscontroller.GetPodNetwork(w.cluster),
-				"securityGroups":   []string{nodesSecurityGroup.Name},
+				"securityGroups":   securityGroups,
 				"tags": utils.MergeStringMaps(
 					NormalizeLabelsForMachineClass(pool.Labels),
 					NormalizeLabelsForMachineClass(machineLabels),
@@ -358,6 +359,12 @@ func (w *WorkerDelegate) generateWorkerPoolHash(pool extensionsv1alpha1.WorkerPo
 		// include machine labels marked for rolling
 		sort.Strings(pairs)
 		additionalHashData = append(additionalHashData, pairs...)
+	}
+
+	if len(workerConfig.AdditionalSecurityGroups) > 0 {
+		sortedSGs := append([]string(nil), workerConfig.AdditionalSecurityGroups...)
+		sort.Strings(sortedSGs)
+		additionalHashData = append(additionalHashData, sortedSGs...)
 	}
 
 	// hash v1 would otherwise hash the ProviderConfig

--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -1266,6 +1266,40 @@ var _ = Describe("Machines", func() {
 				})
 			})
 
+			Context("Additional Security Groups", func() {
+				It("should include additional security groups in the machine class and handle rolling updates", func() {
+					applySGs := func(sgs []string) string {
+						workerConfig := &apiv1alpha1.WorkerConfig{
+							TypeMeta: metav1.TypeMeta{
+								Kind:       "WorkerConfig",
+								APIVersion: apiv1alpha1.SchemeGroupVersion.String(),
+							},
+							AdditionalSecurityGroups: sgs,
+						}
+						w.Spec.Pools[0].ProviderConfig = &runtime.RawExtension{
+							Raw: encode(workerConfig),
+						}
+						workerDelegate, _ := NewWorkerDelegate(c, scheme, chartApplier, w, cluster, nil)
+						expectedUserDataSecretRefRead()
+						result, err := workerDelegate.GenerateMachineDeployments(ctx)
+						Expect(err).NotTo(HaveOccurred())
+						return result[0].ClassName
+					}
+
+					classNameNone := applySGs(nil)
+					classNameWithSGs := applySGs([]string{"sg-a", "sg-b"})
+					classNameReordered := applySGs([]string{"sg-b", "sg-a"})
+					classNameDifferent := applySGs([]string{"sg-a", "sg-c"})
+
+					// adding security groups must trigger a roll
+					Expect(classNameNone).NotTo(Equal(classNameWithSGs))
+					// reordering must not trigger a roll
+					Expect(classNameWithSGs).To(Equal(classNameReordered))
+					// different names must trigger a roll
+					Expect(classNameWithSGs).NotTo(Equal(classNameDifferent))
+				})
+			})
+
 			It("should fail because the version is invalid", func() {
 				clusterWithoutImages.Shoot.Spec.Kubernetes.Version = "invalid"
 				workerDelegate, _ = NewWorkerDelegate(c, scheme, chartApplier, w, cluster, nil)


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area quality
/kind enhancement
/platform openstack

**What this PR does / why we need it**:
This PR adds support for additional security groups in worker configuration.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener-extension-provider-openstack/issues/1031

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
support for additional security groups in worker configuration
```
