### PR TITLE
fix: filter DNS servers by IP family in reconcile logic

### DIFF
--- a/pkg/controller/infrastructure/infraflow/infraflow_suite_test.go
+++ b/pkg/controller/infrastructure/infraflow/infraflow_suite_test.go
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package infraflow
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestInfraflow(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Infraflow Suite")
+}

--- a/pkg/controller/infrastructure/infraflow/reconcile.go
+++ b/pkg/controller/infrastructure/infraflow/reconcile.go
@@ -306,7 +306,7 @@ func (fctx *FlowContext) ensureSubnet(ctx context.Context) error {
 		Name:           fctx.defaultSubnetName(),
 		NetworkID:      networkID,
 		IPVersion:      4,
-		DNSNameservers: fctx.cloudProfileConfig.DNSServers,
+		DNSNameservers: filterDNSServersByIPFamily(fctx.cloudProfileConfig.DNSServers, gardencorev1beta1.IPFamilyIPv4),
 	}
 	if fctx.config.Networks.SubnetPool != nil {
 		desired.SubnetPoolID = fctx.config.Networks.SubnetPool.ID
@@ -378,7 +378,7 @@ func (fctx *FlowContext) ensureSubnetIPv6(ctx context.Context) error {
 			NetworkID:       networkID,
 			CIDR:            nodeCIDR,
 			IPVersion:       6,
-			DNSNameservers:  fctx.cloudProfileConfig.DNSServers,
+			DNSNameservers:  filterDNSServersByIPFamily(fctx.cloudProfileConfig.DNSServers, gardencorev1beta1.IPFamilyIPv6),
 			IPv6RAMode:      "slaac",
 			IPv6AddressMode: "slaac",
 			SubnetPoolID:    subnetPoolID,
@@ -388,7 +388,7 @@ func (fctx *FlowContext) ensureSubnetIPv6(ctx context.Context) error {
 			NetworkID:      networkID,
 			CIDR:           podCIDR,
 			IPVersion:      6,
-			DNSNameservers: fctx.cloudProfileConfig.DNSServers,
+			DNSNameservers: filterDNSServersByIPFamily(fctx.cloudProfileConfig.DNSServers, gardencorev1beta1.IPFamilyIPv6),
 			SubnetPoolID:   subnetPoolID,
 		},
 		{
@@ -396,7 +396,7 @@ func (fctx *FlowContext) ensureSubnetIPv6(ctx context.Context) error {
 			NetworkID:      networkID,
 			CIDR:           serviceCIDR,
 			IPVersion:      6,
-			DNSNameservers: fctx.cloudProfileConfig.DNSServers,
+			DNSNameservers: filterDNSServersByIPFamily(fctx.cloudProfileConfig.DNSServers, gardencorev1beta1.IPFamilyIPv6),
 			SubnetPoolID:   subnetPoolID,
 		},
 	}

--- a/pkg/controller/infrastructure/infraflow/utils.go
+++ b/pkg/controller/infrastructure/infraflow/utils.go
@@ -62,6 +62,20 @@ func sliceToPtr[T any](slice []T) []*T {
 	return res
 }
 
+// filterDNSServersByIPFamily returns only the DNS servers matching the given IP family.
+// OpenStack rejects DNS nameservers whose address family doesn't match the subnet's IP version.
+func filterDNSServersByIPFamily(dnsServers []string, ipFamily gardencorev1beta1.IPFamily) []string {
+	var result []string
+	for _, ip := range dnsServers {
+		if ipFamily == gardencorev1beta1.IPFamilyIPv4 && netutils.IsIPv4String(ip) {
+			result = append(result, ip)
+		} else if ipFamily == gardencorev1beta1.IPFamilyIPv6 && netutils.IsIPv6String(ip) {
+			result = append(result, ip)
+		}
+	}
+	return result
+}
+
 // ComputeEgressCIDRs converts an IP to a CIDR depending on the IP family.
 func ComputeEgressCIDRs(ips []string) []string {
 	var result []string

--- a/pkg/controller/infrastructure/infraflow/utils_test.go
+++ b/pkg/controller/infrastructure/infraflow/utils_test.go
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package infraflow
+
+import (
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("filterDNSServersByIPFamily", func() {
+	DescribeTable("filters DNS servers by IP family",
+		func(servers []string, family gardencorev1beta1.IPFamily, expected []string) {
+			Expect(filterDNSServersByIPFamily(servers, family)).To(Equal(expected))
+		},
+		Entry("returns only IPv4 addresses when family is IPv4",
+			[]string{"8.8.8.8", "2001:4860:4860::8888", "1.1.1.1"},
+			gardencorev1beta1.IPFamilyIPv4,
+			[]string{"8.8.8.8", "1.1.1.1"},
+		),
+		Entry("returns only IPv6 addresses when family is IPv6",
+			[]string{"8.8.8.8", "2001:4860:4860::8888", "2606:4700:4700::1111"},
+			gardencorev1beta1.IPFamilyIPv6,
+			[]string{"2001:4860:4860::8888", "2606:4700:4700::1111"},
+		),
+		Entry("returns nil when no addresses match IPv4 family",
+			[]string{"2001:4860:4860::8888"},
+			gardencorev1beta1.IPFamilyIPv4,
+			nil,
+		),
+		Entry("returns nil when no addresses match IPv6 family",
+			[]string{"8.8.8.8", "1.1.1.1"},
+			gardencorev1beta1.IPFamilyIPv6,
+			nil,
+		),
+		Entry("returns nil for empty input",
+			[]string{},
+			gardencorev1beta1.IPFamilyIPv4,
+			nil,
+		),
+		Entry("returns nil for nil input",
+			nil,
+			gardencorev1beta1.IPFamilyIPv4,
+			nil,
+		),
+		Entry("handles all-IPv4 input with IPv4 family",
+			[]string{"8.8.8.8", "1.1.1.1"},
+			gardencorev1beta1.IPFamilyIPv4,
+			[]string{"8.8.8.8", "1.1.1.1"},
+		),
+		Entry("handles all-IPv6 input with IPv6 family",
+			[]string{"2001:4860:4860::8888", "2606:4700:4700::1111"},
+			gardencorev1beta1.IPFamilyIPv6,
+			[]string{"2001:4860:4860::8888", "2606:4700:4700::1111"},
+		),
+	)
+})


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area quality
/kind enhancement
/platform openstack

**What this PR does / why we need it**:
When creating a dual-stack shoot cluster (IPv4 + IPv6), the IPv6 subnet creation fails because the dnsServers in the cloud profile contain only IPv4 addresses. OpenStack rejects IPv4 DNS servers when configuring an IPv6 subnet.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener-extension-provider-openstack/issues/1346

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Filter subnet DNS servers from CloudProfile by IP family in reconcile logic
```
