### PR TITLE
[port] Enable caching in build pipelines

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -121,12 +121,12 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/setup-go@v5
-        with:
-          go-version: '1.26'
       - uses: gardener/cc-utils/.github/actions/trusted-checkout@v1
         with:
           remove-trusted-label: false
+      - uses: actions/setup-go@v6
+        with:
+          go-version: '1.26'
       - name: run-verify
         run: |
           set -euo pipefail


### PR DESCRIPTION
Port of gardener/gardener-extension-provider-azure#1530 from azure.

## Changes

- Reorder build steps: move `trusted-checkout` before `setup-go` so `setup-go` can use the checked-out `go.mod`/`go.sum` for cache key generation
- Upgrade `setup-go` from v5 to v6

/area dev-productivity
/kind enhancement