### PR TITLE
`Fix:` add share client worker cidr fall back

### DIFF
--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -923,6 +923,10 @@ func (vp *valuesProvider) addCSIManilaValues(
 		"clusterID": cp.Namespace,
 	}
 
+	infraConfig, err := helper.InfrastructureConfigFromRawExtension(cluster.Shoot.Spec.Provider.InfrastructureConfig)
+	if err != nil {
+		return fmt.Errorf("could not decode infrastructure config of controlplane '%s': %w", k8sclient.ObjectKeyFromObject(cp), err)
+	}
 	infraStatus, err := vp.getInfrastructureStatus(cp)
 	if err != nil {
 		return err
@@ -952,10 +956,16 @@ func (vp *valuesProvider) addCSIManilaValues(
 	if err != nil {
 		return fmt.Errorf("could not find nodes subnet in infrastructure status: %w", err)
 	}
+	shareClient := nodesSubnet.CIDR
+	// If the status has not yet been updated, we need to fall back to the value from the spec
+	// TODO remove in future release
+	if shareClient == "" {
+		shareClient = infraConfig.WorkersCIDR()
+	}
 	values["openstack"] = map[string]interface{}{
 		"availabilityZones":           vp.getAllWorkerPoolsZones(cluster),
 		"shareNetworkID":              shareNetworkID,
-		"shareClient":                 nodesSubnet.CIDR,
+		"shareClient":                 shareClient,
 		"authURL":                     authURL,
 		"region":                      cp.Spec.Region,
 		"domainName":                  domainName,

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -754,6 +754,45 @@ var _ = Describe("ValuesProvider", func() {
 					"calico-mutating-admission-policy": enabledFalse,
 				}))
 			})
+			It("should fall back to Workers CIDR from infra config when nodes subnet CIDR is empty in infra status", func() {
+				c.EXPECT().Get(ctx, cpSecretKey, &corev1.Secret{}).DoAndReturn(clientGet(cpSecret))
+
+				// Simulate a shoot whose infrastructure status was written before the CIDR field
+				// was populated in the subnet status (pre-subnet-pool feature).
+				cpManila := defaultControlPlaneWithManila(true)
+				// Override the subnet to have an empty CIDR.
+				cpManila.Spec.InfrastructureProviderStatus = &runtime.RawExtension{
+					Raw: encode(&api.InfrastructureStatus{
+						Networks: api.NetworkStatus{
+							Name: technicalID,
+							FloatingPool: api.FloatingPoolStatus{
+								ID: "floating-network-id",
+							},
+							Router: api.RouterStatus{
+								ID: "routerID",
+							},
+							Subnets: []api.Subnet{
+								{
+									ID:      "subnet-acbd1234",
+									Purpose: api.PurposeNodes,
+									CIDR:    "", // empty: pre-dates the field being written
+								},
+							},
+							ShareNetwork: &api.ShareNetworkStatus{
+								ID:   "1111-2222-3333-4444",
+								Name: "sharenetwork",
+							},
+						},
+					}),
+				}
+
+				values, err := vp.GetControlPlaneShootChartValues(ctx, cpManila, cluster, fakeSecretsManager, map[string]string{})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(values).To(HaveKey(openstack.CSIDriverManila))
+				// Falls back to Workers CIDR from infra config ("10.200.0.0/19").
+				Expect(values[openstack.CSIDriverManila]).To(HaveKeyWithValue("openstack", HaveKeyWithValue("shareClient", "10.200.0.0/19")))
+			})
+
 			It("should return correct shoot control plane chart if CSI Manila is enabled and subnet pool is used", func() {
 				c.EXPECT().Get(ctx, cpSecretKey, &corev1.Secret{}).DoAndReturn(clientGet(cpSecret))
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area control-plane
/kind bug
/platform openstack

**What this PR does / why we need it**:
https://github.com/gardener/gardener-extension-provider-openstack/pull/1326 introduced a race condition for existing shoots.
The change added a new subnetCIDR status field that is consumed during control plane reconciliation. 
However, the infrastructure reconciliation may not have populated the infrastructure status yet when the control plane reconciliation reads it, leading to a race condition for existing shoots.
For new shoots, the infra controller always writes CIDR into the subnet status from the very first reconcile so nodesSubnet.CIDR will always be set before the control plane can meaningfully reconcile.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fix CSI manila share client value race condition in control plane reconciliation
```
