### PR TITLE
Fix: prevent nil pointer panic in machine image lookup

### DIFF
--- a/pkg/apis/openstack/helper/helper.go
+++ b/pkg/apis/openstack/helper/helper.go
@@ -214,17 +214,18 @@ func convertRegionsToCapabilityFlavors(regions []api.RegionIDMapping, image stri
 // The worker status is an external source that may contain images in either legacy format (Architecture field)
 // or capability format (Capabilities field). The capabilityDefinitions parameter should be the original
 // (non-normalized) spec.MachineCapabilities from the CloudProfile to distinguish the two cases.
-func FindImageInWorkerStatus(machineImages []api.MachineImage, name string, version string, architecture *string, machineCapabilities gardencorev1beta1.Capabilities, capabilityDefinitions []gardencorev1beta1.CapabilityDefinition) (*api.MachineImage, error) {
+// An empty architecture is treated as the default architecture (amd64).
+func FindImageInWorkerStatus(machineImages []api.MachineImage, name string, version string, architecture string, machineCapabilities gardencorev1beta1.Capabilities, capabilityDefinitions []gardencorev1beta1.CapabilityDefinition) (*api.MachineImage, error) {
+	if architecture == "" {
+		architecture = v1beta1constants.ArchitectureAMD64
+	}
 	if len(capabilityDefinitions) == 0 {
 		for _, statusMachineImage := range machineImages {
-			if statusMachineImage.Architecture == nil {
-				statusMachineImage.Architecture = ptr.To(v1beta1constants.ArchitectureAMD64)
-			}
-			if statusMachineImage.Name == name && statusMachineImage.Version == version && ptr.Equal(architecture, statusMachineImage.Architecture) {
+			if statusMachineImage.Name == name && statusMachineImage.Version == version && architecture == ptr.Deref(statusMachineImage.Architecture, v1beta1constants.ArchitectureAMD64) {
 				return &statusMachineImage, nil
 			}
 		}
-		return nil, fmt.Errorf("no machine image found for image %q with version %q and architecture %q", name, version, *architecture)
+		return nil, fmt.Errorf("no machine image found for image %q with version %q and architecture %q", name, version, architecture)
 	}
 
 	// Capability format: find the best matching capability set.

--- a/pkg/apis/openstack/helper/helper_test.go
+++ b/pkg/apis/openstack/helper/helper_test.go
@@ -191,9 +191,9 @@ var _ = Describe("Helper", func() {
 		}
 
 		DescribeTable("#FindImageInWorkerStatus",
-			func(machineImages []api.MachineImage, name, version string, arch *string, expectedMachineImage *api.MachineImage, expectErr bool) {
+			func(machineImages []api.MachineImage, name, version string, arch string, expectedMachineImage *api.MachineImage, expectErr bool) {
 				if hasCapabilities {
-					machineTypeCapabilities["architecture"] = []string{*arch}
+					machineTypeCapabilities["architecture"] = []string{arch}
 					if expectedMachineImage != nil {
 						expectedMachineImage.Capabilities = imageCapabilities
 						expectedMachineImage.Architecture = nil
@@ -203,13 +203,13 @@ var _ = Describe("Helper", func() {
 				expectResults(machineImage, expectedMachineImage, err, expectErr)
 			},
 
-			Entry("list is nil", nil, "bar", "1.2.3", ptr.To("amd64"), nil, true),
-			Entry("empty list", []api.MachineImage{}, "image", "1.2.3", ptr.To("amd64"), nil, true),
-			Entry("entry not found (no name)", makeStatusMachineImages("bar", "1.2.3", "id-1234", ptr.To("amd64"), imageCapabilities), "foo", "1.2.3", ptr.To("amd64"), nil, true),
-			Entry("entry not found (no version)", makeStatusMachineImages("bar", "1.2.3", "id-1234", ptr.To("amd64"), imageCapabilities), "bar", "1.2.ś", ptr.To("amd64"), nil, true),
-			Entry("entry not found (no architecture)", []api.MachineImage{{Name: "bar", Version: "1.2.3", Architecture: ptr.To("arm64"), Capabilities: gardencorev1beta1.Capabilities{"architecture": []string{"arm64"}}}}, "bar", "1.2.3", ptr.To("amd64"), nil, true),
-			Entry("entry exists if architecture is nil", makeStatusMachineImages("bar", "1.2.3", "id-1234", nil, imageCapabilities), "bar", "1.2.3", ptr.To("amd64"), &api.MachineImage{Name: "bar", Version: "1.2.3", ID: "id-1234", Architecture: ptr.To("amd64")}, false),
-			Entry("entry exists", makeStatusMachineImages("bar", "1.2.3", "id-1234", ptr.To("amd64"), imageCapabilities), "bar", "1.2.3", ptr.To("amd64"), &api.MachineImage{Name: "bar", Version: "1.2.3", ID: "id-1234", Architecture: ptr.To("amd64")}, false),
+			Entry("list is nil", nil, "bar", "1.2.3", "amd64", nil, true),
+			Entry("empty list", []api.MachineImage{}, "image", "1.2.3", "amd64", nil, true),
+			Entry("entry not found (no name)", makeStatusMachineImages("bar", "1.2.3", "id-1234", ptr.To("amd64"), imageCapabilities), "foo", "1.2.3", "amd64", nil, true),
+			Entry("entry not found (no version)", makeStatusMachineImages("bar", "1.2.3", "id-1234", ptr.To("amd64"), imageCapabilities), "bar", "1.2.ś", "amd64", nil, true),
+			Entry("entry not found (no architecture)", []api.MachineImage{{Name: "bar", Version: "1.2.3", Architecture: ptr.To("arm64"), Capabilities: gardencorev1beta1.Capabilities{"architecture": []string{"arm64"}}}}, "bar", "1.2.3", "amd64", nil, true),
+			Entry("entry exists if architecture is nil", makeStatusMachineImages("bar", "1.2.3", "id-1234", nil, imageCapabilities), "bar", "1.2.3", "amd64", &api.MachineImage{Name: "bar", Version: "1.2.3", ID: "id-1234", Architecture: nil}, false),
+			Entry("entry exists", makeStatusMachineImages("bar", "1.2.3", "id-1234", ptr.To("amd64"), imageCapabilities), "bar", "1.2.3", "amd64", &api.MachineImage{Name: "bar", Version: "1.2.3", ID: "id-1234", Architecture: ptr.To("amd64")}, false),
 		)
 
 		DescribeTable("#FindImageInCloudProfile",

--- a/pkg/controller/worker/machine_images.go
+++ b/pkg/controller/worker/machine_images.go
@@ -41,7 +41,7 @@ func (w *WorkerDelegate) UpdateMachineImagesStatus(ctx context.Context) error {
 	return nil
 }
 
-func (w *WorkerDelegate) selectMachineImageForWorkerPool(name, version string, region string, machineCapabilities gardencorev1beta1.Capabilities, capabilityDefinitions []gardencorev1beta1.CapabilityDefinition) (*api.MachineImage, error) {
+func (w *WorkerDelegate) selectMachineImageForWorkerPool(name, version string, region string, arch string, machineCapabilities gardencorev1beta1.Capabilities, capabilityDefinitions []gardencorev1beta1.CapabilityDefinition) (*api.MachineImage, error) {
 	selectedMachineImage := &api.MachineImage{
 		Name:    name,
 		Version: version,
@@ -68,14 +68,9 @@ func (w *WorkerDelegate) selectMachineImageForWorkerPool(name, version string, r
 
 		// Pass the original (non-normalized) MachineCapabilities so FindImageInWorkerStatus
 		// can distinguish legacy format (Architecture field) from capability format (Capabilities field).
-		return helper.FindImageInWorkerStatus(workerStatus.MachineImages, name, version, nil, machineCapabilities, w.cluster.CloudProfile.Spec.MachineCapabilities)
+		return helper.FindImageInWorkerStatus(workerStatus.MachineImages, name, version, arch, machineCapabilities, w.cluster.CloudProfile.Spec.MachineCapabilities)
 	}
 
-	archValues := machineCapabilities[v1beta1constants.ArchitectureName]
-	arch := v1beta1constants.ArchitectureAMD64
-	if len(archValues) > 0 {
-		arch = archValues[0]
-	}
 	return nil, worker.ErrorMachineImageNotFound(name, version, arch, region)
 }
 

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -138,7 +138,7 @@ func (w *WorkerDelegate) generateMachineConfig(ctx context.Context) error {
 		capabilityDefinitions := helper.NormalizeCapabilityDefinitions(w.cluster.CloudProfile.Spec.MachineCapabilities)
 		architecture := ptr.Deref(pool.Architecture, v1beta1constants.ArchitectureAMD64)
 		machineTypeCapabilities := helper.NormalizeMachineTypeCapabilities(machineTypeFromCloudProfile.Capabilities, &architecture, capabilityDefinitions)
-		machineImage, err := w.selectMachineImageForWorkerPool(pool.MachineImage.Name, pool.MachineImage.Version, w.worker.Spec.Region, machineTypeCapabilities, capabilityDefinitions)
+		machineImage, err := w.selectMachineImageForWorkerPool(pool.MachineImage.Name, pool.MachineImage.Version, w.worker.Spec.Region, architecture, machineTypeCapabilities, capabilityDefinitions)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
**How to categorize this PR?**

/area robustness
/kind bug
/platform openstack

**What this PR does / why we need it**:

Fixes a nil pointer dereference panic in `FindImageInWorkerStatus` that crashed the worker controller during reconcile and delete of half-initialized workers (e.g. workers that never finished their first reconciliation, so `providerStatus.machineImages` is empty, while the referenced image is also no longer present in the CloudProfile).

- Change `FindImageInWorkerStatus` `architecture` parameter from `*string` to `string`; default empty to `amd64`.
- Pass an architecture explicitly from `selectMachineImageForWorkerPool` (previously hard-coded `nil`, which both caused the panic and prevented any legacy-format match from succeeding).
- Update tests accordingly.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
cc @hebelsan 

**Release note**:
```bugfix operator
Fix a nil pointer dereference panic in the worker controller that could prevent reconciliation or deletion of workers whose `providerStatus.machineImages` was empty and whose referenced machine image was missing from the CloudProfile.
```
