### PR TITLE
Migrate shoot DNS provider validation from secretName to credentialsRef

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ The following lists known compatibility issues of this extension controller with
 | OpenStack Extension | Gardener | Action | Notes |
 | ----- | ----- | --- |  --------------- |
 | `< v1.12.0` | `> v1.10.0` |  Please update the provider version to `>= v1.12.0` or disable the feature gate `MountHostCADirectories` in the Gardenlet. | Applies if feature flag `MountHostCADirectories` in the Gardenlet is enabled. This is to prevent duplicate volume mounts to `/usr/share/ca-certificates` in the Shoot API Server. |
+| `>= v1.56.0` | `< v1.135.0` | Please update Gardener to version `>= v1.135.0`. | The shoot API field `shoot.spec.dns.providers[].secretName` has been deprecated in favor of `shoot.spec.dns.providers[].credentialsRef` which is available in Gardener `>= v1.135.0`; the provider extension is adapted to use the new field from `v1.56.0` onward. |
 
 ## How to start using or developing this extension controller locally
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ The following lists known compatibility issues of this extension controller with
 | OpenStack Extension | Gardener | Action | Notes |
 | ----- | ----- | --- |  --------------- |
 | `< v1.12.0` | `> v1.10.0` |  Please update the provider version to `>= v1.12.0` or disable the feature gate `MountHostCADirectories` in the Gardenlet. | Applies if feature flag `MountHostCADirectories` in the Gardenlet is enabled. This is to prevent duplicate volume mounts to `/usr/share/ca-certificates` in the Shoot API Server. |
-| `>= v1.56.0` | `< v1.135.0` | Please update Gardener to version `>= v1.135.0`. | The shoot API field `shoot.spec.dns.providers[].secretName` has been deprecated in favor of `shoot.spec.dns.providers[].credentialsRef` which is available in Gardener `>= v1.135.0`; the provider extension is adapted to use the new field from `v1.56.0` onward. |
 
 ## How to start using or developing this extension controller locally
 

--- a/pkg/admission/validator/shoot.go
+++ b/pkg/admission/validator/shoot.go
@@ -21,7 +21,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
@@ -280,27 +279,30 @@ func (s *shoot) validateDNS(ctx context.Context, shoot *core.Shoot) field.ErrorL
 			continue
 		}
 
-		providerFldPath := providersPath.Index(i)
+		credentialsFldPath := providersPath.Index(i).Child("credentialsRef")
 
-		if ptr.Deref(p.SecretName, "") == "" {
-			allErrs = append(allErrs, field.Required(providerFldPath.Child("secretName"),
-				fmt.Sprintf("secretName must be specified for %v provider", openstack.DNSType)))
+		if p.CredentialsRef == nil {
+			allErrs = append(allErrs, field.Required(credentialsFldPath,
+				fmt.Sprintf("credentialsRef must be specified for %v provider", openstack.DNSType)))
 			continue
 		}
 
-		secret := &corev1.Secret{}
-		key := client.ObjectKey{Namespace: shoot.Namespace, Name: *p.SecretName}
-		if err := s.apiReader.Get(ctx, key, secret); err != nil {
+		credentials, err := kutil.GetCredentialsByCrossVersionObjectReference(ctx, s.apiReader, *p.CredentialsRef, shoot.Namespace)
+		if err != nil {
 			if apierrors.IsNotFound(err) {
-				allErrs = append(allErrs, field.Invalid(providerFldPath.Child("secretName"),
-					*p.SecretName, "referenced secret not found"))
+				allErrs = append(allErrs, field.NotFound(credentialsFldPath, p.CredentialsRef.String()))
 			} else {
-				allErrs = append(allErrs, field.InternalError(providerFldPath.Child("secretName"), err))
+				allErrs = append(allErrs, field.InternalError(credentialsFldPath, err))
 			}
 			continue
 		}
 
-		allErrs = append(allErrs, openstackvalidation.ValidateCloudProviderSecret(secret, providerFldPath, true)...)
+		switch creds := credentials.(type) {
+		case *corev1.Secret:
+			allErrs = append(allErrs, openstackvalidation.ValidateCloudProviderSecret(creds, credentialsFldPath, true)...)
+		default:
+			allErrs = append(allErrs, field.Invalid(credentialsFldPath, p.CredentialsRef.String(), "supported credentials type is Secret"))
+		}
 	}
 
 	return allErrs

--- a/pkg/admission/validator/shoot.go
+++ b/pkg/admission/validator/shoot.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
@@ -279,29 +280,51 @@ func (s *shoot) validateDNS(ctx context.Context, shoot *core.Shoot) field.ErrorL
 			continue
 		}
 
-		credentialsFldPath := providersPath.Index(i).Child("credentialsRef")
+		providerFldPath := providersPath.Index(i)
+		credentialsFldPath := providerFldPath.Child("credentialsRef")
 
-		if p.CredentialsRef == nil {
+		// Push users towards credentialsRef when neither field is set
+		// TODO(@wpross): Remove this check once support for Kubernetes 1.34 is dropped and secretName is no longer accepted.
+		if p.CredentialsRef == nil && ptr.Deref(p.SecretName, "") == "" {
 			allErrs = append(allErrs, field.Required(credentialsFldPath,
 				fmt.Sprintf("credentialsRef must be specified for %v provider", openstack.DNSType)))
 			continue
 		}
 
-		credentials, err := kutil.GetCredentialsByCrossVersionObjectReference(ctx, s.apiReader, *p.CredentialsRef, shoot.Namespace)
-		if err != nil {
-			if apierrors.IsNotFound(err) {
-				allErrs = append(allErrs, field.NotFound(credentialsFldPath, p.CredentialsRef.String()))
-			} else {
-				allErrs = append(allErrs, field.InternalError(credentialsFldPath, err))
-			}
-			continue
-		}
+		// TODO(@wpross) Uncomment this check once support for Kubernetes 1.34
+		// if p.CredentialsRef == nil {
+		// 	allErrs = append(allErrs, field.Required(credentialsFldPath, fmt.Sprintf("credentialsRef must be specified for %v provider", openstack.DNSType)))
+		// }
 
-		switch creds := credentials.(type) {
-		case *corev1.Secret:
-			allErrs = append(allErrs, openstackvalidation.ValidateCloudProviderSecret(creds, credentialsFldPath, true)...)
-		default:
-			allErrs = append(allErrs, field.Invalid(credentialsFldPath, p.CredentialsRef.String(), "supported credentials type is Secret"))
+		if p.CredentialsRef != nil {
+			credentials, err := kutil.GetCredentialsByCrossVersionObjectReference(ctx, s.apiReader, *p.CredentialsRef, shoot.Namespace)
+			if err != nil {
+				if apierrors.IsNotFound(err) {
+					allErrs = append(allErrs, field.NotFound(credentialsFldPath, p.CredentialsRef.String()))
+				} else {
+					allErrs = append(allErrs, field.InternalError(credentialsFldPath, err))
+				}
+				continue
+			}
+
+			switch creds := credentials.(type) {
+			case *corev1.Secret:
+				allErrs = append(allErrs, openstackvalidation.ValidateCloudProviderSecret(creds, credentialsFldPath, true)...)
+			default:
+				allErrs = append(allErrs, field.Invalid(credentialsFldPath, p.CredentialsRef.String(), "supported credentials type is Secret"))
+			}
+		} else { // TODO(@wpross): Remove this else branch once support for Kubernetes 1.34 is dropped
+			secretNameFldPath := providerFldPath.Child("secretName")
+			secret := &corev1.Secret{}
+			if err := s.apiReader.Get(ctx, client.ObjectKey{Namespace: shoot.Namespace, Name: *p.SecretName}, secret); err != nil {
+				if apierrors.IsNotFound(err) {
+					allErrs = append(allErrs, field.NotFound(secretNameFldPath, *p.SecretName))
+				} else {
+					allErrs = append(allErrs, field.InternalError(secretNameFldPath, err))
+				}
+				continue
+			}
+			allErrs = append(allErrs, openstackvalidation.ValidateCloudProviderSecret(secret, secretNameFldPath, true)...)
 		}
 	}
 

--- a/pkg/admission/validator/shoot_test.go
+++ b/pkg/admission/validator/shoot_test.go
@@ -11,12 +11,14 @@ import (
 	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
 	"github.com/gardener/gardener/pkg/apis/core"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	securityv1alpha1 "github.com/gardener/gardener/pkg/apis/security/v1alpha1"
 	"github.com/gardener/gardener/pkg/utils/test"
 	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
 	"go.uber.org/mock/gomock"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -425,168 +427,307 @@ var _ = Describe("Shoot validator", func() {
 				Expect(err).NotTo(HaveOccurred())
 			})
 
-			It("should pass when shoot has DNS but no OpenStack providers", func() {
-				shoot.Spec.DNS = &core.DNS{
-					Providers: []core.DNSProvider{
-						{
-							Type:       ptr.To("aws-route53"),
-							SecretName: ptr.To("aws-dns-secret"),
-							Primary:    ptr.To(true),
+			Context("primaryProvider", func() {
+				It("should pass when shoot has DNS but no OpenStack providers", func() {
+					shoot.Spec.DNS = &core.DNS{
+						Providers: []core.DNSProvider{
+							{
+								Type:    ptr.To("aws-route53"),
+								Primary: ptr.To(true),
+								CredentialsRef: &autoscalingv1.CrossVersionObjectReference{
+									APIVersion: "v1",
+									Kind:       "Secret",
+									Name:       "aws-dns-secret",
+								},
+							},
 						},
-					},
-				}
-				c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
+					}
+					c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
 
-				err := shootValidator.Validate(ctx, shoot, nil)
-				Expect(err).NotTo(HaveOccurred())
+					err := shootValidator.Validate(ctx, shoot, nil)
+					Expect(err).NotTo(HaveOccurred())
+				})
+
+				It("should pass when shoot has non-primary OpenStack DNS provider", func() {
+					shoot.Spec.DNS = &core.DNS{
+						Providers: []core.DNSProvider{
+							{
+								Type:    ptr.To(openstack.DNSType),
+								Primary: ptr.To(false),
+								CredentialsRef: &autoscalingv1.CrossVersionObjectReference{
+									APIVersion: "v1",
+									Kind:       "Secret",
+									Name:       "dns-secret",
+								},
+							},
+						},
+					}
+					c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
+
+					err := shootValidator.Validate(ctx, shoot, nil)
+					Expect(err).NotTo(HaveOccurred())
+				})
+
+				It("should pass when shoot has OpenStack DNS provider with Primary=nil", func() {
+					shoot.Spec.DNS = &core.DNS{
+						Providers: []core.DNSProvider{
+							{
+								Type:    ptr.To(openstack.DNSType),
+								Primary: nil,
+								CredentialsRef: &autoscalingv1.CrossVersionObjectReference{
+									APIVersion: "v1",
+									Kind:       "Secret",
+									Name:       "dns-secret",
+								},
+							},
+						},
+					}
+					c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
+
+					err := shootValidator.Validate(ctx, shoot, nil)
+					Expect(err).NotTo(HaveOccurred())
+				})
+
+				It("should pass when all OpenStack DNS providers are non-primary", func() {
+					shoot.Spec.DNS = &core.DNS{
+						Providers: []core.DNSProvider{
+							{
+								Type:    ptr.To(openstack.DNSType),
+								Primary: ptr.To(false),
+								CredentialsRef: &autoscalingv1.CrossVersionObjectReference{
+									APIVersion: "v1",
+									Kind:       "Secret",
+									Name:       "secret1",
+								},
+							},
+							{
+								Type:    ptr.To(openstack.DNSType),
+								Primary: ptr.To(false),
+								CredentialsRef: &autoscalingv1.CrossVersionObjectReference{
+									APIVersion: "v1",
+									Kind:       "Secret",
+									Name:       "secret2",
+								},
+							},
+						},
+					}
+					c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
+
+					err := shootValidator.Validate(ctx, shoot, nil)
+					Expect(err).NotTo(HaveOccurred())
+				})
+
+				It("should pass with multiple DNS providers (only validates primary OpenStack)", func() {
+					shoot.Spec.DNS = &core.DNS{
+						Providers: []core.DNSProvider{
+							{
+								Type:    ptr.To("aws-route53"),
+								Primary: ptr.To(false),
+								CredentialsRef: &autoscalingv1.CrossVersionObjectReference{
+									APIVersion: "v1",
+									Kind:       "Secret",
+									Name:       "aws-secret",
+								},
+							},
+							{
+								Type:    ptr.To(openstack.DNSType),
+								Primary: ptr.To(true),
+								CredentialsRef: &autoscalingv1.CrossVersionObjectReference{
+									APIVersion: "v1",
+									Kind:       "Secret",
+									Name:       "dns-secret",
+								},
+							},
+							{
+								Type:    ptr.To(openstack.DNSType),
+								Primary: ptr.To(false),
+								CredentialsRef: &autoscalingv1.CrossVersionObjectReference{
+									APIVersion: "v1",
+									Kind:       "Secret",
+									Name:       "other-secret",
+								},
+							},
+						},
+					}
+					c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
+					apiReader.EXPECT().Get(ctx, dnsSecretKey, &corev1.Secret{}).SetArg(2, *dnsSecret)
+
+					err := shootValidator.Validate(ctx, shoot, nil)
+					Expect(err).NotTo(HaveOccurred())
+				})
+
+				It("should report errors against the correct provider index", func() {
+					shoot.Spec.DNS = &core.DNS{
+						Providers: []core.DNSProvider{
+							{
+								Type:    ptr.To(openstack.DNSType),
+								Primary: ptr.To(false),
+								CredentialsRef: &autoscalingv1.CrossVersionObjectReference{
+									APIVersion: "v1",
+									Kind:       "Secret",
+									Name:       "non-primary-secret",
+								},
+							},
+							{
+								Type:    ptr.To(openstack.DNSType),
+								Primary: ptr.To(true),
+							},
+						},
+					}
+					c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
+
+					err := shootValidator.Validate(ctx, shoot, nil)
+					Expect(err).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeRequired),
+						"Field": Equal("spec.dns.providers[1].credentialsRef"),
+					}))))
+				})
 			})
 
-			It("should pass when shoot has non-primary OpenStack DNS provider", func() {
-				shoot.Spec.DNS = &core.DNS{
-					Providers: []core.DNSProvider{
-						{
-							Type:       ptr.To(openstack.DNSType),
-							SecretName: ptr.To("dns-secret"),
-							Primary:    ptr.To(false),
+			Context("credentialsRef", func() {
+				It("should fail when credentialsRef is missing", func() {
+					shoot.Spec.DNS = &core.DNS{
+						Providers: []core.DNSProvider{
+							{
+								Type:    ptr.To(openstack.DNSType),
+								Primary: ptr.To(true),
+							},
 						},
-					},
-				}
-				c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
+					}
+					c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
 
-				err := shootValidator.Validate(ctx, shoot, nil)
-				Expect(err).NotTo(HaveOccurred())
-			})
+					err := shootValidator.Validate(ctx, shoot, nil)
+					Expect(err).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":   Equal(field.ErrorTypeRequired),
+						"Field":  Equal("spec.dns.providers[0].credentialsRef"),
+						"Detail": ContainSubstring("credentialsRef must be specified"),
+					}))))
+				})
 
-			It("should pass with valid primary OpenStack DNS provider", func() {
-				shoot.Spec.DNS = &core.DNS{
-					Providers: []core.DNSProvider{
-						{
-							Type:       ptr.To(openstack.DNSType),
-							SecretName: ptr.To("dns-secret"),
-							Primary:    ptr.To(true),
+				It("should fail when credentialsRef points to an unsupported GVK", func() {
+					shoot.Spec.DNS = &core.DNS{
+						Providers: []core.DNSProvider{
+							{
+								Type:    ptr.To(openstack.DNSType),
+								Primary: ptr.To(true),
+								CredentialsRef: &autoscalingv1.CrossVersionObjectReference{
+									APIVersion: "foo.bar/v1",
+									Kind:       "Baz",
+									Name:       "dns-baz-ref",
+								},
+							},
 						},
-					},
-				}
-				c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
-				apiReader.EXPECT().Get(ctx, dnsSecretKey, &corev1.Secret{}).SetArg(2, *dnsSecret)
+					}
+					c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
 
-				err := shootValidator.Validate(ctx, shoot, nil)
-				Expect(err).NotTo(HaveOccurred())
-			})
+					err := shootValidator.Validate(ctx, shoot, nil)
+					Expect(err).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":   Equal(field.ErrorTypeInternal),
+						"Field":  Equal("spec.dns.providers[0].credentialsRef"),
+						"Detail": ContainSubstring("unsupported credentials reference"),
+					}))))
+				})
 
-			It("should pass with multiple DNS providers (only validates primary OpenStack)", func() {
-				shoot.Spec.DNS = &core.DNS{
-					Providers: []core.DNSProvider{
-						{
-							Type:       ptr.To("aws-route53"),
-							SecretName: ptr.To("aws-secret"),
-							Primary:    ptr.To(false),
+				It("should fail when credentialsRef points to a WorkloadIdentity", func() {
+					shoot.Spec.DNS = &core.DNS{
+						Providers: []core.DNSProvider{
+							{
+								Type:    ptr.To(openstack.DNSType),
+								Primary: ptr.To(true),
+								CredentialsRef: &autoscalingv1.CrossVersionObjectReference{
+									APIVersion: "security.gardener.cloud/v1alpha1",
+									Kind:       "WorkloadIdentity",
+									Name:       "dns-workload-identity",
+								},
+							},
 						},
-						{
-							Type:       ptr.To(openstack.DNSType),
-							SecretName: ptr.To("dns-secret"),
-							Primary:    ptr.To(true),
+					}
+					c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
+					apiReader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "dns-workload-identity"}, &securityv1alpha1.WorkloadIdentity{}).Return(nil)
+
+					err := shootValidator.Validate(ctx, shoot, nil)
+					Expect(err).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":   Equal(field.ErrorTypeInvalid),
+						"Field":  Equal("spec.dns.providers[0].credentialsRef"),
+						"Detail": ContainSubstring("supported credentials type is Secret"),
+					}))))
+				})
+
+				It("should fail when DNS credentials do not exist", func() {
+					shoot.Spec.DNS = &core.DNS{
+						Providers: []core.DNSProvider{
+							{
+								Type:    ptr.To(openstack.DNSType),
+								Primary: ptr.To(true),
+								CredentialsRef: &autoscalingv1.CrossVersionObjectReference{
+									APIVersion: "v1",
+									Kind:       "Secret",
+									Name:       "dns-secret",
+								},
+							},
 						},
-						{
-							Type:       ptr.To(openstack.DNSType),
-							SecretName: ptr.To("other-secret"),
-							Primary:    ptr.To(false),
+					}
+					c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
+					apiReader.EXPECT().Get(ctx, dnsSecretKey, &corev1.Secret{}).Return(apierrors.NewNotFound(corev1.Resource("Secret"), "dns-secret"))
+
+					err := shootValidator.Validate(ctx, shoot, nil)
+					Expect(err).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeNotFound),
+						"Field": Equal("spec.dns.providers[0].credentialsRef"),
+					}))))
+				})
+
+				It("should fail when DNS secret has validation errors", func() {
+					shoot.Spec.DNS = &core.DNS{
+						Providers: []core.DNSProvider{
+							{
+								Type:    ptr.To(openstack.DNSType),
+								Primary: ptr.To(true),
+								CredentialsRef: &autoscalingv1.CrossVersionObjectReference{
+									APIVersion: "v1",
+									Kind:       "Secret",
+									Name:       "dns-secret",
+								},
+							},
 						},
-					},
-				}
-				c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
-				apiReader.EXPECT().Get(ctx, dnsSecretKey, &corev1.Secret{}).SetArg(2, *dnsSecret)
+					}
+					// Invalid secret - missing authURL (required for DNS)
+					dnsSecret.Data = map[string][]byte{
+						openstack.DomainName: []byte("my-domain"),
+						openstack.TenantName: []byte("my-tenant"),
+						openstack.UserName:   []byte("my-user"),
+						openstack.Password:   []byte("my-password"),
+					}
+					c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
+					apiReader.EXPECT().Get(ctx, dnsSecretKey, &corev1.Secret{}).SetArg(2, *dnsSecret)
 
-				err := shootValidator.Validate(ctx, shoot, nil)
-				Expect(err).NotTo(HaveOccurred())
-			})
+					err := shootValidator.Validate(ctx, shoot, nil)
+					Expect(err).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeRequired),
+						"Field": Equal("spec.dns.providers[0].credentialsRef.data[authURL]"),
+					}))))
+				})
 
-			It("should fail when secretName is missing", func() {
-				shoot.Spec.DNS = &core.DNS{
-					Providers: []core.DNSProvider{
-						{
-							Type:    ptr.To(openstack.DNSType),
-							Primary: ptr.To(true),
+				It("should pass with valid primary OpenStack DNS provider", func() {
+					shoot.Spec.DNS = &core.DNS{
+						Providers: []core.DNSProvider{
+							{
+								Type:    ptr.To(openstack.DNSType),
+								Primary: ptr.To(true),
+								CredentialsRef: &autoscalingv1.CrossVersionObjectReference{
+									APIVersion: "v1",
+									Kind:       "Secret",
+									Name:       "dns-secret",
+								},
+							},
 						},
-					},
-				}
-				c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
+					}
+					c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
+					apiReader.EXPECT().Get(ctx, dnsSecretKey, &corev1.Secret{}).SetArg(2, *dnsSecret)
 
-				err := shootValidator.Validate(ctx, shoot, nil)
-				Expect(err).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":   Equal(field.ErrorTypeRequired),
-					"Field":  Equal("spec.dns.providers[0].secretName"),
-					"Detail": ContainSubstring("secretName must be specified"),
-				}))))
-			})
-
-			It("should fail when secretName is empty string", func() {
-				shoot.Spec.DNS = &core.DNS{
-					Providers: []core.DNSProvider{
-						{
-							Type:       ptr.To(openstack.DNSType),
-							SecretName: ptr.To(""),
-							Primary:    ptr.To(true),
-						},
-					},
-				}
-				c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
-
-				err := shootValidator.Validate(ctx, shoot, nil)
-				Expect(err).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":   Equal(field.ErrorTypeRequired),
-					"Field":  Equal("spec.dns.providers[0].secretName"),
-					"Detail": ContainSubstring("secretName must be specified"),
-				}))))
-			})
-
-			It("should fail when DNS secret does not exist", func() {
-				shoot.Spec.DNS = &core.DNS{
-					Providers: []core.DNSProvider{
-						{
-							Type:       ptr.To(openstack.DNSType),
-							SecretName: ptr.To("dns-secret"),
-							Primary:    ptr.To(true),
-						},
-					},
-				}
-				c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
-				apiReader.EXPECT().Get(ctx, dnsSecretKey, &corev1.Secret{}).Return(apierrors.NewNotFound(corev1.Resource("Secret"), "dns-secret"))
-
-				err := shootValidator.Validate(ctx, shoot, nil)
-				Expect(err).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":     Equal(field.ErrorTypeInvalid),
-					"Field":    Equal("spec.dns.providers[0].secretName"),
-					"BadValue": Equal("dns-secret"),
-					"Detail":   Equal("referenced secret not found"),
-				}))))
-			})
-
-			It("should fail when DNS secret has validation errors", func() {
-				shoot.Spec.DNS = &core.DNS{
-					Providers: []core.DNSProvider{
-						{
-							Type:       ptr.To(openstack.DNSType),
-							SecretName: ptr.To("dns-secret"),
-							Primary:    ptr.To(true),
-						},
-					},
-				}
-				// Invalid secret - missing authURL (required for DNS)
-				dnsSecret.Data = map[string][]byte{
-					openstack.DomainName: []byte("my-domain"),
-					openstack.TenantName: []byte("my-tenant"),
-					openstack.UserName:   []byte("my-user"),
-					openstack.Password:   []byte("my-password"),
-				}
-				c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
-				apiReader.EXPECT().Get(ctx, dnsSecretKey, &corev1.Secret{}).SetArg(2, *dnsSecret)
-
-				err := shootValidator.Validate(ctx, shoot, nil)
-				Expect(err).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("spec.dns.providers[0].data[authURL]"),
-				}))))
+					err := shootValidator.Validate(ctx, shoot, nil)
+					Expect(err).NotTo(HaveOccurred())
+				})
 			})
 		})
 	})

--- a/pkg/admission/validator/shoot_test.go
+++ b/pkg/admission/validator/shoot_test.go
@@ -729,6 +729,114 @@ var _ = Describe("Shoot validator", func() {
 					Expect(err).NotTo(HaveOccurred())
 				})
 			})
+
+			// TODO(@wpross): Remove this context once support for Kubernetes 1.34 is dropped and secretName is no longer accepted.
+			Context("secretName", func() {
+				It("should require credentialsRef (not secretName) when both are unset, to push migration", func() {
+					shoot.Spec.DNS = &core.DNS{
+						Providers: []core.DNSProvider{
+							{
+								Type:    ptr.To(openstack.DNSType),
+								Primary: ptr.To(true),
+							},
+						},
+					}
+					c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
+
+					err := shootValidator.Validate(ctx, shoot, nil)
+					Expect(err).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":   Equal(field.ErrorTypeRequired),
+						"Field":  Equal("spec.dns.providers[0].credentialsRef"),
+						"Detail": ContainSubstring("credentialsRef must be specified"),
+					}))))
+				})
+
+				It("should pass with valid primary OpenStack DNS provider using secretName", func() {
+					shoot.Spec.DNS = &core.DNS{
+						Providers: []core.DNSProvider{
+							{
+								Type:       ptr.To(openstack.DNSType),
+								Primary:    ptr.To(true),
+								SecretName: ptr.To("dns-secret"),
+							},
+						},
+					}
+					c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
+					apiReader.EXPECT().Get(ctx, dnsSecretKey, &corev1.Secret{}).SetArg(2, *dnsSecret)
+
+					err := shootValidator.Validate(ctx, shoot, nil)
+					Expect(err).NotTo(HaveOccurred())
+				})
+
+				It("should fail when DNS secret referenced by secretName does not exist", func() {
+					shoot.Spec.DNS = &core.DNS{
+						Providers: []core.DNSProvider{
+							{
+								Type:       ptr.To(openstack.DNSType),
+								Primary:    ptr.To(true),
+								SecretName: ptr.To("dns-secret"),
+							},
+						},
+					}
+					c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
+					apiReader.EXPECT().Get(ctx, dnsSecretKey, &corev1.Secret{}).Return(apierrors.NewNotFound(corev1.Resource("Secret"), "dns-secret"))
+
+					err := shootValidator.Validate(ctx, shoot, nil)
+					Expect(err).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeNotFound),
+						"Field": Equal("spec.dns.providers[0].secretName"),
+					}))))
+				})
+
+				It("should fail when DNS secret referenced by secretName has validation errors", func() {
+					shoot.Spec.DNS = &core.DNS{
+						Providers: []core.DNSProvider{
+							{
+								Type:       ptr.To(openstack.DNSType),
+								Primary:    ptr.To(true),
+								SecretName: ptr.To("dns-secret"),
+							},
+						},
+					}
+					// Invalid secret - missing authURL (required for DNS)
+					dnsSecret.Data = map[string][]byte{
+						openstack.DomainName: []byte("my-domain"),
+						openstack.TenantName: []byte("my-tenant"),
+						openstack.UserName:   []byte("my-user"),
+						openstack.Password:   []byte("my-password"),
+					}
+					c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
+					apiReader.EXPECT().Get(ctx, dnsSecretKey, &corev1.Secret{}).SetArg(2, *dnsSecret)
+
+					err := shootValidator.Validate(ctx, shoot, nil)
+					Expect(err).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeRequired),
+						"Field": Equal("spec.dns.providers[0].secretName.data[authURL]"),
+					}))))
+				})
+
+				It("should prefer credentialsRef when both credentialsRef and secretName are set", func() {
+					shoot.Spec.DNS = &core.DNS{
+						Providers: []core.DNSProvider{
+							{
+								Type:    ptr.To(openstack.DNSType),
+								Primary: ptr.To(true),
+								CredentialsRef: &autoscalingv1.CrossVersionObjectReference{
+									APIVersion: "v1",
+									Kind:       "Secret",
+									Name:       "dns-secret",
+								},
+								SecretName: ptr.To("other-secret"),
+							},
+						},
+					}
+					c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
+					apiReader.EXPECT().Get(ctx, dnsSecretKey, &corev1.Secret{}).SetArg(2, *dnsSecret)
+
+					err := shootValidator.Validate(ctx, shoot, nil)
+					Expect(err).NotTo(HaveOccurred())
+				})
+			})
 		})
 	})
 })


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area security
/area robustness
/kind api-change
/platform openstack

**What this PR does / why we need it**:
This PR enables the use of `spec.dns.providers[].credentialsRef` in the shoot spec so that the shoot can be updated to k8s version `v1.135` that does not support spec.dns.providers[].secretName anymore.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Enables the use of `spec.dns.providers[].credentialsRef` and thus enables to upgrade to k8s version `v1.135` where spec.dns.providers[].secretName is not allowed anymore.
```
