### PR TITLE
Fix: credentials validation to support InternalSecret type

### DIFF
--- a/charts/gardener-extension-admission-openstack/charts/application/templates/rbac.yaml
+++ b/charts/gardener-extension-admission-openstack/charts/application/templates/rbac.yaml
@@ -17,6 +17,12 @@ rules:
   - list
   - watch
 - apiGroups:
+  - core.gardener.cloud
+  resources:
+  - internalsecrets
+  verbs:
+  - get
+- apiGroups:
   - security.gardener.cloud
   resources:
   - credentialsbindings

--- a/pkg/admission/validator/credentialsbinding.go
+++ b/pkg/admission/validator/credentialsbinding.go
@@ -9,7 +9,9 @@ import (
 	"fmt"
 
 	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/apis/security"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -48,15 +50,16 @@ func (cb *credentialsBinding) Validate(ctx context.Context, newObj, oldObj clien
 
 	// Explicitly use the client.Reader to prevent controller-runtime to start Informer for Secrets
 	// under the hood. The latter increases the memory usage of the component.
-	var credentialsKey = client.ObjectKey{Namespace: credentialsBinding.CredentialsRef.Namespace, Name: credentialsBinding.CredentialsRef.Name}
-	switch {
-	case credentialsBinding.CredentialsRef.APIVersion == corev1.SchemeGroupVersion.String() && credentialsBinding.CredentialsRef.Kind == "Secret":
-		secret := &corev1.Secret{}
-		if err := cb.apiReader.Get(ctx, credentialsKey, secret); err != nil {
-			return err
-		}
+	credentials, err := kutil.GetCredentialsByObjectReference(ctx, cb.apiReader, credentialsBinding.CredentialsRef)
+	if err != nil {
+		return err
+	}
 
-		return openstackvalidation.ValidateCloudProviderSecret(secret, field.NewPath("secret"), false).ToAggregate()
+	switch creds := credentials.(type) {
+	case *corev1.Secret:
+		return openstackvalidation.ValidateCloudProviderSecret(creds, field.NewPath("secret"), false).ToAggregate()
+	case *gardencorev1beta1.InternalSecret:
+		return openstackvalidation.ValidateCloudProviderSecretData(creds.Data, field.NewPath("secret"), false).ToAggregate()
 	default:
 		return fmt.Errorf("unsupported credentials reference: version %q, kind %q", credentialsBinding.CredentialsRef.APIVersion, credentialsBinding.CredentialsRef.Kind)
 	}

--- a/pkg/admission/validator/credentialsbinding.go
+++ b/pkg/admission/validator/credentialsbinding.go
@@ -57,7 +57,7 @@ func (cb *credentialsBinding) Validate(ctx context.Context, newObj, oldObj clien
 
 	switch creds := credentials.(type) {
 	case *corev1.Secret:
-		return openstackvalidation.ValidateCloudProviderSecret(creds, field.NewPath("secret"), false).ToAggregate()
+		return openstackvalidation.ValidateCloudProviderSecretData(creds.Data, field.NewPath("secret"), false).ToAggregate()
 	case *gardencorev1beta1.InternalSecret:
 		return openstackvalidation.ValidateCloudProviderSecretData(creds.Data, field.NewPath("secret"), false).ToAggregate()
 	default:

--- a/pkg/admission/validator/credentialsbinding_test.go
+++ b/pkg/admission/validator/credentialsbinding_test.go
@@ -6,10 +6,10 @@ package validator_test
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/apis/security"
 	"github.com/gardener/gardener/pkg/utils/test"
 	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
@@ -77,7 +77,7 @@ var _ = Describe("CredentialsBinding validator", func() {
 		It("should return err if the CredentialsBinding references unknown credentials type", func() {
 			credentialsBinding.CredentialsRef.APIVersion = "unknown"
 			err := credentialsBindingValidator.Validate(ctx, credentialsBinding, nil)
-			Expect(err).To(MatchError(errors.New(`unsupported credentials reference: version "unknown", kind "Secret"`)))
+			Expect(err).To(MatchError(ContainSubstring("unsupported credentials reference")))
 		})
 
 		It("should return err if it fails to get the corresponding Secret", func() {
@@ -121,6 +121,50 @@ var _ = Describe("CredentialsBinding validator", func() {
 			old := credentialsBinding.DeepCopy()
 
 			Expect(credentialsBindingValidator.Validate(ctx, credentialsBinding, old)).To(Succeed())
+		})
+
+		Context("InternalSecret", func() {
+			BeforeEach(func() {
+				credentialsBinding.CredentialsRef = corev1.ObjectReference{
+					Name:       name,
+					Namespace:  namespace,
+					Kind:       "InternalSecret",
+					APIVersion: gardencorev1beta1.SchemeGroupVersion.String(),
+				}
+			})
+
+			It("should return err if it fails to get the corresponding InternalSecret", func() {
+				apiReader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&gardencorev1beta1.InternalSecret{})).Return(fakeErr)
+
+				err := credentialsBindingValidator.Validate(ctx, credentialsBinding, nil)
+				Expect(err).To(MatchError(fakeErr))
+			})
+
+			It("should return err when the corresponding InternalSecret is not valid", func() {
+				apiReader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&gardencorev1beta1.InternalSecret{})).
+					DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.InternalSecret, _ ...client.GetOption) error {
+						obj.Data = map[string][]byte{"foo": []byte("bar")}
+						return nil
+					})
+
+				err := credentialsBindingValidator.Validate(ctx, credentialsBinding, nil)
+				Expect(err).To(HaveOccurred())
+			})
+
+			It("should succeed when the corresponding InternalSecret is valid", func() {
+				apiReader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&gardencorev1beta1.InternalSecret{})).
+					DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.InternalSecret, _ ...client.GetOption) error {
+						obj.Data = map[string][]byte{
+							openstack.DomainName: []byte("domain"),
+							openstack.TenantName: []byte("tenant"),
+							openstack.UserName:   []byte("user"),
+							openstack.Password:   []byte("password"),
+						}
+						return nil
+					})
+
+				Expect(credentialsBindingValidator.Validate(ctx, credentialsBinding, nil)).To(Succeed())
+			})
 		})
 	})
 })

--- a/pkg/admission/validator/shoot.go
+++ b/pkg/admission/validator/shoot.go
@@ -325,10 +325,8 @@ func (s *shoot) validateDNS(ctx context.Context, shoot *core.Shoot) field.ErrorL
 			switch creds := credentials.(type) {
 			case *corev1.Secret:
 				allErrs = append(allErrs, openstackvalidation.ValidateCloudProviderSecret(creds, credentialsFldPath, true)...)
-			case *gardencorev1beta1.InternalSecret:
-				allErrs = append(allErrs, openstackvalidation.ValidateCloudProviderSecretData(creds.Data, credentialsFldPath, true)...)
 			default:
-				allErrs = append(allErrs, field.Invalid(credentialsFldPath, p.CredentialsRef.String(), "supported credentials type is Secret or InternalSecret"))
+				allErrs = append(allErrs, field.Invalid(credentialsFldPath, p.CredentialsRef.String(), "supported credentials type is Secret"))
 			}
 		} else { // TODO(@wpross): Remove this else branch once support for Kubernetes 1.34 is dropped
 			secretNameFldPath := providerFldPath.Child("secretName")

--- a/pkg/admission/validator/shoot.go
+++ b/pkg/admission/validator/shoot.go
@@ -78,14 +78,10 @@ func (s *shoot) Validate(ctx context.Context, newObj, oldObj client.Object) erro
 
 	var credentials *openstack.Credentials
 	if shoot.Spec.SecretBindingName != nil || shoot.Spec.CredentialsBindingName != nil {
-		secret, err := s.getCloudProviderSecretForShoot(ctx, shoot)
+		var err error
+		credentials, err = s.getCloudProviderCredentialsForShoot(ctx, shoot)
 		if err != nil {
 			return fmt.Errorf("failed to get cloud provider credentials: %v", err)
-		}
-
-		credentials, err = openstack.ExtractCredentials(secret, false)
-		if err != nil {
-			return fmt.Errorf("invalid cloud credentials: %v", err)
 		}
 	}
 
@@ -228,7 +224,7 @@ func newValidationContext(decoder runtime.Decoder, shoot *core.Shoot, cloudProfi
 	}, nil
 }
 
-func (s *shoot) getCloudProviderSecretForShoot(ctx context.Context, shoot *core.Shoot) (*corev1.Secret, error) {
+func (s *shoot) getCloudProviderCredentialsForShoot(ctx context.Context, shoot *core.Shoot) (*openstack.Credentials, error) {
 	var credentialsRef corev1.ObjectReference
 	if shoot.Spec.SecretBindingName != nil {
 		var (
@@ -257,19 +253,16 @@ func (s *shoot) getCloudProviderSecretForShoot(ctx context.Context, shoot *core.
 
 	// Explicitly use the client.Reader to prevent controller-runtime to start Informer for Secrets
 	// under the hood. The latter increases the memory usage of the component.
-	credentials, err := kutil.GetCredentialsByObjectReference(ctx, s.apiReader, credentialsRef)
+	creds, err := kutil.GetCredentialsByObjectReference(ctx, s.apiReader, credentialsRef)
 	if err != nil {
 		return nil, err
 	}
 
-	switch creds := credentials.(type) {
+	switch c := creds.(type) {
 	case *corev1.Secret:
-		return creds, nil
+		return openstack.ExtractCredentials(c, false)
 	case *gardencorev1beta1.InternalSecret:
-		return &corev1.Secret{
-			ObjectMeta: creds.ObjectMeta,
-			Data:       creds.Data,
-		}, nil
+		return openstack.ExtractCredentialsFromData(c.Data, false)
 	default:
 		return nil, fmt.Errorf("unsupported credentials reference: version %q, kind %q", credentialsRef.APIVersion, credentialsRef.Kind)
 	}

--- a/pkg/admission/validator/shoot.go
+++ b/pkg/admission/validator/shoot.go
@@ -229,7 +229,7 @@ func newValidationContext(decoder runtime.Decoder, shoot *core.Shoot, cloudProfi
 }
 
 func (s *shoot) getCloudProviderSecretForShoot(ctx context.Context, shoot *core.Shoot) (*corev1.Secret, error) {
-	var secretKey client.ObjectKey
+	var credentialsRef corev1.ObjectReference
 	if shoot.Spec.SecretBindingName != nil {
 		var (
 			bindingKey    = client.ObjectKey{Namespace: shoot.Namespace, Name: *shoot.Spec.SecretBindingName}
@@ -238,7 +238,12 @@ func (s *shoot) getCloudProviderSecretForShoot(ctx context.Context, shoot *core.
 		if err := kutil.LookupObject(ctx, s.client, s.apiReader, bindingKey, secretBinding); err != nil {
 			return nil, err
 		}
-		secretKey = client.ObjectKey{Namespace: secretBinding.SecretRef.Namespace, Name: secretBinding.SecretRef.Name}
+		credentialsRef = corev1.ObjectReference{
+			APIVersion: corev1.SchemeGroupVersion.String(),
+			Kind:       "Secret",
+			Namespace:  secretBinding.SecretRef.Namespace,
+			Name:       secretBinding.SecretRef.Name,
+		}
 	} else {
 		var (
 			bindingKey         = client.ObjectKey{Namespace: shoot.Namespace, Name: *shoot.Spec.CredentialsBindingName}
@@ -247,17 +252,27 @@ func (s *shoot) getCloudProviderSecretForShoot(ctx context.Context, shoot *core.
 		if err := kutil.LookupObject(ctx, s.client, s.apiReader, bindingKey, credentialsBinding); err != nil {
 			return nil, err
 		}
-		secretKey = client.ObjectKey{Namespace: credentialsBinding.CredentialsRef.Namespace, Name: credentialsBinding.CredentialsRef.Name}
+		credentialsRef = credentialsBinding.CredentialsRef
 	}
 
 	// Explicitly use the client.Reader to prevent controller-runtime to start Informer for Secrets
 	// under the hood. The latter increases the memory usage of the component.
-	secret := &corev1.Secret{}
-	if err := s.apiReader.Get(ctx, secretKey, secret); err != nil {
+	credentials, err := kutil.GetCredentialsByObjectReference(ctx, s.apiReader, credentialsRef)
+	if err != nil {
 		return nil, err
 	}
 
-	return secret, nil
+	switch creds := credentials.(type) {
+	case *corev1.Secret:
+		return creds, nil
+	case *gardencorev1beta1.InternalSecret:
+		return &corev1.Secret{
+			ObjectMeta: creds.ObjectMeta,
+			Data:       creds.Data,
+		}, nil
+	default:
+		return nil, fmt.Errorf("unsupported credentials reference: version %q, kind %q", credentialsRef.APIVersion, credentialsRef.Kind)
+	}
 }
 
 // validateDNS validates all openstack provider entries in the Shoot spec.
@@ -310,8 +325,10 @@ func (s *shoot) validateDNS(ctx context.Context, shoot *core.Shoot) field.ErrorL
 			switch creds := credentials.(type) {
 			case *corev1.Secret:
 				allErrs = append(allErrs, openstackvalidation.ValidateCloudProviderSecret(creds, credentialsFldPath, true)...)
+			case *gardencorev1beta1.InternalSecret:
+				allErrs = append(allErrs, openstackvalidation.ValidateCloudProviderSecretData(creds.Data, credentialsFldPath, true)...)
 			default:
-				allErrs = append(allErrs, field.Invalid(credentialsFldPath, p.CredentialsRef.String(), "supported credentials type is Secret"))
+				allErrs = append(allErrs, field.Invalid(credentialsFldPath, p.CredentialsRef.String(), "supported credentials type is Secret or InternalSecret"))
 			}
 		} else { // TODO(@wpross): Remove this else branch once support for Kubernetes 1.34 is dropped
 			secretNameFldPath := providerFldPath.Child("secretName")

--- a/pkg/admission/validator/shoot_test.go
+++ b/pkg/admission/validator/shoot_test.go
@@ -649,7 +649,7 @@ var _ = Describe("Shoot validator", func() {
 					Expect(err).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 						"Type":   Equal(field.ErrorTypeInvalid),
 						"Field":  Equal("spec.dns.providers[0].credentialsRef"),
-						"Detail": ContainSubstring("supported credentials type is Secret"),
+						"Detail": ContainSubstring("supported credentials type is Secret or InternalSecret"),
 					}))))
 				})
 
@@ -727,6 +727,71 @@ var _ = Describe("Shoot validator", func() {
 
 					err := shootValidator.Validate(ctx, shoot, nil)
 					Expect(err).NotTo(HaveOccurred())
+				})
+
+				It("should pass with valid primary OpenStack DNS provider using InternalSecret", func() {
+					dnsInternalSecretKey := client.ObjectKey{Namespace: namespace, Name: "dns-internal-secret"}
+					dnsInternalSecret := &gardencorev1beta1.InternalSecret{
+						Data: map[string][]byte{
+							openstack.AuthURL:    []byte("https://keystone.example.com:5000/v3"),
+							openstack.DomainName: []byte("my-domain"),
+							openstack.TenantName: []byte("my-tenant"),
+							openstack.UserName:   []byte("my-user"),
+							openstack.Password:   []byte("my-password"),
+						},
+					}
+					shoot.Spec.DNS = &core.DNS{
+						Providers: []core.DNSProvider{
+							{
+								Type:    ptr.To(openstack.DNSType),
+								Primary: ptr.To(true),
+								CredentialsRef: &autoscalingv1.CrossVersionObjectReference{
+									APIVersion: gardencorev1beta1.SchemeGroupVersion.String(),
+									Kind:       "InternalSecret",
+									Name:       "dns-internal-secret",
+								},
+							},
+						},
+					}
+					c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
+					apiReader.EXPECT().Get(ctx, dnsInternalSecretKey, &gardencorev1beta1.InternalSecret{}).SetArg(2, *dnsInternalSecret)
+
+					err := shootValidator.Validate(ctx, shoot, nil)
+					Expect(err).NotTo(HaveOccurred())
+				})
+
+				It("should fail when DNS InternalSecret has validation errors", func() {
+					dnsInternalSecretKey := client.ObjectKey{Namespace: namespace, Name: "dns-internal-secret"}
+					dnsInternalSecret := &gardencorev1beta1.InternalSecret{
+						Data: map[string][]byte{
+							// missing authURL (required for DNS)
+							openstack.DomainName: []byte("my-domain"),
+							openstack.TenantName: []byte("my-tenant"),
+							openstack.UserName:   []byte("my-user"),
+							openstack.Password:   []byte("my-password"),
+						},
+					}
+					shoot.Spec.DNS = &core.DNS{
+						Providers: []core.DNSProvider{
+							{
+								Type:    ptr.To(openstack.DNSType),
+								Primary: ptr.To(true),
+								CredentialsRef: &autoscalingv1.CrossVersionObjectReference{
+									APIVersion: gardencorev1beta1.SchemeGroupVersion.String(),
+									Kind:       "InternalSecret",
+									Name:       "dns-internal-secret",
+								},
+							},
+						},
+					}
+					c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
+					apiReader.EXPECT().Get(ctx, dnsInternalSecretKey, &gardencorev1beta1.InternalSecret{}).SetArg(2, *dnsInternalSecret)
+
+					err := shootValidator.Validate(ctx, shoot, nil)
+					Expect(err).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeRequired),
+						"Field": Equal("spec.dns.providers[0].credentialsRef.data[authURL]"),
+					}))))
 				})
 			})
 

--- a/pkg/admission/validator/shoot_test.go
+++ b/pkg/admission/validator/shoot_test.go
@@ -649,7 +649,7 @@ var _ = Describe("Shoot validator", func() {
 					Expect(err).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 						"Type":   Equal(field.ErrorTypeInvalid),
 						"Field":  Equal("spec.dns.providers[0].credentialsRef"),
-						"Detail": ContainSubstring("supported credentials type is Secret or InternalSecret"),
+						"Detail": ContainSubstring("supported credentials type is Secret"),
 					}))))
 				})
 
@@ -727,71 +727,6 @@ var _ = Describe("Shoot validator", func() {
 
 					err := shootValidator.Validate(ctx, shoot, nil)
 					Expect(err).NotTo(HaveOccurred())
-				})
-
-				It("should pass with valid primary OpenStack DNS provider using InternalSecret", func() {
-					dnsInternalSecretKey := client.ObjectKey{Namespace: namespace, Name: "dns-internal-secret"}
-					dnsInternalSecret := &gardencorev1beta1.InternalSecret{
-						Data: map[string][]byte{
-							openstack.AuthURL:    []byte("https://keystone.example.com:5000/v3"),
-							openstack.DomainName: []byte("my-domain"),
-							openstack.TenantName: []byte("my-tenant"),
-							openstack.UserName:   []byte("my-user"),
-							openstack.Password:   []byte("my-password"),
-						},
-					}
-					shoot.Spec.DNS = &core.DNS{
-						Providers: []core.DNSProvider{
-							{
-								Type:    ptr.To(openstack.DNSType),
-								Primary: ptr.To(true),
-								CredentialsRef: &autoscalingv1.CrossVersionObjectReference{
-									APIVersion: gardencorev1beta1.SchemeGroupVersion.String(),
-									Kind:       "InternalSecret",
-									Name:       "dns-internal-secret",
-								},
-							},
-						},
-					}
-					c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
-					apiReader.EXPECT().Get(ctx, dnsInternalSecretKey, &gardencorev1beta1.InternalSecret{}).SetArg(2, *dnsInternalSecret)
-
-					err := shootValidator.Validate(ctx, shoot, nil)
-					Expect(err).NotTo(HaveOccurred())
-				})
-
-				It("should fail when DNS InternalSecret has validation errors", func() {
-					dnsInternalSecretKey := client.ObjectKey{Namespace: namespace, Name: "dns-internal-secret"}
-					dnsInternalSecret := &gardencorev1beta1.InternalSecret{
-						Data: map[string][]byte{
-							// missing authURL (required for DNS)
-							openstack.DomainName: []byte("my-domain"),
-							openstack.TenantName: []byte("my-tenant"),
-							openstack.UserName:   []byte("my-user"),
-							openstack.Password:   []byte("my-password"),
-						},
-					}
-					shoot.Spec.DNS = &core.DNS{
-						Providers: []core.DNSProvider{
-							{
-								Type:    ptr.To(openstack.DNSType),
-								Primary: ptr.To(true),
-								CredentialsRef: &autoscalingv1.CrossVersionObjectReference{
-									APIVersion: gardencorev1beta1.SchemeGroupVersion.String(),
-									Kind:       "InternalSecret",
-									Name:       "dns-internal-secret",
-								},
-							},
-						},
-					}
-					c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
-					apiReader.EXPECT().Get(ctx, dnsInternalSecretKey, &gardencorev1beta1.InternalSecret{}).SetArg(2, *dnsInternalSecret)
-
-					err := shootValidator.Validate(ctx, shoot, nil)
-					Expect(err).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
-						"Type":  Equal(field.ErrorTypeRequired),
-						"Field": Equal("spec.dns.providers[0].credentialsRef.data[authURL]"),
-					}))))
 				})
 			})
 

--- a/pkg/apis/openstack/validation/secrets.go
+++ b/pkg/apis/openstack/validation/secrets.go
@@ -21,6 +21,13 @@ import (
 // It checks required fields (domainName, tenantName), validates authentication methods (username/password or application credentials),
 // and ensures all field values meet format requirements. When allowDNSKeys is true, DNS-specific key aliases (e.g., OS_DOMAIN_NAME) are accepted.
 func ValidateCloudProviderSecret(secret *corev1.Secret, fldPath *field.Path, allowDNSKeys bool) field.ErrorList {
+	return ValidateCloudProviderSecretData(secret.Data, fldPath, allowDNSKeys)
+}
+
+// ValidateCloudProviderSecretData validates OpenStack credentials from a raw data map.
+// It is equivalent to ValidateCloudProviderSecret but accepts a map[string][]byte directly,
+// allowing validation of both corev1.Secret and gardencorev1beta1.InternalSecret data.
+func ValidateCloudProviderSecretData(data map[string][]byte, fldPath *field.Path, allowDNSKeys bool) field.ErrorList {
 	allErrs := field.ErrorList{}
 	dataPath := fldPath.Child("data")
 
@@ -57,51 +64,51 @@ func ValidateCloudProviderSecret(secret *corev1.Secret, fldPath *field.Path, all
 	}
 
 	// validate required fields (domainName, tenantName)
-	domainName, domainNameKey, errs := validateRequiredField(secret, dataPath, openstack.DomainName, domainNameDNSKey)
+	domainName, domainNameKey, errs := validateRequiredField(data, dataPath, openstack.DomainName, domainNameDNSKey)
 	allErrs = append(allErrs, errs...)
 	allErrs = append(allErrs, validateDomainName(domainName, dataPath.Key(domainNameKey))...)
 
-	tenantName, tenantNameKey, errs := validateRequiredField(secret, dataPath, openstack.TenantName, tenantNameDNSKey)
+	tenantName, tenantNameKey, errs := validateRequiredField(data, dataPath, openstack.TenantName, tenantNameDNSKey)
 	allErrs = append(allErrs, errs...)
 	allErrs = append(allErrs, validateTenantName(tenantName, dataPath.Key(tenantNameKey))...)
 
 	// get optional fields
-	userName, userNameKey, errs := getOptionalField(secret, dataPath, openstack.UserName, userNameDNSKey)
+	userName, userNameKey, errs := getOptionalField(data, dataPath, openstack.UserName, userNameDNSKey)
 	allErrs = append(allErrs, errs...)
 	allErrs = append(allErrs, validateUserName(userName, dataPath.Key(userNameKey))...)
 
-	password, passwordKey, errs := getOptionalField(secret, dataPath, openstack.Password, passwordDNSKey)
+	password, passwordKey, errs := getOptionalField(data, dataPath, openstack.Password, passwordDNSKey)
 	allErrs = append(allErrs, errs...)
 	allErrs = append(allErrs, validatePassword(password, dataPath.Key(passwordKey))...)
 
-	appCredID, appCredIDKey, errs := getOptionalField(secret, dataPath, openstack.ApplicationCredentialID, appCredIDDNSKey)
+	appCredID, appCredIDKey, errs := getOptionalField(data, dataPath, openstack.ApplicationCredentialID, appCredIDDNSKey)
 	allErrs = append(allErrs, errs...)
 	allErrs = append(allErrs, validateAppCredentialID(appCredID, dataPath.Key(appCredIDKey))...)
 
-	appCredName, appCredNameKey, errs := getOptionalField(secret, dataPath, openstack.ApplicationCredentialName, appCredNameDNSKey)
+	appCredName, appCredNameKey, errs := getOptionalField(data, dataPath, openstack.ApplicationCredentialName, appCredNameDNSKey)
 	allErrs = append(allErrs, errs...)
 	allErrs = append(allErrs, validateAppCredentialName(appCredName, dataPath.Key(appCredNameKey))...)
 
-	appCredSecret, appCredSecretKey, errs := getOptionalField(secret, dataPath, openstack.ApplicationCredentialSecret, appCredSecretDNSKey)
+	appCredSecret, appCredSecretKey, errs := getOptionalField(data, dataPath, openstack.ApplicationCredentialSecret, appCredSecretDNSKey)
 	allErrs = append(allErrs, errs...)
 	allErrs = append(allErrs, validateAppCredentialSecret(appCredSecret, dataPath.Key(appCredSecretKey))...)
 
 	// authURL is required for DNS secrets, optional for infrastructure secrets
 	var authURL, authURLKey string
 	if allowDNSKeys {
-		authURL, authURLKey, errs = validateRequiredField(secret, dataPath, openstack.AuthURL, authURLDNSKey)
+		authURL, authURLKey, errs = validateRequiredField(data, dataPath, openstack.AuthURL, authURLDNSKey)
 		allErrs = append(allErrs, errs...)
 	} else {
-		authURL, authURLKey, errs = getOptionalField(secret, dataPath, openstack.AuthURL, authURLDNSKey)
+		authURL, authURLKey, errs = getOptionalField(data, dataPath, openstack.AuthURL, authURLDNSKey)
 		allErrs = append(allErrs, errs...)
 	}
 	allErrs = append(allErrs, validateHTTPURL(authURL, dataPath.Key(authURLKey))...)
 
-	caCert, caCertKey, errs := getOptionalField(secret, dataPath, openstack.CACert, caBundleDNSKey)
+	caCert, caCertKey, errs := getOptionalField(data, dataPath, openstack.CACert, caBundleDNSKey)
 	allErrs = append(allErrs, errs...)
 	allErrs = append(allErrs, validateCACert(caCert, dataPath.Key(caCertKey))...)
 
-	insecure, insecureKey, errs := getOptionalField(secret, dataPath, openstack.Insecure, nil)
+	insecure, insecureKey, errs := getOptionalField(data, dataPath, openstack.Insecure, nil)
 	allErrs = append(allErrs, errs...)
 	allErrs = append(allErrs, validateInsecure(insecure, dataPath.Key(insecureKey))...)
 
@@ -111,22 +118,22 @@ func ValidateCloudProviderSecret(secret *corev1.Secret, fldPath *field.Path, all
 		appCredID, appCredIDKey, appCredName, appCredNameKey, appCredSecret, appCredSecretKey, dataPath)...)
 
 	// make sure that only expected keys exist
-	allErrs = append(allErrs, validateNoUnexpectedKeys(secret, dataPath, expectedKeys)...)
+	allErrs = append(allErrs, validateNoUnexpectedKeys(data, dataPath, expectedKeys)...)
 
 	return allErrs
 }
 
-// validateRequiredField checks if a required field exists in the secret and is non-empty.
+// validateRequiredField checks if a required field exists in the data map and is non-empty.
 // It first looks for the standard key, then falls back to the DNS key if provided and allowDNSKeys is true.
 // Returns the field value, the actual key used (standard or DNS), and any validation errors.
-func validateRequiredField(secret *corev1.Secret, fldPath *field.Path, key string, dnsKey *string) (string, string, field.ErrorList) {
+func validateRequiredField(data map[string][]byte, fldPath *field.Path, key string, dnsKey *string) (string, string, field.ErrorList) {
 	allErrs := field.ErrorList{}
 
-	value, ok := secret.Data[key]
+	value, ok := data[key]
 	actualKey := key
 	if !ok && dnsKey != nil {
 		actualKey = *dnsKey
-		value, ok = secret.Data[actualKey]
+		value, ok = data[actualKey]
 	}
 
 	if !ok {
@@ -141,18 +148,18 @@ func validateRequiredField(secret *corev1.Secret, fldPath *field.Path, key strin
 	return string(value), actualKey, allErrs
 }
 
-// getOptionalField extracts an optional field value from the secret.
+// getOptionalField extracts an optional field value from the data map.
 // It first checks for the standard key, then falls back to the DNS key if provided.
 // Returns the field value (empty string if not found) and the actual key used.
 // Returns an error if the key is used but no value provided.
-func getOptionalField(secret *corev1.Secret, fldPath *field.Path, key string, dnsKey *string) (string, string, field.ErrorList) {
+func getOptionalField(data map[string][]byte, fldPath *field.Path, key string, dnsKey *string) (string, string, field.ErrorList) {
 	allErrs := field.ErrorList{}
 
-	value, ok := secret.Data[key]
+	value, ok := data[key]
 	actualKey := key
 	if !ok && dnsKey != nil {
 		actualKey = *dnsKey
-		if value, ok = secret.Data[*dnsKey]; !ok {
+		if value, ok = data[*dnsKey]; !ok {
 			return "", key, allErrs
 		}
 	}
@@ -232,13 +239,13 @@ func validateAuthCombination(
 			userNameKey, pwKey))}
 }
 
-// validateNoUnexpectedKeys ensures that the secret contains only expected keys.
+// validateNoUnexpectedKeys ensures that the data map contains only expected keys.
 // Any key not in the expectedKeys list is reported as a forbidden field.
-func validateNoUnexpectedKeys(secret *corev1.Secret, fldPath *field.Path, expectedKeys []string) field.ErrorList {
+func validateNoUnexpectedKeys(data map[string][]byte, fldPath *field.Path, expectedKeys []string) field.ErrorList {
 	allErrs := field.ErrorList{}
 	expectedKeysSet := sets.NewString(expectedKeys...)
 
-	for k := range secret.Data {
+	for k := range data {
 		if !expectedKeysSet.Has(k) {
 			allErrs = append(allErrs, field.Forbidden(fldPath.Key(k),
 				fmt.Sprintf("unexpected field %q", k)))

--- a/pkg/openstack/credentials.go
+++ b/pkg/openstack/credentials.go
@@ -46,7 +46,11 @@ func GetCredentials(ctx context.Context, c client.Client, secretRef corev1.Secre
 
 // ExtractCredentials generates a credentials object for a given provider secret.
 func ExtractCredentials(secret *corev1.Secret, allowDNSKeys bool) (*Credentials, error) {
-	return ExtractCredentialsFromData(secret.Data, allowDNSKeys)
+	credentials, err := ExtractCredentialsFromData(secret.Data, allowDNSKeys)
+	if err != nil {
+		return nil, fmt.Errorf("%w in secret %s/%s", err, secret.Namespace, secret.Name)
+	}
+	return credentials, nil
 }
 
 // ExtractCredentialsFromData generates a credentials object from a raw secret data map.

--- a/pkg/openstack/credentials.go
+++ b/pkg/openstack/credentials.go
@@ -46,6 +46,13 @@ func GetCredentials(ctx context.Context, c client.Client, secretRef corev1.Secre
 
 // ExtractCredentials generates a credentials object for a given provider secret.
 func ExtractCredentials(secret *corev1.Secret, allowDNSKeys bool) (*Credentials, error) {
+	return ExtractCredentialsFromData(secret.Data, allowDNSKeys)
+}
+
+// ExtractCredentialsFromData generates a credentials object from a raw secret data map.
+// It is equivalent to ExtractCredentials but accepts a map[string][]byte directly,
+// allowing extraction from both corev1.Secret and gardencorev1beta1.InternalSecret data.
+func ExtractCredentialsFromData(data map[string][]byte, allowDNSKeys bool) (*Credentials, error) {
 	var altDomainNameKey, altTenantNameKey, altUserNameKey, altPasswordKey, altAuthURLKey, altCABundleKey *string
 	var altApplicationCredentialID, altApplicationCredentialName, altApplicationCredentialSecret *string
 	if allowDNSKeys {
@@ -60,28 +67,27 @@ func ExtractCredentials(secret *corev1.Secret, allowDNSKeys bool) (*Credentials,
 		altCABundleKey = ptr.To(DNS_CA_Bundle)
 	}
 
-	if secret.Data == nil {
+	if data == nil {
 		return nil, fmt.Errorf("secret does not contain any data")
 	}
-	domainName, err := getRequired(secret, DomainName, altDomainNameKey)
+	domainName, err := getRequiredFromData(data, DomainName, altDomainNameKey)
 	if err != nil {
 		return nil, err
 	}
-	tenantName, err := getRequired(secret, TenantName, altTenantNameKey)
+	tenantName, err := getRequiredFromData(data, TenantName, altTenantNameKey)
 	if err != nil {
 		return nil, err
 	}
-	userName := getOptional(secret, UserName, altUserNameKey)
-	password := getOptional(secret, Password, altPasswordKey)
-	applicationCredentialID := getOptional(secret, ApplicationCredentialID, altApplicationCredentialID)
-	applicationCredentialName := getOptional(secret, ApplicationCredentialName, altApplicationCredentialName)
-	applicationCredentialSecret := getOptional(secret, ApplicationCredentialSecret, altApplicationCredentialSecret)
-	authURL := getOptional(secret, AuthURL, altAuthURLKey)
-	caCert := getOptional(secret, CACert, altCABundleKey)
+	userName := getOptionalFromData(data, UserName, altUserNameKey)
+	password := getOptionalFromData(data, Password, altPasswordKey)
+	applicationCredentialID := getOptionalFromData(data, ApplicationCredentialID, altApplicationCredentialID)
+	applicationCredentialName := getOptionalFromData(data, ApplicationCredentialName, altApplicationCredentialName)
+	applicationCredentialSecret := getOptionalFromData(data, ApplicationCredentialSecret, altApplicationCredentialSecret)
+	authURL := getOptionalFromData(data, AuthURL, altAuthURLKey)
+	caCert := getOptionalFromData(data, CACert, altCABundleKey)
 
-	err = ValidateSecrets(userName, password, applicationCredentialID, applicationCredentialName, applicationCredentialSecret)
-	if err != nil {
-		return nil, fmt.Errorf("%w in secret %s/%s", err, secret.Namespace, secret.Name)
+	if err := ValidateSecrets(userName, password, applicationCredentialID, applicationCredentialName, applicationCredentialSecret); err != nil {
+		return nil, err
 	}
 
 	return &Credentials{
@@ -94,7 +100,7 @@ func ExtractCredentials(secret *corev1.Secret, allowDNSKeys bool) (*Credentials,
 		ApplicationCredentialSecret: applicationCredentialSecret,
 		AuthURL:                     authURL,
 		CACert:                      caCert,
-		Insecure:                    strings.ToLower(strings.TrimSpace(string(secret.Data[Insecure]))) == "true",
+		Insecure:                    strings.ToLower(strings.TrimSpace(string(data[Insecure]))) == "true",
 	}, nil
 }
 
@@ -120,36 +126,36 @@ func ValidateSecrets(userName, password, appID, appName, appSecret string) error
 	return nil
 }
 
-// getOptional returns optional value for a corresponding key or empty string
-func getOptional(secret *corev1.Secret, key string, altKey *string) string {
-	if value, ok := secret.Data[key]; ok {
+// getOptionalFromData returns optional value for a corresponding key or empty string
+func getOptionalFromData(data map[string][]byte, key string, altKey *string) string {
+	if value, ok := data[key]; ok {
 		return string(value)
 	}
 	if altKey != nil {
-		if value, ok := secret.Data[*altKey]; ok {
+		if value, ok := data[*altKey]; ok {
 			return string(value)
 		}
 	}
 	return ""
 }
 
-// getRequired checks if the provided map has a valid value for a corresponding key.
-func getRequired(secret *corev1.Secret, key string, altKey *string) (string, error) {
-	value, ok := secret.Data[key]
+// getRequiredFromData checks if the provided map has a valid value for a corresponding key.
+func getRequiredFromData(data map[string][]byte, key string, altKey *string) (string, error) {
+	value, ok := data[key]
 	if !ok {
 		if altKey == nil {
-			return "", fmt.Errorf("missing %q data key in secret %s/%s", key, secret.Namespace, secret.Name)
+			return "", fmt.Errorf("missing %q data key in secret data", key)
 		}
-		value, ok = secret.Data[*altKey]
+		value, ok = data[*altKey]
 		if !ok {
-			return "", fmt.Errorf("missing %q (or %q) data key in secret %s/%s", key, *altKey, secret.Namespace, secret.Name)
+			return "", fmt.Errorf("missing %q (or %q) data key in secret data", key, *altKey)
 		}
 	}
 	if len(value) == 0 {
 		if altKey != nil {
-			return "", fmt.Errorf("key %q (or %q) in secret %s/%s cannot be empty", key, *altKey, secret.Namespace, secret.Name)
+			return "", fmt.Errorf("key %q (or %q) in secret data cannot be empty", key, *altKey)
 		}
-		return "", fmt.Errorf("key %q in secret %s/%s cannot be empty", key, secret.Namespace, secret.Name)
+		return "", fmt.Errorf("key %q in secret data cannot be empty", key)
 	}
 	return string(value), nil
 }


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area quality
/kind bug
/platform openstack

**What this PR does / why we need it**:
This PR adds the missing credentials validation to support InternalSecret type

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Add credentials validation to support InternalSecret type
```
