### PR TITLE
Migrate mock client usages to fakeclient in tests

### DIFF
--- a/pkg/admission/validator/credentialsbinding_test.go
+++ b/pkg/admission/validator/credentialsbinding_test.go
@@ -6,18 +6,17 @@ package validator_test
 
 import (
 	"context"
-	"fmt"
 
 	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/apis/security"
 	"github.com/gardener/gardener/pkg/utils/test"
-	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/gardener/gardener-extension-provider-openstack/pkg/admission/validator"
 	"github.com/gardener/gardener-extension-provider-openstack/pkg/openstack"
@@ -33,20 +32,18 @@ var _ = Describe("CredentialsBinding validator", func() {
 		var (
 			credentialsBindingValidator extensionswebhook.Validator
 
-			ctrl      *gomock.Controller
-			apiReader *mockclient.MockReader
+			scheme *runtime.Scheme
+			ctx    = context.TODO()
 
-			ctx                = context.TODO()
 			credentialsBinding *security.CredentialsBinding
-
-			fakeErr = fmt.Errorf("fake err")
 		)
 
 		BeforeEach(func() {
-			ctrl = gomock.NewController(GinkgoT())
+			scheme = runtime.NewScheme()
+			Expect(corev1.AddToScheme(scheme)).To(Succeed())
+			Expect(gardencorev1beta1.AddToScheme(scheme)).To(Succeed())
 
-			apiReader = mockclient.NewMockReader(ctrl)
-
+			apiReader := fakeclient.NewClientBuilder().WithScheme(scheme).Build()
 			mgr := test.FakeManager{APIReader: apiReader}
 			credentialsBindingValidator = validator.NewCredentialsBindingValidator(mgr)
 
@@ -58,10 +55,6 @@ var _ = Describe("CredentialsBinding validator", func() {
 					APIVersion: "v1",
 				},
 			}
-		})
-
-		AfterEach(func() {
-			ctrl.Finish()
 		})
 
 		It("should return err when obj is not a CredentialsBinding", func() {
@@ -81,40 +74,35 @@ var _ = Describe("CredentialsBinding validator", func() {
 		})
 
 		It("should return err if it fails to get the corresponding Secret", func() {
-			apiReader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.Secret{})).Return(fakeErr)
-
+			// Secret not pre-populated → fake returns NotFound, which the validator propagates as an error
 			err := credentialsBindingValidator.Validate(ctx, credentialsBinding, nil)
-			Expect(err).To(MatchError(fakeErr))
+			Expect(err).To(MatchError(ContainSubstring("not found")))
 		})
 
 		It("should return err when the corresponding Secret is not valid", func() {
-			apiReader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.Secret{})).
-				DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Secret, _ ...client.GetOption) error {
-					secret := &corev1.Secret{Data: map[string][]byte{
-						"foo": []byte("bar"),
-					}}
-					*obj = *secret
-					return nil
-				})
+			apiReader := fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+				Data:       map[string][]byte{"foo": []byte("bar")},
+			}).Build()
+			v := validator.NewCredentialsBindingValidator(test.FakeManager{APIReader: apiReader})
 
-			err := credentialsBindingValidator.Validate(ctx, credentialsBinding, nil)
+			err := v.Validate(ctx, credentialsBinding, nil)
 			Expect(err).To(HaveOccurred())
 		})
 
 		It("should succeed when the corresponding Secret is valid", func() {
-			apiReader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.Secret{})).
-				DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Secret, _ ...client.GetOption) error {
-					secret := &corev1.Secret{Data: map[string][]byte{
-						openstack.DomainName: []byte("domain"),
-						openstack.TenantName: []byte("tenant"),
-						openstack.UserName:   []byte("user"),
-						openstack.Password:   []byte("password"),
-					}}
-					*obj = *secret
-					return nil
-				})
+			apiReader := fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+				Data: map[string][]byte{
+					openstack.DomainName: []byte("domain"),
+					openstack.TenantName: []byte("tenant"),
+					openstack.UserName:   []byte("user"),
+					openstack.Password:   []byte("password"),
+				},
+			}).Build()
+			v := validator.NewCredentialsBindingValidator(test.FakeManager{APIReader: apiReader})
 
-			Expect(credentialsBindingValidator.Validate(ctx, credentialsBinding, nil)).To(Succeed())
+			Expect(v.Validate(ctx, credentialsBinding, nil)).To(Succeed())
 		})
 
 		It("should return nil when the CredentialsBinding did not change", func() {
@@ -134,36 +122,35 @@ var _ = Describe("CredentialsBinding validator", func() {
 			})
 
 			It("should return err if it fails to get the corresponding InternalSecret", func() {
-				apiReader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&gardencorev1beta1.InternalSecret{})).Return(fakeErr)
-
+				// InternalSecret not pre-populated → fake returns NotFound
 				err := credentialsBindingValidator.Validate(ctx, credentialsBinding, nil)
-				Expect(err).To(MatchError(fakeErr))
+				Expect(err).To(MatchError(ContainSubstring("not found")))
 			})
 
 			It("should return err when the corresponding InternalSecret is not valid", func() {
-				apiReader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&gardencorev1beta1.InternalSecret{})).
-					DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.InternalSecret, _ ...client.GetOption) error {
-						obj.Data = map[string][]byte{"foo": []byte("bar")}
-						return nil
-					})
+				apiReader := fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(&gardencorev1beta1.InternalSecret{
+					ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+					Data:       map[string][]byte{"foo": []byte("bar")},
+				}).Build()
+				v := validator.NewCredentialsBindingValidator(test.FakeManager{APIReader: apiReader})
 
-				err := credentialsBindingValidator.Validate(ctx, credentialsBinding, nil)
+				err := v.Validate(ctx, credentialsBinding, nil)
 				Expect(err).To(HaveOccurred())
 			})
 
 			It("should succeed when the corresponding InternalSecret is valid", func() {
-				apiReader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&gardencorev1beta1.InternalSecret{})).
-					DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.InternalSecret, _ ...client.GetOption) error {
-						obj.Data = map[string][]byte{
-							openstack.DomainName: []byte("domain"),
-							openstack.TenantName: []byte("tenant"),
-							openstack.UserName:   []byte("user"),
-							openstack.Password:   []byte("password"),
-						}
-						return nil
-					})
+				apiReader := fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(&gardencorev1beta1.InternalSecret{
+					ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+					Data: map[string][]byte{
+						openstack.DomainName: []byte("domain"),
+						openstack.TenantName: []byte("tenant"),
+						openstack.UserName:   []byte("user"),
+						openstack.Password:   []byte("password"),
+					},
+				}).Build()
+				v := validator.NewCredentialsBindingValidator(test.FakeManager{APIReader: apiReader})
 
-				Expect(credentialsBindingValidator.Validate(ctx, credentialsBinding, nil)).To(Succeed())
+				Expect(v.Validate(ctx, credentialsBinding, nil)).To(Succeed())
 			})
 		})
 	})

--- a/pkg/admission/validator/secretbinding_test.go
+++ b/pkg/admission/validator/secretbinding_test.go
@@ -32,8 +32,8 @@ var _ = Describe("SecretBinding validator", func() {
 		var (
 			secretBindingValidator extensionswebhook.Validator
 
-			scheme    *runtime.Scheme
-			ctx       = context.TODO()
+			scheme        *runtime.Scheme
+			ctx           = context.TODO()
 			secretBinding = &core.SecretBinding{
 				SecretRef: corev1.SecretReference{
 					Name:      name,

--- a/pkg/admission/validator/secretbinding_test.go
+++ b/pkg/admission/validator/secretbinding_test.go
@@ -6,17 +6,16 @@ package validator_test
 
 import (
 	"context"
-	"fmt"
 
 	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
 	"github.com/gardener/gardener/pkg/apis/core"
 	"github.com/gardener/gardener/pkg/utils/test"
-	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/gardener/gardener-extension-provider-openstack/pkg/admission/validator"
 	"github.com/gardener/gardener-extension-provider-openstack/pkg/openstack"
@@ -33,30 +32,23 @@ var _ = Describe("SecretBinding validator", func() {
 		var (
 			secretBindingValidator extensionswebhook.Validator
 
-			ctrl      *gomock.Controller
-			apiReader *mockclient.MockReader
-
-			ctx           = context.TODO()
+			scheme    *runtime.Scheme
+			ctx       = context.TODO()
 			secretBinding = &core.SecretBinding{
 				SecretRef: corev1.SecretReference{
 					Name:      name,
 					Namespace: namespace,
 				},
 			}
-			fakeErr = fmt.Errorf("fake err")
 		)
 
 		BeforeEach(func() {
-			ctrl = gomock.NewController(GinkgoT())
+			scheme = runtime.NewScheme()
+			Expect(corev1.AddToScheme(scheme)).To(Succeed())
 
-			apiReader = mockclient.NewMockReader(ctrl)
-
+			apiReader := fakeclient.NewClientBuilder().WithScheme(scheme).Build()
 			mgr := test.FakeManager{APIReader: apiReader}
 			secretBindingValidator = validator.NewSecretBindingValidator(mgr)
-		})
-
-		AfterEach(func() {
-			ctrl.Finish()
 		})
 
 		It("should return err when obj is not a SecretBinding", func() {
@@ -70,40 +62,35 @@ var _ = Describe("SecretBinding validator", func() {
 		})
 
 		It("should return err if it fails to get the corresponding Secret", func() {
-			apiReader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.Secret{})).Return(fakeErr)
-
+			// Secret not pre-populated → fake returns NotFound, which the validator propagates as an error
 			err := secretBindingValidator.Validate(ctx, secretBinding, nil)
-			Expect(err).To(MatchError(fakeErr))
+			Expect(err).To(MatchError(ContainSubstring("not found")))
 		})
 
 		It("should return err when the corresponding Secret is not valid", func() {
-			apiReader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.Secret{})).
-				DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Secret, _ ...client.GetOption) error {
-					secret := &corev1.Secret{Data: map[string][]byte{
-						"foo": []byte("bar"),
-					}}
-					*obj = *secret
-					return nil
-				})
+			apiReader := fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+				Data:       map[string][]byte{"foo": []byte("bar")},
+			}).Build()
+			v := validator.NewSecretBindingValidator(test.FakeManager{APIReader: apiReader})
 
-			err := secretBindingValidator.Validate(ctx, secretBinding, nil)
+			err := v.Validate(ctx, secretBinding, nil)
 			Expect(err).To(HaveOccurred())
 		})
 
 		It("should return nil when the corresponding Secret is valid", func() {
-			apiReader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.Secret{})).
-				DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Secret, _ ...client.GetOption) error {
-					secret := &corev1.Secret{Data: map[string][]byte{
-						openstack.DomainName: []byte("domain"),
-						openstack.TenantName: []byte("tenant"),
-						openstack.UserName:   []byte("user"),
-						openstack.Password:   []byte("password"),
-					}}
-					*obj = *secret
-					return nil
-				})
+			apiReader := fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+				Data: map[string][]byte{
+					openstack.DomainName: []byte("domain"),
+					openstack.TenantName: []byte("tenant"),
+					openstack.UserName:   []byte("user"),
+					openstack.Password:   []byte("password"),
+				},
+			}).Build()
+			v := validator.NewSecretBindingValidator(test.FakeManager{APIReader: apiReader})
 
-			err := secretBindingValidator.Validate(ctx, secretBinding, nil)
+			err := v.Validate(ctx, secretBinding, nil)
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})

--- a/pkg/admission/validator/shoot_test.go
+++ b/pkg/admission/validator/shoot_test.go
@@ -13,19 +13,17 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	securityv1alpha1 "github.com/gardener/gardener/pkg/apis/security/v1alpha1"
 	"github.com/gardener/gardener/pkg/utils/test"
-	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
-	"go.uber.org/mock/gomock"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/gardener/gardener-extension-provider-openstack/pkg/admission/validator"
 	apisopenstack "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack"
@@ -40,10 +38,7 @@ var _ = Describe("Shoot validator", func() {
 		var (
 			shootValidator extensionswebhook.Validator
 
-			ctrl      *gomock.Controller
-			c         *mockclient.MockClient
-			apiReader *mockclient.MockReader
-			shoot     *core.Shoot
+			shoot *core.Shoot
 
 			ctx = context.Background()
 
@@ -51,21 +46,15 @@ var _ = Describe("Shoot validator", func() {
 			imageName    string
 			imageVersion string
 			architecture *string
+
+			scheme *runtime.Scheme
 		)
 
 		BeforeEach(func() {
-			ctrl = gomock.NewController(GinkgoT())
-
-			scheme := runtime.NewScheme()
+			scheme = runtime.NewScheme()
 			Expect(apisopenstack.AddToScheme(scheme)).To(Succeed())
 			Expect(apiv1alpha1.AddToScheme(scheme)).To(Succeed())
 			Expect(gardencorev1beta1.AddToScheme(scheme)).To(Succeed())
-
-			c = mockclient.NewMockClient(ctrl)
-			apiReader = mockclient.NewMockReader(ctrl)
-
-			mgr := test.FakeManager{Scheme: scheme, Client: c, APIReader: apiReader}
-			shootValidator = validator.NewShootValidator(mgr)
 
 			regionName = "eu-de-1"
 			imageName = "Foo"
@@ -134,6 +123,18 @@ var _ = Describe("Shoot validator", func() {
 		Context("Workerless Shoot", func() {
 			BeforeEach(func() {
 				shoot.Spec.Provider.Workers = nil
+
+				// No cloud profile lookup happens for workerless shoots; build a minimal validator.
+				clientScheme := runtime.NewScheme()
+				Expect(gardencorev1beta1.AddToScheme(clientScheme)).To(Succeed())
+				c := fakeclient.NewClientBuilder().WithScheme(clientScheme).Build()
+
+				apiReaderScheme := runtime.NewScheme()
+				Expect(corev1.AddToScheme(apiReaderScheme)).To(Succeed())
+				apiReader := fakeclient.NewClientBuilder().WithScheme(apiReaderScheme).Build()
+
+				mgr := test.FakeManager{Scheme: scheme, Client: c, APIReader: apiReader}
+				shootValidator = validator.NewShootValidator(mgr)
 			})
 
 			It("should not validate", func() {
@@ -144,17 +145,11 @@ var _ = Describe("Shoot validator", func() {
 
 		Context("Shoot creation", func() {
 			var (
-				cloudProfileKey           client.ObjectKey
-				namespacedCloudProfileKey client.ObjectKey
-
 				cloudProfile           *gardencorev1beta1.CloudProfile
 				namespacedCloudProfile *gardencorev1beta1.NamespacedCloudProfile
 			)
 
 			BeforeEach(func() {
-				cloudProfileKey = client.ObjectKey{Name: "openstack"}
-				namespacedCloudProfileKey = client.ObjectKey{Name: "openstack-nscpfl", Namespace: namespace}
-
 				cloudProfile = &gardencorev1beta1.CloudProfile{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "openstack",
@@ -203,7 +198,8 @@ var _ = Describe("Shoot validator", func() {
 
 				namespacedCloudProfile = &gardencorev1beta1.NamespacedCloudProfile{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "openstack-nscpfl",
+						Name:      "openstack-nscpfl",
+						Namespace: namespace,
 					},
 					Spec: gardencorev1beta1.NamespacedCloudProfileSpec{
 						Parent: gardencorev1beta1.CloudProfileReference{
@@ -217,23 +213,38 @@ var _ = Describe("Shoot validator", func() {
 				}
 			})
 
+			// buildValidator constructs a shootValidator with a fakeclient containing the given objects.
+			// Call this at the start of each It that needs the current state of cloudProfile/namespacedCloudProfile.
+			buildValidator := func(objects ...client.Object) extensionswebhook.Validator {
+				clientScheme := runtime.NewScheme()
+				Expect(gardencorev1beta1.AddToScheme(clientScheme)).To(Succeed())
+				c := fakeclient.NewClientBuilder().WithScheme(clientScheme).WithObjects(objects...).Build()
+
+				apiReaderScheme := runtime.NewScheme()
+				Expect(corev1.AddToScheme(apiReaderScheme)).To(Succeed())
+				apiReader := fakeclient.NewClientBuilder().WithScheme(apiReaderScheme).Build()
+
+				mgr := test.FakeManager{Scheme: scheme, Client: c, APIReader: apiReader}
+				return validator.NewShootValidator(mgr)
+			}
+
 			It("should work for CloudProfile referenced from Shoot", func() {
 				shoot.Spec.CloudProfile = &core.CloudProfileReference{
 					Kind: "CloudProfile",
 					Name: "openstack",
 				}
-				c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
+				v := buildValidator(cloudProfile)
 
-				err := shootValidator.Validate(ctx, shoot, nil)
+				err := v.Validate(ctx, shoot, nil)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
 			It("should work for CloudProfile referenced from cloudProfileName", func() {
 				shoot.Spec.CloudProfileName = ptr.To("openstack")
 				shoot.Spec.CloudProfile = nil
-				c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
+				v := buildValidator(cloudProfile)
 
-				err := shootValidator.Validate(ctx, shoot, nil)
+				err := v.Validate(ctx, shoot, nil)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -242,9 +253,9 @@ var _ = Describe("Shoot validator", func() {
 					Kind: "NamespacedCloudProfile",
 					Name: "openstack-nscpfl",
 				}
-				c.EXPECT().Get(ctx, namespacedCloudProfileKey, &gardencorev1beta1.NamespacedCloudProfile{}).SetArg(2, *namespacedCloudProfile)
+				v := buildValidator(namespacedCloudProfile)
 
-				err := shootValidator.Validate(ctx, shoot, nil)
+				err := v.Validate(ctx, shoot, nil)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -254,9 +265,9 @@ var _ = Describe("Shoot validator", func() {
 					Name: "openstack-nscpfl",
 				}
 				namespacedCloudProfile.Status.CloudProfileSpec.ProviderConfig = nil
-				c.EXPECT().Get(ctx, namespacedCloudProfileKey, &gardencorev1beta1.NamespacedCloudProfile{}).SetArg(2, *namespacedCloudProfile)
+				v := buildValidator(namespacedCloudProfile)
 
-				err := shootValidator.Validate(ctx, shoot, nil)
+				err := v.Validate(ctx, shoot, nil)
 				Expect(err).To(MatchError(And(
 					ContainSubstring("providerConfig is not given for cloud profile"),
 					ContainSubstring("NamespacedCloudProfile"),
@@ -272,8 +283,11 @@ var _ = Describe("Shoot validator", func() {
 					}
 				})
 
+				JustBeforeEach(func() {
+					shootValidator = buildValidator(cloudProfile)
+				})
+
 				It("should succeed when networking is configured with dual-stack and subnetPoolID", func() {
-					c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
 					shoot.Spec.Networking.IPFamilies = []core.IPFamily{core.IPFamilyIPv4, core.IPFamilyIPv6}
 					shoot.Spec.Provider.InfrastructureConfig = &runtime.RawExtension{
 						Raw: encode(&apiv1alpha1.InfrastructureConfig{
@@ -296,7 +310,6 @@ var _ = Describe("Shoot validator", func() {
 				})
 
 				It("should succeed when networking is configured with dual-stack and IPv6 config", func() {
-					c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
 					shoot.Spec.Networking.IPFamilies = []core.IPFamily{core.IPFamilyIPv4, core.IPFamilyIPv6}
 					shoot.Spec.Provider.InfrastructureConfig = &runtime.RawExtension{
 						Raw: encode(&apiv1alpha1.InfrastructureConfig{
@@ -321,7 +334,6 @@ var _ = Describe("Shoot validator", func() {
 				})
 
 				It("should return err when networking is configured to use dual-stack without subnetPoolID or IPv6 config", func() {
-					c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
 					shoot.Spec.Networking.IPFamilies = []core.IPFamily{core.IPFamilyIPv4, core.IPFamilyIPv6}
 
 					err := shootValidator.Validate(ctx, shoot, nil)
@@ -332,7 +344,6 @@ var _ = Describe("Shoot validator", func() {
 				})
 
 				It("should return err when networking is configured to use IPv6-only", func() {
-					c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
 					shoot.Spec.Networking.IPFamilies = []core.IPFamily{core.IPFamilyIPv6}
 
 					err := shootValidator.Validate(ctx, shoot, nil)
@@ -348,14 +359,11 @@ var _ = Describe("Shoot validator", func() {
 
 		Context("DNS validation", func() {
 			var (
-				cloudProfileKey client.ObjectKey
-				cloudProfile    *gardencorev1beta1.CloudProfile
-				dnsSecretKey    client.ObjectKey
-				dnsSecret       *corev1.Secret
+				cloudProfile *gardencorev1beta1.CloudProfile
+				dnsSecret    *corev1.Secret
 			)
 
 			BeforeEach(func() {
-				cloudProfileKey = client.ObjectKey{Name: "openstack"}
 				cloudProfile = &gardencorev1beta1.CloudProfile{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "openstack",
@@ -398,7 +406,6 @@ var _ = Describe("Shoot validator", func() {
 					},
 				}
 
-				dnsSecretKey = client.ObjectKey{Namespace: namespace, Name: "dns-secret"}
 				dnsSecret = &corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "dns-secret",
@@ -419,11 +426,27 @@ var _ = Describe("Shoot validator", func() {
 				}
 			})
 
+			// buildDNSValidator constructs a shootValidator with cloudProfile in the main client
+			// and the given apiReader objects (DNS secrets, workload identities, etc.).
+			buildDNSValidator := func(apiReaderObjects ...client.Object) extensionswebhook.Validator {
+				clientScheme := runtime.NewScheme()
+				Expect(gardencorev1beta1.AddToScheme(clientScheme)).To(Succeed())
+				c := fakeclient.NewClientBuilder().WithScheme(clientScheme).WithObjects(cloudProfile).Build()
+
+				apiReaderScheme := runtime.NewScheme()
+				Expect(corev1.AddToScheme(apiReaderScheme)).To(Succeed())
+				Expect(securityv1alpha1.AddToScheme(apiReaderScheme)).To(Succeed())
+				apiReader := fakeclient.NewClientBuilder().WithScheme(apiReaderScheme).WithObjects(apiReaderObjects...).Build()
+
+				mgr := test.FakeManager{Scheme: scheme, Client: c, APIReader: apiReader}
+				return validator.NewShootValidator(mgr)
+			}
+
 			It("should pass when shoot has no DNS configuration", func() {
 				shoot.Spec.DNS = nil
-				c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
+				v := buildDNSValidator()
 
-				err := shootValidator.Validate(ctx, shoot, nil)
+				err := v.Validate(ctx, shoot, nil)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -442,9 +465,9 @@ var _ = Describe("Shoot validator", func() {
 							},
 						},
 					}
-					c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
+					v := buildDNSValidator()
 
-					err := shootValidator.Validate(ctx, shoot, nil)
+					err := v.Validate(ctx, shoot, nil)
 					Expect(err).NotTo(HaveOccurred())
 				})
 
@@ -462,9 +485,9 @@ var _ = Describe("Shoot validator", func() {
 							},
 						},
 					}
-					c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
+					v := buildDNSValidator()
 
-					err := shootValidator.Validate(ctx, shoot, nil)
+					err := v.Validate(ctx, shoot, nil)
 					Expect(err).NotTo(HaveOccurred())
 				})
 
@@ -482,9 +505,9 @@ var _ = Describe("Shoot validator", func() {
 							},
 						},
 					}
-					c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
+					v := buildDNSValidator()
 
-					err := shootValidator.Validate(ctx, shoot, nil)
+					err := v.Validate(ctx, shoot, nil)
 					Expect(err).NotTo(HaveOccurred())
 				})
 
@@ -511,9 +534,9 @@ var _ = Describe("Shoot validator", func() {
 							},
 						},
 					}
-					c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
+					v := buildDNSValidator()
 
-					err := shootValidator.Validate(ctx, shoot, nil)
+					err := v.Validate(ctx, shoot, nil)
 					Expect(err).NotTo(HaveOccurred())
 				})
 
@@ -549,10 +572,9 @@ var _ = Describe("Shoot validator", func() {
 							},
 						},
 					}
-					c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
-					apiReader.EXPECT().Get(ctx, dnsSecretKey, &corev1.Secret{}).SetArg(2, *dnsSecret)
+					v := buildDNSValidator(dnsSecret)
 
-					err := shootValidator.Validate(ctx, shoot, nil)
+					err := v.Validate(ctx, shoot, nil)
 					Expect(err).NotTo(HaveOccurred())
 				})
 
@@ -574,9 +596,9 @@ var _ = Describe("Shoot validator", func() {
 							},
 						},
 					}
-					c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
+					v := buildDNSValidator()
 
-					err := shootValidator.Validate(ctx, shoot, nil)
+					err := v.Validate(ctx, shoot, nil)
 					Expect(err).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 						"Type":  Equal(field.ErrorTypeRequired),
 						"Field": Equal("spec.dns.providers[1].credentialsRef"),
@@ -594,9 +616,9 @@ var _ = Describe("Shoot validator", func() {
 							},
 						},
 					}
-					c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
+					v := buildDNSValidator()
 
-					err := shootValidator.Validate(ctx, shoot, nil)
+					err := v.Validate(ctx, shoot, nil)
 					Expect(err).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 						"Type":   Equal(field.ErrorTypeRequired),
 						"Field":  Equal("spec.dns.providers[0].credentialsRef"),
@@ -618,9 +640,9 @@ var _ = Describe("Shoot validator", func() {
 							},
 						},
 					}
-					c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
+					v := buildDNSValidator()
 
-					err := shootValidator.Validate(ctx, shoot, nil)
+					err := v.Validate(ctx, shoot, nil)
 					Expect(err).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 						"Type":   Equal(field.ErrorTypeInternal),
 						"Field":  Equal("spec.dns.providers[0].credentialsRef"),
@@ -642,10 +664,14 @@ var _ = Describe("Shoot validator", func() {
 							},
 						},
 					}
-					c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
-					apiReader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "dns-workload-identity"}, &securityv1alpha1.WorkloadIdentity{}).Return(nil)
+					v := buildDNSValidator(&securityv1alpha1.WorkloadIdentity{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "dns-workload-identity",
+							Namespace: namespace,
+						},
+					})
 
-					err := shootValidator.Validate(ctx, shoot, nil)
+					err := v.Validate(ctx, shoot, nil)
 					Expect(err).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 						"Type":   Equal(field.ErrorTypeInvalid),
 						"Field":  Equal("spec.dns.providers[0].credentialsRef"),
@@ -667,10 +693,9 @@ var _ = Describe("Shoot validator", func() {
 							},
 						},
 					}
-					c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
-					apiReader.EXPECT().Get(ctx, dnsSecretKey, &corev1.Secret{}).Return(apierrors.NewNotFound(corev1.Resource("Secret"), "dns-secret"))
+					v := buildDNSValidator() // no dnsSecret → not found
 
-					err := shootValidator.Validate(ctx, shoot, nil)
+					err := v.Validate(ctx, shoot, nil)
 					Expect(err).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 						"Type":  Equal(field.ErrorTypeNotFound),
 						"Field": Equal("spec.dns.providers[0].credentialsRef"),
@@ -698,10 +723,9 @@ var _ = Describe("Shoot validator", func() {
 						openstack.UserName:   []byte("my-user"),
 						openstack.Password:   []byte("my-password"),
 					}
-					c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
-					apiReader.EXPECT().Get(ctx, dnsSecretKey, &corev1.Secret{}).SetArg(2, *dnsSecret)
+					v := buildDNSValidator(dnsSecret)
 
-					err := shootValidator.Validate(ctx, shoot, nil)
+					err := v.Validate(ctx, shoot, nil)
 					Expect(err).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
 						"Type":  Equal(field.ErrorTypeRequired),
 						"Field": Equal("spec.dns.providers[0].credentialsRef.data[authURL]"),
@@ -722,10 +746,9 @@ var _ = Describe("Shoot validator", func() {
 							},
 						},
 					}
-					c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
-					apiReader.EXPECT().Get(ctx, dnsSecretKey, &corev1.Secret{}).SetArg(2, *dnsSecret)
+					v := buildDNSValidator(dnsSecret)
 
-					err := shootValidator.Validate(ctx, shoot, nil)
+					err := v.Validate(ctx, shoot, nil)
 					Expect(err).NotTo(HaveOccurred())
 				})
 			})
@@ -741,9 +764,9 @@ var _ = Describe("Shoot validator", func() {
 							},
 						},
 					}
-					c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
+					v := buildDNSValidator()
 
-					err := shootValidator.Validate(ctx, shoot, nil)
+					err := v.Validate(ctx, shoot, nil)
 					Expect(err).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 						"Type":   Equal(field.ErrorTypeRequired),
 						"Field":  Equal("spec.dns.providers[0].credentialsRef"),
@@ -761,10 +784,9 @@ var _ = Describe("Shoot validator", func() {
 							},
 						},
 					}
-					c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
-					apiReader.EXPECT().Get(ctx, dnsSecretKey, &corev1.Secret{}).SetArg(2, *dnsSecret)
+					v := buildDNSValidator(dnsSecret)
 
-					err := shootValidator.Validate(ctx, shoot, nil)
+					err := v.Validate(ctx, shoot, nil)
 					Expect(err).NotTo(HaveOccurred())
 				})
 
@@ -778,10 +800,9 @@ var _ = Describe("Shoot validator", func() {
 							},
 						},
 					}
-					c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
-					apiReader.EXPECT().Get(ctx, dnsSecretKey, &corev1.Secret{}).Return(apierrors.NewNotFound(corev1.Resource("Secret"), "dns-secret"))
+					v := buildDNSValidator() // no dnsSecret → not found
 
-					err := shootValidator.Validate(ctx, shoot, nil)
+					err := v.Validate(ctx, shoot, nil)
 					Expect(err).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 						"Type":  Equal(field.ErrorTypeNotFound),
 						"Field": Equal("spec.dns.providers[0].secretName"),
@@ -805,10 +826,9 @@ var _ = Describe("Shoot validator", func() {
 						openstack.UserName:   []byte("my-user"),
 						openstack.Password:   []byte("my-password"),
 					}
-					c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
-					apiReader.EXPECT().Get(ctx, dnsSecretKey, &corev1.Secret{}).SetArg(2, *dnsSecret)
+					v := buildDNSValidator(dnsSecret)
 
-					err := shootValidator.Validate(ctx, shoot, nil)
+					err := v.Validate(ctx, shoot, nil)
 					Expect(err).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
 						"Type":  Equal(field.ErrorTypeRequired),
 						"Field": Equal("spec.dns.providers[0].secretName.data[authURL]"),
@@ -830,10 +850,9 @@ var _ = Describe("Shoot validator", func() {
 							},
 						},
 					}
-					c.EXPECT().Get(ctx, cloudProfileKey, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
-					apiReader.EXPECT().Get(ctx, dnsSecretKey, &corev1.Secret{}).SetArg(2, *dnsSecret)
+					v := buildDNSValidator(dnsSecret)
 
-					err := shootValidator.Validate(ctx, shoot, nil)
+					err := v.Validate(ctx, shoot, nil)
 					Expect(err).NotTo(HaveOccurred())
 				})
 			})

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -18,10 +18,8 @@ import (
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
 	fakesecretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager/fake"
 	"github.com/gardener/gardener/pkg/utils/test"
-	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"go.uber.org/mock/gomock"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
@@ -123,8 +121,6 @@ var _ = Describe("ValuesProvider", func() {
 	var (
 		ctx = context.TODO()
 
-		ctrl *gomock.Controller
-
 		scheme = runtime.NewScheme()
 		_      = api.AddToScheme(scheme)
 
@@ -132,7 +128,7 @@ var _ = Describe("ValuesProvider", func() {
 		fakeSecretsManager secretsmanager.Interface
 
 		vp genericactuator.ValuesProvider
-		c  *mockclient.MockClient
+		c  client.Client
 
 		cp = defaultControlPlane()
 
@@ -236,7 +232,6 @@ var _ = Describe("ValuesProvider", func() {
 
 		domainName  = "domain-name"
 		tenantName  = "tenant-name"
-		cpSecretKey = client.ObjectKey{Namespace: namespace, Name: v1beta1constants.SecretNameCloudProvider}
 		cpSecret    = &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      v1beta1constants.SecretNameCloudProvider,
@@ -252,7 +247,6 @@ var _ = Describe("ValuesProvider", func() {
 			},
 		}
 
-		cpConfigKey = client.ObjectKey{Namespace: namespace, Name: openstack.CloudProviderConfigName}
 		cpConfig    = &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      openstack.CloudProviderConfigName,
@@ -265,7 +259,6 @@ var _ = Describe("ValuesProvider", func() {
 		}
 
 		cloudProviderDiskConfig = []byte("foo")
-		cpCSIDiskConfigKey      = client.ObjectKey{Namespace: namespace, Name: openstack.CloudProviderCSIDiskConfigName}
 		cpCSIDiskConfig         = &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      openstack.CloudProviderCSIDiskConfigName,
@@ -288,19 +281,23 @@ var _ = Describe("ValuesProvider", func() {
 	)
 
 	BeforeEach(func() {
-		ctrl = gomock.NewController(GinkgoT())
+		clientScheme := runtime.NewScheme()
+		Expect(api.AddToScheme(clientScheme)).To(Succeed())
+		Expect(corev1.AddToScheme(clientScheme)).To(Succeed())
+		Expect(appsv1.AddToScheme(clientScheme)).To(Succeed())
+		Expect(policyv1.AddToScheme(clientScheme)).To(Succeed())
+		Expect(vpaautoscalingv1.AddToScheme(clientScheme)).To(Succeed())
 
-		c = mockclient.NewMockClient(ctrl)
+		c = fakeclient.NewClientBuilder().
+			WithScheme(clientScheme).
+			WithObjects(cpSecret.DeepCopy(), cpConfig.DeepCopy(), cpCSIDiskConfig.DeepCopy()).
+			Build()
 
 		fakeClient = fakeclient.NewClientBuilder().Build()
 		fakeSecretsManager = fakesecretsmanager.New(fakeClient, namespace)
 
 		mgr := test.FakeManager{Client: c, Scheme: scheme}
 		vp = NewValuesProvider(mgr)
-	})
-
-	AfterEach(func() {
-		ctrl.Finish()
 	})
 
 	Describe("#GetConfigChartValues", func() {
@@ -325,16 +322,12 @@ var _ = Describe("ValuesProvider", func() {
 		}
 
 		It("should return correct config chart values", func() {
-			c.EXPECT().Get(ctx, cpSecretKey, &corev1.Secret{}).DoAndReturn(clientGet(cpSecret))
-
 			values, err := vp.GetConfigChartValues(ctx, cp, cluster)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(values).To(Equal(configChartValues))
 		})
 
 		It("should return correct config chart values with load balancer classes", func() {
-			c.EXPECT().Get(ctx, cpSecretKey, &corev1.Secret{}).DoAndReturn(clientGet(cpSecret))
-
 			var (
 				floatingNetworkID  = "4711"
 				fsid               = "0815"
@@ -425,8 +418,6 @@ var _ = Describe("ValuesProvider", func() {
 		})
 
 		It("should return correct config chart values with load balancer classes with purpose", func() {
-			c.EXPECT().Get(ctx, cpSecretKey, &corev1.Secret{}).DoAndReturn(clientGet(cpSecret))
-
 			var (
 				floatingNetworkID = "fip1"
 				cp                = controlPlane(
@@ -475,7 +466,7 @@ var _ = Describe("ValuesProvider", func() {
 		})
 
 		It("should return correct config chart values with application credentials", func() {
-			secret2 := *cpSecret
+			secret2 := cpSecret.DeepCopy()
 			secret2.Data = map[string][]byte{
 				"domainName":                  []byte(domainName),
 				"tenantName":                  []byte(tenantName),
@@ -483,8 +474,7 @@ var _ = Describe("ValuesProvider", func() {
 				"applicationCredentialSecret": []byte(`app-secret`),
 				"authURL":                     []byte(authURL),
 			}
-
-			c.EXPECT().Get(ctx, cpSecretKey, &corev1.Secret{}).DoAndReturn(clientGet(&secret2))
+			Expect(c.Update(ctx, secret2)).To(Succeed())
 
 			expectedValues := utils.MergeMaps(configChartValues, map[string]interface{}{
 				"username":                    "",
@@ -499,7 +489,6 @@ var _ = Describe("ValuesProvider", func() {
 		})
 
 		It("should configure cloud routes when not using overlay", func() {
-			c.EXPECT().Get(ctx, cpSecretKey, &corev1.Secret{}).DoAndReturn(clientGet(cpSecret))
 			expectedValues := utils.MergeMaps(configChartValues, map[string]interface{}{
 				"routerID": "routerID",
 			})
@@ -512,7 +501,7 @@ var _ = Describe("ValuesProvider", func() {
 			secret2 := cpSecret.DeepCopy()
 			caCert := "custom-cert"
 			secret2.Data["caCert"] = []byte(caCert)
-			c.EXPECT().Get(ctx, cpSecretKey, &corev1.Secret{}).DoAndReturn(clientGet(secret2))
+			Expect(c.Update(ctx, secret2)).To(Succeed())
 			expectedValues := utils.MergeMaps(configChartValues, map[string]interface{}{
 				"caCert": caCert,
 			})
@@ -554,22 +543,12 @@ var _ = Describe("ValuesProvider", func() {
 		})
 
 		BeforeEach(func() {
-			c.EXPECT().Get(ctx, cpConfigKey, &corev1.Secret{}).DoAndReturn(clientGet(cpConfig))
-
-			c.EXPECT().Delete(context.TODO(), &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "csi-snapshot-validation", Namespace: namespace}})
-			c.EXPECT().Delete(context.TODO(), &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "csi-snapshot-validation", Namespace: namespace}})
-			c.EXPECT().Delete(context.TODO(), &vpaautoscalingv1.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Name: "csi-snapshot-webhook-vpa", Namespace: namespace}})
-			c.EXPECT().Delete(context.TODO(), &policyv1.PodDisruptionBudget{ObjectMeta: metav1.ObjectMeta{Name: "csi-snapshot-validation", Namespace: namespace}})
-
 			By("creating secrets managed outside of this package for whose secretsmanager.Get() will be called")
 			Expect(fakeClient.Create(context.TODO(), &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "ca-provider-openstack-controlplane", Namespace: namespace}})).To(Succeed())
 			Expect(fakeClient.Create(context.TODO(), &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "cloud-controller-manager-server", Namespace: namespace}})).To(Succeed())
 		})
 
 		It("should return correct control plane chart values", func() {
-			c.EXPECT().Get(ctx, cpCSIDiskConfigKey, &corev1.Secret{}).DoAndReturn(clientGet(cpCSIDiskConfig))
-			c.EXPECT().Get(ctx, cpSecretKey, &corev1.Secret{}).DoAndReturn(clientGet(cpSecret))
-
 			values, err := vp.GetControlPlaneChartValues(ctx, cp, cluster, fakeSecretsManager, checksums, false)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(values).To(Equal(map[string]interface{}{
@@ -595,9 +574,6 @@ var _ = Describe("ValuesProvider", func() {
 		})
 
 		It("should return correct control plane chart values if CSI Manila is enabled", func() {
-			c.EXPECT().Get(ctx, cpCSIDiskConfigKey, &corev1.Secret{}).DoAndReturn(clientGet(cpCSIDiskConfig))
-			c.EXPECT().Get(ctx, cpSecretKey, &corev1.Secret{}).DoAndReturn(clientGet(cpSecret))
-
 			cpManila := defaultControlPlaneWithManila(true)
 			values, err := vp.GetControlPlaneChartValues(ctx, cpManila, cluster, fakeSecretsManager, checksums, false)
 			Expect(err).NotTo(HaveOccurred())
@@ -650,9 +626,6 @@ var _ = Describe("ValuesProvider", func() {
 
 		DescribeTable("topologyAwareRoutingEnabled value",
 			func(seedSettings *gardencorev1beta1.SeedSettings, shootControlPlane *gardencorev1beta1.ControlPlane) {
-				c.EXPECT().Get(ctx, cpCSIDiskConfigKey, &corev1.Secret{}).DoAndReturn(clientGet(cpCSIDiskConfig))
-				c.EXPECT().Get(ctx, cpSecretKey, &corev1.Secret{}).DoAndReturn(clientGet(cpSecret))
-
 				cluster.Seed = &gardencorev1beta1.Seed{
 					Spec: gardencorev1beta1.SeedSpec{
 						Settings: seedSettings,
@@ -701,8 +674,6 @@ var _ = Describe("ValuesProvider", func() {
 
 		Context("shoot control plane chart values", func() {
 			It("should return correct shoot control plane chart when ca is secret found", func() {
-				c.EXPECT().Get(ctx, cpSecretKey, &corev1.Secret{}).DoAndReturn(clientGet(cpSecret))
-
 				values, err := vp.GetControlPlaneShootChartValues(ctx, cp, cluster, fakeSecretsManager, map[string]string{})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(values).To(Equal(map[string]interface{}{
@@ -718,8 +689,6 @@ var _ = Describe("ValuesProvider", func() {
 			})
 
 			It("should return correct shoot control plane chart if CSI Manila is enabled", func() {
-				c.EXPECT().Get(ctx, cpSecretKey, &corev1.Secret{}).DoAndReturn(clientGet(cpSecret))
-
 				cpManila := defaultControlPlaneWithManila(true)
 				values, err := vp.GetControlPlaneShootChartValues(ctx, cpManila, cluster, fakeSecretsManager, map[string]string{})
 				Expect(err).NotTo(HaveOccurred())
@@ -755,8 +724,6 @@ var _ = Describe("ValuesProvider", func() {
 				}))
 			})
 			It("should fall back to Workers CIDR from infra config when nodes subnet CIDR is empty in infra status", func() {
-				c.EXPECT().Get(ctx, cpSecretKey, &corev1.Secret{}).DoAndReturn(clientGet(cpSecret))
-
 				// Simulate a shoot whose infrastructure status was written before the CIDR field
 				// was populated in the subnet status (pre-subnet-pool feature).
 				cpManila := defaultControlPlaneWithManila(true)
@@ -794,8 +761,6 @@ var _ = Describe("ValuesProvider", func() {
 			})
 
 			It("should return correct shoot control plane chart if CSI Manila is enabled and subnet pool is used", func() {
-				c.EXPECT().Get(ctx, cpSecretKey, &corev1.Secret{}).DoAndReturn(clientGet(cpSecret))
-
 				// Build a ControlPlane with Manila enabled and an infra status where the nodes subnet
 				// has a CIDR allocated from a subnet pool (no static Workers CIDR in the infra config).
 				cpConfig := &api.ControlPlaneConfig{
@@ -895,14 +860,4 @@ var _ = Describe("ValuesProvider", func() {
 func encode(obj runtime.Object) []byte {
 	data, _ := json.Marshal(obj)
 	return data
-}
-
-func clientGet(result runtime.Object) interface{} {
-	return func(_ context.Context, _ client.ObjectKey, obj runtime.Object, _ ...client.GetOption) error {
-		switch obj.(type) {
-		case *corev1.Secret:
-			*obj.(*corev1.Secret) = *result.(*corev1.Secret)
-		}
-		return nil
-	}
 }

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -230,9 +230,9 @@ var _ = Describe("ValuesProvider", func() {
 			},
 		}
 
-		domainName  = "domain-name"
-		tenantName  = "tenant-name"
-		cpSecret    = &corev1.Secret{
+		domainName = "domain-name"
+		tenantName = "tenant-name"
+		cpSecret   = &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      v1beta1constants.SecretNameCloudProvider,
 				Namespace: namespace,
@@ -247,7 +247,7 @@ var _ = Describe("ValuesProvider", func() {
 			},
 		}
 
-		cpConfig    = &corev1.Secret{
+		cpConfig = &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      openstack.CloudProviderConfigName,
 				Namespace: namespace,

--- a/pkg/controller/dnsrecord/actuator_test.go
+++ b/pkg/controller/dnsrecord/actuator_test.go
@@ -10,15 +10,15 @@ import (
 	"github.com/gardener/gardener/extensions/pkg/controller/dnsrecord"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/utils/test"
-	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/ptr"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	. "github.com/gardener/gardener-extension-provider-openstack/pkg/controller/dnsrecord"
@@ -44,8 +44,6 @@ const (
 var _ = Describe("Actuator", func() {
 	var (
 		ctrl                          *gomock.Controller
-		c                             *mockclient.MockClient
-		sw                            *mockclient.MockStatusWriter
 		openstackClientFactoryFactory *mockopenstackclient.MockFactoryFactory
 		openstackClientFactory        *mockopenstackclient.MockFactory
 		dnsClient                     *mockopenstackclient.MockDNS
@@ -61,20 +59,31 @@ var _ = Describe("Actuator", func() {
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
 
-		c = mockclient.NewMockClient(ctrl)
-		sw = mockclient.NewMockStatusWriter(ctrl)
 		openstackClientFactoryFactory = mockopenstackclient.NewMockFactoryFactory(ctrl)
 		openstackClientFactory = mockopenstackclient.NewMockFactory(ctrl)
 		dnsClient = mockopenstackclient.NewMockDNS(ctrl)
 
-		c.EXPECT().Status().Return(sw).AnyTimes()
-
 		ctx = context.TODO()
 		logger = log.Log.WithName("test")
 
-		mgr := test.FakeManager{Client: c}
+		scheme := runtime.NewScheme()
+		Expect(corev1.AddToScheme(scheme)).To(Succeed())
+		Expect(extensionsv1alpha1.AddToScheme(scheme)).To(Succeed())
 
-		a = NewActuator(mgr, openstackClientFactoryFactory)
+		secret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+			Type: corev1.SecretTypeOpaque,
+			Data: map[string][]byte{
+				openstack.DNSDomainName: []byte(domainName),
+				openstack.DNSTenantName: []byte(tenantName),
+				openstack.DNSUserName:   []byte(userName),
+				openstack.DNSPassword:   []byte(password),
+				openstack.DNSAuthURL:    []byte(authURL),
+			},
+		}
 
 		dns = &extensionsv1alpha1.DNSRecord{
 			ObjectMeta: metav1.ObjectMeta{
@@ -94,20 +103,15 @@ var _ = Describe("Actuator", func() {
 				Values:     []string{address},
 			},
 		}
-		secret = &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      name,
-				Namespace: namespace,
-			},
-			Type: corev1.SecretTypeOpaque,
-			Data: map[string][]byte{
-				openstack.DNSDomainName: []byte(domainName),
-				openstack.DNSTenantName: []byte(tenantName),
-				openstack.DNSUserName:   []byte(userName),
-				openstack.DNSPassword:   []byte(password),
-				openstack.DNSAuthURL:    []byte(authURL),
-			},
-		}
+
+		c := fakeclient.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(secret, dns).
+			WithStatusSubresource(&extensionsv1alpha1.DNSRecord{}).
+			Build()
+		mgr := test.FakeManager{Client: c}
+		a = NewActuator(mgr, openstackClientFactoryFactory)
+
 		credentials = &openstack.Credentials{
 			DomainName: domainName,
 			TenantName: tenantName,
@@ -129,27 +133,14 @@ var _ = Describe("Actuator", func() {
 
 	Describe("#Reconcile", func() {
 		It("should reconcile the DNSRecord", func() {
-			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(
-				func(_ context.Context, _ client.ObjectKey, obj *corev1.Secret, _ ...client.GetOption) error {
-					*obj = *secret
-					return nil
-				},
-			)
 			openstackClientFactoryFactory.EXPECT().NewFactory(ctx, credentials).Return(openstackClientFactory, nil)
 			openstackClientFactory.EXPECT().DNS().Return(dnsClient, nil)
 			dnsClient.EXPECT().GetZones(ctx).Return(zones, nil)
 			dnsClient.EXPECT().CreateOrUpdateRecordSet(ctx, zone, dnsName, string(extensionsv1alpha1.DNSRecordTypeA), []string{address}, 120).Return(nil)
-			sw.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&extensionsv1alpha1.DNSRecord{}), gomock.Any()).DoAndReturn(
-				func(_ context.Context, obj *extensionsv1alpha1.DNSRecord, _ client.Patch, _ ...client.PatchOption) error {
-					Expect(obj.Status).To(Equal(extensionsv1alpha1.DNSRecordStatus{
-						Zone: ptr.To(zone),
-					}))
-					return nil
-				},
-			)
 
 			err := a.Reconcile(ctx, logger, dns, nil)
 			Expect(err).NotTo(HaveOccurred())
+			Expect(dns.Status.Zone).To(Equal(ptr.To(zone)))
 		})
 	})
 
@@ -157,12 +148,6 @@ var _ = Describe("Actuator", func() {
 		It("should delete the DNSRecord", func() {
 			dns.Status.Zone = ptr.To(zone)
 
-			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(
-				func(_ context.Context, _ client.ObjectKey, obj *corev1.Secret, _ ...client.GetOption) error {
-					*obj = *secret
-					return nil
-				},
-			)
 			openstackClientFactoryFactory.EXPECT().NewFactory(ctx, credentials).Return(openstackClientFactory, nil)
 			openstackClientFactory.EXPECT().DNS().Return(dnsClient, nil)
 			dnsClient.EXPECT().DeleteRecordSet(ctx, zone, dnsName, string(extensionsv1alpha1.DNSRecordTypeA)).Return(nil)

--- a/pkg/controller/infrastructure/configvalidator_test.go
+++ b/pkg/controller/infrastructure/configvalidator_test.go
@@ -13,7 +13,6 @@ import (
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/utils/test"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
-	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -23,7 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	apisopenstack "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack"
@@ -47,7 +46,6 @@ const (
 var _ = Describe("ConfigValidator", func() {
 	var (
 		ctrl                          *gomock.Controller
-		c                             *mockclient.MockClient
 		openstackClientFactoryFactory *mockopenstackclient.MockFactoryFactory
 		openstackClientFactory        *mockopenstackclient.MockFactory
 		networkingClient              *mockopenstackclient.MockNetworking
@@ -62,7 +60,6 @@ var _ = Describe("ConfigValidator", func() {
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
 
-		c = mockclient.NewMockClient(ctrl)
 		openstackClientFactoryFactory = mockopenstackclient.NewMockFactoryFactory(ctrl)
 		openstackClientFactory = mockopenstackclient.NewMockFactory(ctrl)
 		networkingClient = mockopenstackclient.NewMockNetworking(ctrl)
@@ -70,6 +67,25 @@ var _ = Describe("ConfigValidator", func() {
 		ctx = context.TODO()
 		logger = log.Log.WithName("test")
 
+		scheme := runtime.NewScheme()
+		Expect(corev1.AddToScheme(scheme)).To(Succeed())
+
+		secret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+			Type: corev1.SecretTypeOpaque,
+			Data: map[string][]byte{
+				openstack.DomainName: []byte(domainName),
+				openstack.TenantName: []byte(tenantName),
+				openstack.UserName:   []byte(userName),
+				openstack.Password:   []byte(password),
+				openstack.AuthURL:    []byte(authURL),
+			},
+		}
+
+		c := fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(secret).Build()
 		mgr := test.FakeManager{Client: c}
 		cv = NewConfigValidator(mgr, openstackClientFactoryFactory, logger)
 
@@ -123,12 +139,6 @@ var _ = Describe("ConfigValidator", func() {
 
 	Describe("#Validate", func() {
 		BeforeEach(func() {
-			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(
-				func(_ context.Context, _ client.ObjectKey, obj *corev1.Secret, _ ...client.GetOption) error {
-					*obj = *secret
-					return nil
-				},
-			)
 			openstackClientFactoryFactory.EXPECT().NewFactory(ctx, credentials).Return(openstackClientFactory, nil)
 			openstackClientFactory.EXPECT().Networking(gomock.Any()).Return(networkingClient, nil)
 		})

--- a/pkg/controller/worker/machine_dependencies_test.go
+++ b/pkg/controller/worker/machine_dependencies_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/gardener/gardener/extensions/pkg/controller/worker/genericactuator"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
-	k8smocks "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
 	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/servergroups"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -21,6 +20,8 @@ import (
 	"go.uber.org/mock/gomock"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	api "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack"
 	apiv1alpha1 "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack/v1alpha1"
@@ -35,8 +36,6 @@ var _ = Describe("#MachineDependencies", func() {
 
 		osFactory      *mocks.MockFactory
 		computeClient  *mocks.MockCompute
-		cl             *k8smocks.MockClient
-		statusCl       *k8smocks.MockStatusWriter
 		scheme         *runtime.Scheme
 		workerDelegate genericactuator.WorkerDelegate
 	)
@@ -47,14 +46,10 @@ var _ = Describe("#MachineDependencies", func() {
 		osFactory = mocks.NewMockFactory(ctrl)
 		computeClient = mocks.NewMockCompute(ctrl)
 
-		cl = k8smocks.NewMockClient(ctrl)
-		statusCl = k8smocks.NewMockStatusWriter(ctrl)
-
-		cl.EXPECT().Status().AnyTimes().Return(statusCl)
-
 		scheme = runtime.NewScheme()
 		_ = api.AddToScheme(scheme)
 		_ = apiv1alpha1.AddToScheme(scheme)
+		_ = extensionsv1alpha1.AddToScheme(scheme)
 	})
 
 	AfterEach(func() {
@@ -66,6 +61,7 @@ var _ = Describe("#MachineDependencies", func() {
 			namespace   string
 			technicalID string
 			w           *extensionsv1alpha1.Worker
+			cl          client.Client
 		)
 
 		BeforeEach(func() {
@@ -74,9 +70,15 @@ var _ = Describe("#MachineDependencies", func() {
 
 			w = &extensionsv1alpha1.Worker{
 				ObjectMeta: metav1.ObjectMeta{
+					Name:      "worker",
 					Namespace: namespace,
 				},
 			}
+			cl = fakeclient.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(w).
+				WithStatusSubresource(&extensionsv1alpha1.Worker{}).
+				Build()
 			osFactory.EXPECT().Compute(gomock.Any()).AnyTimes().Return(computeClient, nil)
 		})
 
@@ -92,12 +94,11 @@ var _ = Describe("#MachineDependencies", func() {
 				)
 
 				ctx := context.Background()
-				expectStatusUpdateToSucceed(ctx, statusCl)
 
 				err := workerDelegate.PreReconcileHook(ctx)
 				Expect(err).NotTo(HaveOccurred())
 
-				workerStatus := w.Status.ProviderStatus.Object.(*apiv1alpha1.WorkerStatus)
+				workerStatus := decodeWorkerStatus(w)
 				Expect(workerStatus.ServerGroupDependencies).To(BeEmpty())
 			})
 
@@ -117,6 +118,7 @@ var _ = Describe("#MachineDependencies", func() {
 
 				pools = append(pools, *(newWorkerPoolWithPolicy(pool1, &policy)), *(newWorkerPoolWithPolicy(pool2, &policy)))
 				w.Spec.Pools = append(w.Spec.Pools, pools...)
+				syncWorkerSpec(ctx, cl, w)
 
 				cluster := newClusterWithDefaultCloudProfileConfig(namespace, technicalID)
 				workerDelegate, _ = worker.NewWorkerDelegate(
@@ -150,12 +152,11 @@ var _ = Describe("#MachineDependencies", func() {
 							Policies: []string{policy},
 						}, nil
 					}).Times(1)
-				expectStatusUpdateToSucceed(ctx, statusCl)
 
 				err := workerDelegate.PreReconcileHook(ctx)
 				Expect(err).NotTo(HaveOccurred())
 
-				workerStatus := w.Status.ProviderStatus.Object.(*apiv1alpha1.WorkerStatus)
+				workerStatus := decodeWorkerStatus(w)
 				Expect(workerStatus.ServerGroupDependencies).NotTo(BeEmpty())
 				Expect(workerStatus.ServerGroupDependencies).To(HaveLen(2))
 				Expect(workerStatus.ServerGroupDependencies).To(ContainElements(
@@ -184,6 +185,7 @@ var _ = Describe("#MachineDependencies", func() {
 
 				cluster := newClusterWithDefaultCloudProfileConfig(namespace, technicalID)
 				w.Spec.Pools = append(w.Spec.Pools, *(newWorkerPoolWithPolicy("pool", &policy)))
+				syncWorkerSpec(ctx, cl, w)
 				workerDelegate, _ = worker.NewWorkerDelegate(
 					cl,
 					scheme,
@@ -204,11 +206,10 @@ var _ = Describe("#MachineDependencies", func() {
 							Policies: []string{policy},
 						}, nil
 					})
-				expectStatusUpdateToSucceed(ctx, statusCl)
 
 				err := workerDelegate.PreReconcileHook(ctx)
 				Expect(err).NotTo(HaveOccurred())
-				workerStatus := w.Status.ProviderStatus.Object.(*apiv1alpha1.WorkerStatus)
+				workerStatus := decodeWorkerStatus(w)
 				Expect(workerStatus.ServerGroupDependencies).NotTo(BeEmpty())
 				Expect(workerStatus.ServerGroupDependencies).To(ContainElements(
 					MatchFields(IgnoreExtras, Fields{
@@ -220,6 +221,7 @@ var _ = Describe("#MachineDependencies", func() {
 
 				// Second reconcile - policy changed, should recreate
 				w.Spec.Pools[0] = *(newWorkerPoolWithPolicy("pool", &newPolicy))
+				syncWorkerSpec(ctx, cl, w)
 				computeClient.EXPECT().GetServerGroup(ctx, "id").Return(&servergroups.ServerGroup{
 					ID:       "id",
 					Name:     serverGroupName,
@@ -241,11 +243,10 @@ var _ = Describe("#MachineDependencies", func() {
 							Policies: []string{policy},
 						}, nil
 					})
-				expectStatusUpdateToSucceed(ctx, statusCl)
 
 				err = workerDelegate.PreReconcileHook(ctx)
 				Expect(err).NotTo(HaveOccurred())
-				workerStatus = w.Status.ProviderStatus.Object.(*apiv1alpha1.WorkerStatus)
+				workerStatus = decodeWorkerStatus(w)
 				Expect(workerStatus.ServerGroupDependencies).NotTo(BeEmpty())
 				Expect(workerStatus.ServerGroupDependencies).To(ContainElements(
 					MatchFields(IgnoreExtras, Fields{
@@ -277,15 +278,9 @@ var _ = Describe("#MachineDependencies", func() {
 
 				// Empty worker status (no server group dependencies)
 				// This simulates the scenario where GenerateMachineDeployments would trigger PreReconcileHook
-				w.Status.ProviderStatus = &runtime.RawExtension{
-					Object: &apiv1alpha1.WorkerStatus{
-						TypeMeta: metav1.TypeMeta{
-							Kind:       "WorkerStatus",
-							APIVersion: apiv1alpha1.SchemeGroupVersion.String(),
-						},
-						ServerGroupDependencies: []apiv1alpha1.ServerGroupDependency{},
-					},
-				}
+				w.Status.ProviderStatus = workerProviderStatusRaw([]apiv1alpha1.ServerGroupDependency{})
+				syncWorkerSpec(ctx, cl, w)
+				syncWorkerStatus(ctx, cl, w)
 
 				cluster := newClusterWithDefaultCloudProfileConfig(namespace, technicalID)
 				workerDelegate, _ = worker.NewWorkerDelegate(
@@ -308,14 +303,13 @@ var _ = Describe("#MachineDependencies", func() {
 							Policies: []string{policy},
 						}, nil
 					})
-				expectStatusUpdateToSucceed(ctx, statusCl)
 
 				// Directly call PreReconcileHook (which is what GenerateMachineDeployments would do)
 				err := workerDelegate.PreReconcileHook(ctx)
 				Expect(err).NotTo(HaveOccurred())
 
 				// Verify that server group dependencies were created
-				workerStatus := w.Status.ProviderStatus.Object.(*apiv1alpha1.WorkerStatus)
+				workerStatus := decodeWorkerStatus(w)
 				Expect(workerStatus.ServerGroupDependencies).NotTo(BeEmpty())
 				Expect(workerStatus.ServerGroupDependencies).To(HaveLen(1))
 				Expect(workerStatus.ServerGroupDependencies).To(ContainElements(
@@ -351,15 +345,9 @@ var _ = Describe("#MachineDependencies", func() {
 				}
 
 				// Empty worker status (no server group dependencies)
-				w.Status.ProviderStatus = &runtime.RawExtension{
-					Object: &apiv1alpha1.WorkerStatus{
-						TypeMeta: metav1.TypeMeta{
-							Kind:       "WorkerStatus",
-							APIVersion: apiv1alpha1.SchemeGroupVersion.String(),
-						},
-						ServerGroupDependencies: []apiv1alpha1.ServerGroupDependency{},
-					},
-				}
+				w.Status.ProviderStatus = workerProviderStatusRaw([]apiv1alpha1.ServerGroupDependency{})
+				syncWorkerSpec(ctx, cl, w)
+				syncWorkerStatus(ctx, cl, w)
 
 				cluster := newClusterWithDefaultCloudProfileConfig(namespace, technicalID)
 				workerDelegate, _ = worker.NewWorkerDelegate(
@@ -392,14 +380,13 @@ var _ = Describe("#MachineDependencies", func() {
 							Policies: []string{policy},
 						}, nil
 					}).Times(1)
-				expectStatusUpdateToSucceed(ctx, statusCl)
 
 				// Directly call PreReconcileHook
 				err := workerDelegate.PreReconcileHook(ctx)
 				Expect(err).NotTo(HaveOccurred())
 
 				// Verify that server group dependencies were created for both pools
-				workerStatus := w.Status.ProviderStatus.Object.(*apiv1alpha1.WorkerStatus)
+				workerStatus := decodeWorkerStatus(w)
 				Expect(workerStatus.ServerGroupDependencies).NotTo(BeEmpty())
 				Expect(workerStatus.ServerGroupDependencies).To(HaveLen(2))
 				Expect(workerStatus.ServerGroupDependencies).To(ContainElements(
@@ -431,6 +418,7 @@ var _ = Describe("#MachineDependencies", func() {
 				pool := newWorkerPoolWithPolicy(poolName, &policy)
 				pool.KubernetesVersion = &k8sVersion
 				w.Spec.Pools = append(w.Spec.Pools, *pool)
+				syncWorkerSpec(ctx, cl, w)
 
 				cluster := newClusterWithDefaultCloudProfileConfig(namespace, technicalID)
 				cluster.Shoot.Spec.Kubernetes.Version = k8sVersion
@@ -456,12 +444,11 @@ var _ = Describe("#MachineDependencies", func() {
 							Policies: []string{policy},
 						}, nil
 					})
-				expectStatusUpdateToSucceed(ctx, statusCl)
 
 				err := workerDelegate.PreReconcileHook(ctx)
 				Expect(err).NotTo(HaveOccurred())
 
-				workerStatus := w.Status.ProviderStatus.Object.(*apiv1alpha1.WorkerStatus)
+				workerStatus := decodeWorkerStatus(w)
 				Expect(workerStatus.ServerGroupDependencies).To(HaveLen(1))
 				Expect(workerStatus.ServerGroupDependencies[0].ID).To(Equal("new-id"))
 			})
@@ -471,17 +458,15 @@ var _ = Describe("#MachineDependencies", func() {
 				pool := newWorkerPoolWithPolicy(poolName, &policy)
 				pool.KubernetesVersion = &k8sVersion
 				w.Spec.Pools = append(w.Spec.Pools, *pool)
-				w.Status.ProviderStatus = &runtime.RawExtension{
-					Object: &api.WorkerStatus{
-						ServerGroupDependencies: []api.ServerGroupDependency{
-							{
-								ID:       "existing-old-id",
-								Name:     oldSGName,
-								PoolName: poolName,
-							},
-						},
+				w.Status.ProviderStatus = workerProviderStatusRaw([]apiv1alpha1.ServerGroupDependency{
+					{
+						ID:       "existing-old-id",
+						Name:     oldSGName,
+						PoolName: poolName,
 					},
-				}
+				})
+				syncWorkerSpec(ctx, cl, w)
+				syncWorkerStatus(ctx, cl, w)
 
 				cluster := newClusterWithDefaultCloudProfileConfig(namespace, technicalID)
 				cluster.Shoot.Spec.Kubernetes.Version = k8sVersion
@@ -503,12 +488,11 @@ var _ = Describe("#MachineDependencies", func() {
 							Policies: []string{policy},
 						}, nil
 					})
-				expectStatusUpdateToSucceed(ctx, statusCl)
 
 				err := workerDelegate.PreReconcileHook(ctx)
 				Expect(err).NotTo(HaveOccurred())
 
-				workerStatus := w.Status.ProviderStatus.Object.(*apiv1alpha1.WorkerStatus)
+				workerStatus := decodeWorkerStatus(w)
 				Expect(workerStatus.ServerGroupDependencies).To(HaveLen(1))
 				Expect(workerStatus.ServerGroupDependencies[0].ID).To(Equal("existing-old-id"))
 				Expect(workerStatus.ServerGroupDependencies[0].Name).To(Equal(oldSGName))
@@ -519,6 +503,7 @@ var _ = Describe("#MachineDependencies", func() {
 				pool := newWorkerPoolWithPolicy(poolName, &policy)
 				pool.KubernetesVersion = &k8sVersion
 				w.Spec.Pools = append(w.Spec.Pools, *pool)
+				syncWorkerSpec(ctx, cl, w)
 
 				cluster := newClusterWithDefaultCloudProfileConfig(namespace, technicalID)
 				cluster.Shoot.Spec.Kubernetes.Version = k8sVersion
@@ -544,12 +529,11 @@ var _ = Describe("#MachineDependencies", func() {
 							Policies: []string{policy},
 						}, nil
 					})
-				expectStatusUpdateToSucceed(ctx, statusCl)
 
 				err := workerDelegate.PreReconcileHook(ctx)
 				Expect(err).NotTo(HaveOccurred())
 
-				workerStatus := w.Status.ProviderStatus.Object.(*apiv1alpha1.WorkerStatus)
+				workerStatus := decodeWorkerStatus(w)
 				Expect(workerStatus.ServerGroupDependencies).To(HaveLen(1))
 				Expect(workerStatus.ServerGroupDependencies[0].ID).To(Equal("new-id"))
 			})
@@ -561,6 +545,7 @@ var _ = Describe("#MachineDependencies", func() {
 				pool := newWorkerPoolWithPolicy(poolName, &newPolicy)
 				pool.KubernetesVersion = &k8sVersion
 				w.Spec.Pools = append(w.Spec.Pools, *pool)
+				syncWorkerSpec(ctx, cl, w)
 
 				cluster := newClusterWithDefaultCloudProfileConfig(namespace, technicalID)
 				cluster.Shoot.Spec.Kubernetes.Version = k8sVersion
@@ -593,12 +578,11 @@ var _ = Describe("#MachineDependencies", func() {
 							Policies: []string{policy},
 						}, nil
 					})
-				expectStatusUpdateToSucceed(ctx, statusCl)
 
 				err := workerDelegate.PreReconcileHook(ctx)
 				Expect(err).NotTo(HaveOccurred())
 
-				workerStatus := w.Status.ProviderStatus.Object.(*apiv1alpha1.WorkerStatus)
+				workerStatus := decodeWorkerStatus(w)
 				Expect(workerStatus.ServerGroupDependencies).To(HaveLen(1))
 				Expect(workerStatus.ServerGroupDependencies[0].ID).To(Equal("new-id-with-new-policy"))
 			})
@@ -613,21 +597,14 @@ var _ = Describe("#MachineDependencies", func() {
 					serverGroupName = technicalID + "-" + poolName + "-" + "rand"
 				)
 
-				w.Status.ProviderStatus = &runtime.RawExtension{
-					Object: &apiv1alpha1.WorkerStatus{
-						TypeMeta: metav1.TypeMeta{
-							Kind:       "WorkerStatus",
-							APIVersion: apiv1alpha1.SchemeGroupVersion.String(),
-						},
-						ServerGroupDependencies: []apiv1alpha1.ServerGroupDependency{
-							{
-								PoolName: poolName,
-								ID:       serverGroupID,
-								Name:     serverGroupName,
-							},
-						},
+				w.Status.ProviderStatus = workerProviderStatusRaw([]apiv1alpha1.ServerGroupDependency{
+					{
+						PoolName: poolName,
+						ID:       serverGroupID,
+						Name:     serverGroupName,
 					},
-				}
+				})
+				syncWorkerStatus(ctx, cl, w)
 				workerDelegate, _ = worker.NewWorkerDelegate(
 					cl,
 					scheme,
@@ -644,12 +621,11 @@ var _ = Describe("#MachineDependencies", func() {
 					},
 				}, nil)
 				computeClient.EXPECT().DeleteServerGroup(ctx, serverGroupID).Return(nil)
-				expectStatusUpdateToSucceed(ctx, statusCl)
 
 				err := workerDelegate.PostReconcileHook(ctx)
 				Expect(err).NotTo(HaveOccurred())
 
-				workerStatus := w.Status.ProviderStatus.Object.(*apiv1alpha1.WorkerStatus)
+				workerStatus := decodeWorkerStatus(w)
 				Expect(workerStatus.ServerGroupDependencies).To(BeEmpty())
 			})
 
@@ -668,21 +644,15 @@ var _ = Describe("#MachineDependencies", func() {
 				)
 
 				w.Spec.Pools = append(w.Spec.Pools, *(newWorkerPoolWithPolicy("pool", &policy)))
-				w.Status.ProviderStatus = &runtime.RawExtension{
-					Object: &apiv1alpha1.WorkerStatus{
-						TypeMeta: metav1.TypeMeta{
-							Kind:       "WorkerStatus",
-							APIVersion: apiv1alpha1.SchemeGroupVersion.String(),
-						},
-						ServerGroupDependencies: []apiv1alpha1.ServerGroupDependency{
-							{
-								PoolName: poolName,
-								ID:       serverGroupID,
-								Name:     serverGroupName,
-							},
-						},
+				w.Status.ProviderStatus = workerProviderStatusRaw([]apiv1alpha1.ServerGroupDependency{
+					{
+						PoolName: poolName,
+						ID:       serverGroupID,
+						Name:     serverGroupName,
 					},
-				}
+				})
+				syncWorkerSpec(ctx, cl, w)
+				syncWorkerStatus(ctx, cl, w)
 				workerDelegate, _ = worker.NewWorkerDelegate(
 					cl,
 					scheme,
@@ -703,12 +673,11 @@ var _ = Describe("#MachineDependencies", func() {
 					},
 				}, nil)
 				computeClient.EXPECT().DeleteServerGroup(ctx, oldServerGroupID).Return(nil)
-				expectStatusUpdateToSucceed(ctx, statusCl)
 
 				err := workerDelegate.PostReconcileHook(ctx)
 				Expect(err).NotTo(HaveOccurred())
 
-				workerStatus := w.Status.ProviderStatus.Object.(*apiv1alpha1.WorkerStatus)
+				workerStatus := decodeWorkerStatus(w)
 				Expect(workerStatus.ServerGroupDependencies).NotTo(BeEmpty())
 			})
 
@@ -727,28 +696,22 @@ var _ = Describe("#MachineDependencies", func() {
 				)
 
 				deletionTime := metav1.NewTime(time.Now())
-				w.DeletionTimestamp = &deletionTime
 				w.Spec.Pools = append(w.Spec.Pools, *(newWorkerPoolWithPolicy(poolName1, &policy)), *(newWorkerPoolWithPolicy(poolName2, &policy)))
-				w.Status.ProviderStatus = &runtime.RawExtension{
-					Object: &apiv1alpha1.WorkerStatus{
-						TypeMeta: metav1.TypeMeta{
-							Kind:       "WorkerStatus",
-							APIVersion: apiv1alpha1.SchemeGroupVersion.String(),
-						},
-						ServerGroupDependencies: []apiv1alpha1.ServerGroupDependency{
-							{
-								PoolName: poolName1,
-								ID:       serverGroupID1,
-								Name:     serverGroupName1,
-							},
-							{
-								PoolName: poolName2,
-								ID:       serverGroupID2,
-								Name:     serverGroupName2,
-							},
-						},
+				w.Status.ProviderStatus = workerProviderStatusRaw([]apiv1alpha1.ServerGroupDependency{
+					{
+						PoolName: poolName1,
+						ID:       serverGroupID1,
+						Name:     serverGroupName1,
 					},
-				}
+					{
+						PoolName: poolName2,
+						ID:       serverGroupID2,
+						Name:     serverGroupName2,
+					},
+				})
+				syncWorkerSpec(ctx, cl, w)
+				syncWorkerStatus(ctx, cl, w)
+				w.DeletionTimestamp = &deletionTime
 				workerDelegate, _ = worker.NewWorkerDelegate(
 					cl,
 					scheme,
@@ -770,12 +733,11 @@ var _ = Describe("#MachineDependencies", func() {
 				}, nil)
 				computeClient.EXPECT().DeleteServerGroup(ctx, serverGroupID1).Return(nil)
 				computeClient.EXPECT().DeleteServerGroup(ctx, serverGroupID2).Return(nil)
-				expectStatusUpdateToSucceed(ctx, statusCl)
 
 				err := workerDelegate.PostReconcileHook(ctx)
 				Expect(err).NotTo(HaveOccurred())
 
-				workerStatus := w.Status.ProviderStatus.Object.(*apiv1alpha1.WorkerStatus)
+				workerStatus := decodeWorkerStatus(w)
 				Expect(workerStatus.ServerGroupDependencies).To(BeEmpty())
 			})
 		})
@@ -789,21 +751,14 @@ var _ = Describe("#MachineDependencies", func() {
 					serverGroupName = technicalID + "-" + poolName + "-" + "rand"
 				)
 
-				w.Status.ProviderStatus = &runtime.RawExtension{
-					Object: &apiv1alpha1.WorkerStatus{
-						TypeMeta: metav1.TypeMeta{
-							Kind:       "WorkerStatus",
-							APIVersion: apiv1alpha1.SchemeGroupVersion.String(),
-						},
-						ServerGroupDependencies: []apiv1alpha1.ServerGroupDependency{
-							{
-								PoolName: poolName,
-								ID:       serverGroupID,
-								Name:     serverGroupName,
-							},
-						},
+				w.Status.ProviderStatus = workerProviderStatusRaw([]apiv1alpha1.ServerGroupDependency{
+					{
+						PoolName: poolName,
+						ID:       serverGroupID,
+						Name:     serverGroupName,
 					},
-				}
+				})
+				syncWorkerStatus(ctx, cl, w)
 				workerDelegate, _ = worker.NewWorkerDelegate(
 					cl,
 					scheme,
@@ -820,12 +775,11 @@ var _ = Describe("#MachineDependencies", func() {
 					},
 				}, nil)
 				computeClient.EXPECT().DeleteServerGroup(ctx, serverGroupID).Return(nil)
-				expectStatusUpdateToSucceed(ctx, statusCl)
 
 				err := workerDelegate.PostDeleteHook(ctx)
 				Expect(err).NotTo(HaveOccurred())
 
-				workerStatus := w.Status.ProviderStatus.Object.(*apiv1alpha1.WorkerStatus)
+				workerStatus := decodeWorkerStatus(w)
 				Expect(workerStatus.ServerGroupDependencies).To(BeEmpty())
 			})
 
@@ -844,21 +798,15 @@ var _ = Describe("#MachineDependencies", func() {
 				)
 
 				w.Spec.Pools = append(w.Spec.Pools, *(newWorkerPoolWithPolicy("pool", &policy)))
-				w.Status.ProviderStatus = &runtime.RawExtension{
-					Object: &apiv1alpha1.WorkerStatus{
-						TypeMeta: metav1.TypeMeta{
-							Kind:       "WorkerStatus",
-							APIVersion: apiv1alpha1.SchemeGroupVersion.String(),
-						},
-						ServerGroupDependencies: []apiv1alpha1.ServerGroupDependency{
-							{
-								PoolName: poolName,
-								ID:       serverGroupID,
-								Name:     serverGroupName,
-							},
-						},
+				w.Status.ProviderStatus = workerProviderStatusRaw([]apiv1alpha1.ServerGroupDependency{
+					{
+						PoolName: poolName,
+						ID:       serverGroupID,
+						Name:     serverGroupName,
 					},
-				}
+				})
+				syncWorkerSpec(ctx, cl, w)
+				syncWorkerStatus(ctx, cl, w)
 				workerDelegate, _ = worker.NewWorkerDelegate(
 					cl,
 					scheme,
@@ -879,12 +827,11 @@ var _ = Describe("#MachineDependencies", func() {
 					},
 				}, nil)
 				computeClient.EXPECT().DeleteServerGroup(ctx, oldServerGroupID).Return(nil)
-				expectStatusUpdateToSucceed(ctx, statusCl)
 
 				err := workerDelegate.PostDeleteHook(ctx)
 				Expect(err).NotTo(HaveOccurred())
 
-				workerStatus := w.Status.ProviderStatus.Object.(*apiv1alpha1.WorkerStatus)
+				workerStatus := decodeWorkerStatus(w)
 				Expect(workerStatus.ServerGroupDependencies).NotTo(BeEmpty())
 			})
 
@@ -903,28 +850,22 @@ var _ = Describe("#MachineDependencies", func() {
 				)
 
 				deletionTime := metav1.NewTime(time.Now())
-				w.DeletionTimestamp = &deletionTime
 				w.Spec.Pools = append(w.Spec.Pools, *(newWorkerPoolWithPolicy(poolName1, &policy)), *(newWorkerPoolWithPolicy(poolName2, &policy)))
-				w.Status.ProviderStatus = &runtime.RawExtension{
-					Object: &apiv1alpha1.WorkerStatus{
-						TypeMeta: metav1.TypeMeta{
-							Kind:       "WorkerStatus",
-							APIVersion: apiv1alpha1.SchemeGroupVersion.String(),
-						},
-						ServerGroupDependencies: []apiv1alpha1.ServerGroupDependency{
-							{
-								PoolName: poolName1,
-								ID:       serverGroupID1,
-								Name:     serverGroupName1,
-							},
-							{
-								PoolName: poolName2,
-								ID:       serverGroupID2,
-								Name:     serverGroupName2,
-							},
-						},
+				w.Status.ProviderStatus = workerProviderStatusRaw([]apiv1alpha1.ServerGroupDependency{
+					{
+						PoolName: poolName1,
+						ID:       serverGroupID1,
+						Name:     serverGroupName1,
 					},
-				}
+					{
+						PoolName: poolName2,
+						ID:       serverGroupID2,
+						Name:     serverGroupName2,
+					},
+				})
+				syncWorkerSpec(ctx, cl, w)
+				syncWorkerStatus(ctx, cl, w)
+				w.DeletionTimestamp = &deletionTime
 				workerDelegate, _ = worker.NewWorkerDelegate(
 					cl,
 					scheme,
@@ -946,12 +887,11 @@ var _ = Describe("#MachineDependencies", func() {
 				}, nil)
 				computeClient.EXPECT().DeleteServerGroup(ctx, serverGroupID1).Return(nil)
 				computeClient.EXPECT().DeleteServerGroup(ctx, serverGroupID2).Return(nil)
-				expectStatusUpdateToSucceed(ctx, statusCl)
 
 				err := workerDelegate.PostDeleteHook(ctx)
 				Expect(err).NotTo(HaveOccurred())
 
-				workerStatus := w.Status.ProviderStatus.Object.(*apiv1alpha1.WorkerStatus)
+				workerStatus := decodeWorkerStatus(w)
 				Expect(workerStatus.ServerGroupDependencies).To(BeEmpty())
 			})
 		})
@@ -1020,6 +960,45 @@ func newClusterWithDefaultCloudProfileConfig(name, technicalID string) *extensio
 	}
 }
 
-func expectStatusUpdateToSucceed(ctx context.Context, statusWriter *k8smocks.MockStatusWriter) {
-	statusWriter.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&extensionsv1alpha1.Worker{}), gomock.Any()).Return(nil)
+// decodeWorkerStatus decodes the WorkerStatus from the Worker's ProviderStatus.
+// After a fakeclient Status().Patch(), the Object field is nil and the status is
+// stored as raw JSON bytes — use this helper instead of a direct type assertion.
+// This helper decodes the raw JSON bytes into a WorkerStatus struct for easier assertions in tests.
+func decodeWorkerStatus(w *extensionsv1alpha1.Worker) *apiv1alpha1.WorkerStatus {
+	Expect(w.Status.ProviderStatus).NotTo(BeNil())
+	raw, err := w.Status.ProviderStatus.MarshalJSON()
+	Expect(err).NotTo(HaveOccurred())
+	status := &apiv1alpha1.WorkerStatus{}
+	Expect(json.Unmarshal(raw, status)).To(Succeed())
+	return status
+}
+
+// workerProviderStatusRaw serialises a WorkerStatus to a RawExtension for use in
+// test setup (fakeclient stores objects as JSON, so Object must be pre-serialised).
+func workerProviderStatusRaw(deps []apiv1alpha1.ServerGroupDependency) *runtime.RawExtension {
+	raw, err := json.Marshal(&apiv1alpha1.WorkerStatus{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: apiv1alpha1.SchemeGroupVersion.String(),
+			Kind:       "WorkerStatus",
+		},
+		ServerGroupDependencies: deps,
+	})
+	Expect(err).NotTo(HaveOccurred())
+	return &runtime.RawExtension{Raw: raw}
+}
+
+// syncWorkerSpec pushes w's spec and metadata (but not status) into the fakeclient
+// store so that subsequent Status().Patch() calls do not clobber in-memory spec changes.
+// It saves and restores the in-memory w.Status so that a subsequent syncWorkerStatus call
+// can still push the intended status.
+func syncWorkerSpec(ctx context.Context, cl client.Client, w *extensionsv1alpha1.Worker) {
+	savedStatus := w.Status.DeepCopy()
+	Expect(cl.Update(ctx, w)).To(Succeed())
+	w.Status = *savedStatus
+}
+
+// syncWorkerStatus pushes w.Status into the fakeclient store so that
+// the WorkerDelegate's seedClient can read it back via the status subresource.
+func syncWorkerStatus(ctx context.Context, cl client.Client, w *extensionsv1alpha1.Worker) {
+	Expect(cl.Status().Update(ctx, w)).To(Succeed())
 }

--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -1101,7 +1101,6 @@ var _ = Describe("Machines", func() {
 							}
 							workerDelegate, _ := NewWorkerDelegate(c, scheme, chartApplier, w, cluster, nil)
 
-
 							result, err := workerDelegate.GenerateMachineDeployments(ctx)
 							Expect(err).NotTo(HaveOccurred())
 							Expect(result[0].Labels).To(HaveKeyWithValue("k1", "v1"))
@@ -1268,7 +1267,6 @@ var _ = Describe("Machines", func() {
 
 				workerDelegate, _ = NewWorkerDelegate(c, scheme, chartApplier, w, cluster, nil)
 
-
 				result, err := workerDelegate.GenerateMachineDeployments(ctx)
 				resultSettings := result[0].MachineConfiguration
 				resultNodeConditions := strings.Join(testNodeConditions, ",")
@@ -1291,7 +1289,6 @@ var _ = Describe("Machines", func() {
 				}
 				w.Spec.Pools[1].ClusterAutoscaler = nil
 				workerDelegate, _ = NewWorkerDelegate(c, scheme, chartApplier, w, cluster, nil)
-
 
 				result, err := workerDelegate.GenerateMachineDeployments(ctx)
 				Expect(err).NotTo(HaveOccurred())

--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	mockkubernetes "github.com/gardener/gardener/pkg/client/kubernetes/mock"
 	"github.com/gardener/gardener/pkg/utils"
-	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
 	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -34,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/gardener/gardener-extension-provider-openstack/charts"
 	api "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack"
@@ -47,8 +47,7 @@ var _ = Describe("Machines", func() {
 		ctx = context.Background()
 
 		ctrl         *gomock.Controller
-		c            *mockclient.MockClient
-		statusWriter *mockclient.MockStatusWriter
+		c            client.Client
 		chartApplier *mockkubernetes.MockChartApplier
 
 		workerDelegate genericworkeractuator.WorkerDelegate
@@ -58,8 +57,6 @@ var _ = Describe("Machines", func() {
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
 
-		c = mockclient.NewMockClient(ctrl)
-		statusWriter = mockclient.NewMockStatusWriter(ctrl)
 		chartApplier = mockkubernetes.NewMockChartApplier(ctrl)
 
 		scheme = runtime.NewScheme()
@@ -425,6 +422,7 @@ var _ = Describe("Machines", func() {
 
 				w = &extensionsv1alpha1.Worker{
 					ObjectMeta: metav1.ObjectMeta{
+						Name:      "worker",
 						Namespace: namespace,
 					},
 					Spec: extensionsv1alpha1.WorkerSpec{
@@ -542,17 +540,26 @@ var _ = Describe("Machines", func() {
 				workerPoolHash2, _ = worker.WorkerPoolHash(w.Spec.Pools[1], cluster, nil, nil, nil)
 				workerPoolHash3, _ = worker.WorkerPoolHash(w.Spec.Pools[2], cluster, nil, nil, nil)
 
+				fakeScheme := runtime.NewScheme()
+				Expect(corev1.AddToScheme(fakeScheme)).To(Succeed())
+				Expect(extensionsv1alpha1.AddToScheme(fakeScheme)).To(Succeed())
+				c = fakeclient.NewClientBuilder().
+					WithScheme(fakeScheme).
+					WithObjects(
+						w,
+						&corev1.Secret{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      userDataSecretName,
+								Namespace: namespace,
+							},
+							Data: map[string][]byte{userDataSecretDataKey: userData},
+						},
+					).
+					WithStatusSubresource(&extensionsv1alpha1.Worker{}).
+					Build()
+
 				workerDelegate, _ = NewWorkerDelegate(c, scheme, chartApplier, w, clusterWithoutImages, nil)
 			})
-
-			expectedUserDataSecretRefRead := func() {
-				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: userDataSecretName}, gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(
-					func(_ context.Context, _ client.ObjectKey, secret *corev1.Secret, _ ...client.GetOption) error {
-						secret.Data = map[string][]byte{userDataSecretDataKey: userData}
-						return nil
-					},
-				).AnyTimes()
-			}
 
 			Describe("machine images", func() {
 				var (
@@ -807,7 +814,6 @@ var _ = Describe("Machines", func() {
 					workerDelegate, _ := NewWorkerDelegate(c, scheme, chartApplier, w, cluster, nil)
 
 					// Test workerDelegate.DeployMachineClasses()
-					expectedUserDataSecretRefRead()
 
 					chartApplier.
 						EXPECT().
@@ -826,63 +832,7 @@ var _ = Describe("Machines", func() {
 
 					// Test workerDelegate.UpdateMachineDeployments()
 					// When using global image names (machineImageID==""), Image field is set;
-					// when using image IDs, Image is empty.
-					expectedImage := ""
-					if usesGlobalImageNames {
-						expectedImage = machineImage
-					}
-					machineImages := []apiv1alpha1.MachineImage{
-						{
-							Name:         machineImageName,
-							Version:      machineImageVersion,
-							Image:        expectedImage,
-							ID:           machineImageID,
-							Capabilities: capabilitiesAmd,
-						},
-						{
-							Name:         machineImageName,
-							Version:      machineImageVersion,
-							Image:        expectedImage,
-							ID:           machineImageID,
-							Capabilities: capabilitiesArm,
-						},
-					}
-					if !isCapabilitiesCloudProfile {
-						machineImages = []apiv1alpha1.MachineImage{
-							{
-								Name:         machineImageName,
-								Version:      machineImageVersion,
-								Image:        expectedImage,
-								ID:           machineImageID,
-								Architecture: &archAMD,
-							},
-							{
-								Name:         machineImageName,
-								Version:      machineImageVersion,
-								Image:        expectedImage,
-								ID:           machineImageID,
-								Architecture: &archARM,
-							},
-						}
-					}
-
 					// Test WorkerDelegate.UpdateMachineDeployments()
-					expectedImages := &apiv1alpha1.WorkerStatus{
-						TypeMeta: metav1.TypeMeta{
-							APIVersion: apiv1alpha1.SchemeGroupVersion.String(),
-							Kind:       "WorkerStatus",
-						},
-						MachineImages: machineImages,
-					}
-
-					workerWithExpectedImages := w.DeepCopy()
-					workerWithExpectedImages.Status.ProviderStatus = &runtime.RawExtension{
-						Object: expectedImages,
-					}
-
-					c.EXPECT().Status().Return(statusWriter)
-					statusWriter.EXPECT().Patch(ctx, workerWithExpectedImages, gomock.Any()).Return(nil)
-
 					err = workerDelegate.UpdateMachineImagesStatus(ctx)
 					Expect(err).NotTo(HaveOccurred())
 
@@ -899,7 +849,6 @@ var _ = Describe("Machines", func() {
 					clusterWithRegion.Shoot.Spec.Hibernation = &gardencorev1beta1.Hibernation{Enabled: ptr.To(true)}
 
 					// Test workerDelegate.DeployMachineClasses()
-					expectedUserDataSecretRefRead()
 
 					chartApplier.
 						EXPECT().
@@ -916,63 +865,8 @@ var _ = Describe("Machines", func() {
 					err := workerDelegate.DeployMachineClasses(ctx)
 					Expect(err).NotTo(HaveOccurred())
 					// When using global image names (machineImageID==""), Image field is set;
-					// when using image IDs, Image is empty.
-					expectedImage := ""
-					if usesGlobalImageNames {
-						expectedImage = machineImage
-					}
-					machineImages := []apiv1alpha1.MachineImage{
-						{
-							Name:         machineImageName,
-							Version:      machineImageVersion,
-							Image:        expectedImage,
-							ID:           machineImageID,
-							Capabilities: capabilitiesAmd,
-						},
-						{
-							Name:         machineImageName,
-							Version:      machineImageVersion,
-							Image:        expectedImage,
-							ID:           machineImageID,
-							Capabilities: capabilitiesArm,
-						},
-					}
-					if !isCapabilitiesCloudProfile {
-						machineImages = []apiv1alpha1.MachineImage{
-							{
-								Name:         machineImageName,
-								Version:      machineImageVersion,
-								Image:        expectedImage,
-								ID:           machineImageID,
-								Architecture: ptr.To(v1beta1constants.ArchitectureAMD64),
-							},
-							{
-								Name:         machineImageName,
-								Version:      machineImageVersion,
-								Image:        expectedImage,
-								ID:           machineImageID,
-								Architecture: ptr.To(v1beta1constants.ArchitectureARM64),
-							},
-						}
-					}
 					// Test workerDelegate.GetMachineImages()
-					expectedImages := &apiv1alpha1.WorkerStatus{
-						TypeMeta: metav1.TypeMeta{
-							APIVersion: apiv1alpha1.SchemeGroupVersion.String(),
-							Kind:       "WorkerStatus",
-						},
-						MachineImages: machineImages,
-					}
-
-					workerWithExpectedImages := workerWithRegion.DeepCopy()
-					workerWithExpectedImages.Status.ProviderStatus = &runtime.RawExtension{
-						Object: expectedImages,
-					}
-
 					ctx := ctx
-					c.EXPECT().Status().Return(statusWriter)
-					statusWriter.EXPECT().Patch(ctx, workerWithExpectedImages, gomock.Any()).Return(nil)
-
 					err = workerDelegate.UpdateMachineImagesStatus(ctx)
 					Expect(err).NotTo(HaveOccurred())
 
@@ -1125,7 +1019,6 @@ var _ = Describe("Machines", func() {
 							machineClassPool3Zone2,
 						}}
 
-						expectedUserDataSecretRefRead()
 						chartApplier.
 							EXPECT().
 							ApplyFromEmbeddedFS(
@@ -1208,7 +1101,6 @@ var _ = Describe("Machines", func() {
 							}
 							workerDelegate, _ := NewWorkerDelegate(c, scheme, chartApplier, w, cluster, nil)
 
-							expectedUserDataSecretRefRead()
 
 							result, err := workerDelegate.GenerateMachineDeployments(ctx)
 							Expect(err).NotTo(HaveOccurred())
@@ -1300,7 +1192,6 @@ var _ = Describe("Machines", func() {
 							Raw: encode(workerConfig),
 						}
 						workerDelegate, _ := NewWorkerDelegate(c, scheme, chartApplier, w, cluster, nil)
-						expectedUserDataSecretRefRead()
 						result, err := workerDelegate.GenerateMachineDeployments(ctx)
 						Expect(err).NotTo(HaveOccurred())
 						return result[0].ClassName
@@ -1377,7 +1268,6 @@ var _ = Describe("Machines", func() {
 
 				workerDelegate, _ = NewWorkerDelegate(c, scheme, chartApplier, w, cluster, nil)
 
-				expectedUserDataSecretRefRead()
 
 				result, err := workerDelegate.GenerateMachineDeployments(ctx)
 				resultSettings := result[0].MachineConfiguration
@@ -1402,7 +1292,6 @@ var _ = Describe("Machines", func() {
 				w.Spec.Pools[1].ClusterAutoscaler = nil
 				workerDelegate, _ = NewWorkerDelegate(c, scheme, chartApplier, w, cluster, nil)
 
-				expectedUserDataSecretRefRead()
 
 				result, err := workerDelegate.GenerateMachineDeployments(ctx)
 				Expect(err).NotTo(HaveOccurred())
@@ -1457,7 +1346,6 @@ var _ = Describe("Machines", func() {
 				workerDelegate, _ = NewWorkerDelegate(c, scheme, chartApplier, w, clusterWithPremiumMachineType, nil)
 
 				var capturedMachineClasses []map[string]interface{}
-				expectedUserDataSecretRefRead()
 				chartApplier.
 					EXPECT().
 					ApplyFromEmbeddedFS(


### PR DESCRIPTION
  * Replace `github.com/gardener/gardener/third_party/mock/controller-runtime/client` (dropped in gardener `v1.144`) with `sigs.k8s.io/controller-runtime/pkg/client/fake` across all affected test files
  * Pre-populate `fakeclient` with `WithObjects`/`WithStatusSubresource` instead of using `MockClient`/`MockStatusWriter EXPECT()` calls
  * Fix bug in `shoot_test.go`: `NamespacedCloudProfile` `ObjectMeta` was missing `Namespace`, hidden by the old mock matching on an explicit key

<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area testing
/kind cleanup
/kind bug
/platform openstack

**What this PR does / why we need it**:
This PR follows the cleanup process outlined in https://github.com/gardener/gardener/issues/14572.

**Which issue(s) this PR fixes**:
Fixes #1365

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Migrate test mock clients to fakeclient following https://github.com/gardener/gardener/pull/14799
```
