### PR TITLE
Enable security group management for OVN load balancers

### DIFF
--- a/charts/internal/cloud-provider-config/templates/cloud-provider-config-loadbalancer.tpl
+++ b/charts/internal/cloud-provider-config/templates/cloud-provider-config-loadbalancer.tpl
@@ -8,6 +8,7 @@ lb-version="v2"
 lb-provider="{{ .Values.lbProvider }}"
 {{- if eq .Values.lbProvider "ovn" }}
 lb-method="SOURCE_IP_PORT"
+manage-security-groups=true
 {{- end }}
 floating-network-id="{{ .Values.floatingNetworkID }}"
 {{- if .Values.floatingSubnetID }}


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
/area networking
/kind enhancement
/platform openstack

**What this PR does / why we need it**:

This PR sets `manage-security-groups=true` in the OpenStack cloud-controller-manager configuration when the OVN load balancer provider is used.

The OpenStack cloud provider can enforce Kubernetes `spec.loadBalancerSourceRanges` for OVN load balancers by creating and attaching security groups to the load balancer members. [However, this behavior is only enabled when security group management is configured.](https://github.com/kubernetes/cloud-provider-openstack/blob/c453fb7c9bbb2091aee763d9d2809cc81fdf31c6/pkg/openstack/loadbalancer.go#L1577-L1579)

Without this setting, `loadBalancerSourceRanges` is ignored when using the OVN provider. Enabling it alongside the existing OVN-specific `SOURCE_IP_PORT` load-balancing method makes source-range restrictions work out of the box.

The change is limited to configurations using the OVN load balancer provider. Other load balancer providers are unaffected.

**Which issue(s) this PR fixes**:

None.

**Special notes for your reviewer**:

**Release note**:

```feature operator
Enable security group management for OVN load balancers so that Kubernetes loadBalancerSourceRanges are enforced out of the box.
```
