### PR TITLE
Reduce unnecessary workflow runs

### DIFF
--- a/.github/workflows/non-release.yaml
+++ b/.github/workflows/non-release.yaml
@@ -4,7 +4,6 @@ on:
   pull_request:
     types:
       - opened
-      - edited
       - reopened
       - synchronize
   pull_request_target:
@@ -15,6 +14,10 @@ on:
     - 'master'
     - 'release-*'
   workflow_dispatch:
+
+concurrency:
+  group: build-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/pullrequest-trust-helper.yaml
+++ b/.github/workflows/pullrequest-trust-helper.yaml
@@ -1,8 +1,8 @@
+name: Pull Request Trust Helper
 on:
   pull_request_target:
     types:
     - opened
-    - edited
     - reopened
     - synchronize
 

--- a/.github/workflows/release-milestone.yaml
+++ b/.github/workflows/release-milestone.yaml
@@ -4,9 +4,6 @@ on:
     types:
     - opened
     - reopened
-    - synchronize
-    - labeled
-    - unlabeled
     - milestoned
     - demilestoned
 
@@ -15,23 +12,22 @@ jobs:
     name: Check Release Milestone
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v7
-      with:
-        ref: master
-        path: './'
-
-    - id: version
-      run: |
-        echo "version=$(cat ./VERSION)" >> $GITHUB_OUTPUT
-
     - name: Block merge if release milestone is missing
       uses: actions/github-script@v9
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
+          const { data: versionFile } = await github.rest.repos.getContent({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            path: 'VERSION',
+            ref: 'master'
+          });
+          const version = Buffer.from(versionFile.content, 'base64').toString().trim();
+
           const nextMinorRegex = /^(v[0-9]+\.[0-9]+)\.0-dev/gmi;
 
-          let match = nextMinorRegex.exec('${{ steps.version.outputs.version }}');
+          let match = nextMinorRegex.exec(version);
           if (match == null) {
             core.info('VERSION does not indicate that the next version is a new minor release - skipping check');
             return;


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area cost
/kind cleanup
/platform openstack

**What this PR does / why we need it**:

Several small improvements to the GitHub actions:
- removed several unnecessary trigger events.
- release milestone check pulls version file through API instead of checking out the entire repository.
- add concurrency group for non-release workflow. This will cancel workflows in the `pull_request` context, when the workflow is triggered in the `pull_request_target` context. Since both are triggered in quick succession for trusted maintainers did should almost half our workflow run time.
- provide a nice name for PR trust helper workflow.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved pull request automation by reducing unnecessary workflow runs when pull requests are edited.
  - Added safeguards to cancel outdated checks when newer changes are submitted.
  - Streamlined release milestone processing to use the latest version information and avoid redundant triggers.
  - Updated automation behavior for newly opened, reopened, or synchronized pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->