### PR TITLE
Add Support for Machine Preservation

### DIFF
--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -302,6 +302,10 @@ func (w *WorkerDelegate) generateMachineConfig(ctx context.Context) error {
 					machineDeploymentStrategy.InPlaceUpdate.OrchestrationType = machinev1alpha1.OrchestrationTypeManual
 				}
 			}
+			var preserveMax int32
+			if pool.MachineControllerManagerSettings != nil {
+				preserveMax = ptr.Deref(pool.MachineControllerManagerSettings.AutoPreserveFailedMachineMax, 0)
+			}
 
 			machineDeployments = append(machineDeployments, worker.MachineDeployment{
 				Name:                         deploymentName,
@@ -317,6 +321,7 @@ func (w *WorkerDelegate) generateMachineConfig(ctx context.Context) error {
 				Taints:                       pool.Taints,
 				MachineConfiguration:         genericworkeractuator.ReadMachineConfiguration(pool),
 				ClusterAutoscalerAnnotations: extensionsv1alpha1helper.GetMachineDeploymentClusterAutoscalerAnnotations(pool.ClusterAutoscaler),
+				AutoPreserveFailedMachineMax: worker.DistributeOverZones(zoneIdx, preserveMax, zoneLen),
 			})
 
 			machineClassSpec["name"] = className

--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -1321,6 +1321,43 @@ var _ = Describe("Machines", func() {
 				Expect(result[1].ClusterAutoscalerAnnotations[extensionsv1alpha1.ScaleDownUtilizationThresholdAnnotation]).To(Equal("0.5"))
 			})
 
+			It("should distribute autoPreserveFailedMachineMax across zones", func() {
+				w.Spec.Pools[0].MachineControllerManagerSettings = &gardencorev1beta1.MachineControllerManagerSettings{
+					AutoPreserveFailedMachineMax: new(int32(4)),
+				}
+				workerDelegate, _ = NewWorkerDelegate(c, scheme, chartApplier, w, cluster, nil)
+
+				result, err := workerDelegate.GenerateMachineDeployments(ctx)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).NotTo(BeNil())
+				Expect(result[0].AutoPreserveFailedMachineMax).To(Equal(int32(2)))
+				Expect(result[1].AutoPreserveFailedMachineMax).To(Equal(int32(2)))
+			})
+
+			It("should set autoPreserveFailedMachineMax to 0 per zone when machineControllerManagerSettings is nil", func() {
+				w.Spec.Pools[0].MachineControllerManagerSettings = nil
+				workerDelegate, _ = NewWorkerDelegate(c, scheme, chartApplier, w, cluster, nil)
+
+				result, err := workerDelegate.GenerateMachineDeployments(ctx)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).NotTo(BeNil())
+				Expect(result[0].AutoPreserveFailedMachineMax).To(Equal(int32(0)))
+				Expect(result[1].AutoPreserveFailedMachineMax).To(Equal(int32(0)))
+			})
+
+			It("should set autoPreserveFailedMachineMax to 0 per zone when autoPreserveFailedMachineMax is nil", func() {
+				w.Spec.Pools[0].MachineControllerManagerSettings = &gardencorev1beta1.MachineControllerManagerSettings{
+					AutoPreserveFailedMachineMax: nil,
+				}
+				workerDelegate, _ = NewWorkerDelegate(c, scheme, chartApplier, w, cluster, nil)
+
+				result, err := workerDelegate.GenerateMachineDeployments(ctx)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).NotTo(BeNil())
+				Expect(result[0].AutoPreserveFailedMachineMax).To(Equal(int32(0)))
+				Expect(result[1].AutoPreserveFailedMachineMax).To(Equal(int32(0)))
+			})
+
 			It("should use storage type and size from cloud profile machine type as default when no pool volume is specified", func() {
 				premiumStorageSize := resource.MustParse("64Gi")
 				clusterWithPremiumMachineType := &extensionscontroller.Cluster{


### PR DESCRIPTION

<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area auto-scaling
/kind enhancement
/platform openstack

**What this PR does / why we need it**:
This PR adds support for the machine preservation feature (introduced in g/g: v1.147 and MCM: v0.62.0 ) by setting the `AutoPreserveFailedMachineMax` field in the `MachineDeployment.Spec`. The value for this field is derived by distributing `MachineControllerManagerSettings.AutoPreserveFailedMachineMax` defined at the worker pool level, across the zones of the worker pool (similar to `worker.Maximum` and `worker.Minimum`).

References:

g/g PR: https://github.com/gardener/gardener/pull/14767
usage doc: https://github.com/gardener/gardener/blob/master/docs/usage/shoot/shoot_machine_preservation.md


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Add support for machine preservation by distributing the value of `worker[].machineControllerManager.autoPreserveFailedMachineMax` across zones.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Machine deployments now honor the configured maximum number of failed machines to preserve.
  * Preservation limits are distributed across availability zones for balanced handling.
  * The setting safely defaults to zero when not configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->