### PR TITLE
Handle FIPs when they're in state DOWN

### DIFF
--- a/pkg/controller/bastion/actuator.go
+++ b/pkg/controller/bastion/actuator.go
@@ -12,8 +12,6 @@ import (
 	"github.com/gardener/gardener/extensions/pkg/controller/bastion"
 	"github.com/gophercloud/gophercloud/v2/openstack/compute/v2/servers"
 	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/layer3/floatingips"
-	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/security/groups"
-	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/security/rules"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -118,41 +116,6 @@ func GetIPs(s servers.Server, opts Options) (string, string, error) {
 func createFloatingIP(ctx context.Context, client openstackclient.Networking, parameters floatingips.CreateOpts) (floatingips.FloatingIP, error) {
 	fip, err := client.CreateFloatingIP(ctx, parameters)
 	return ptr.Deref(fip, floatingips.FloatingIP{}), err
-}
-
-func deleteFloatingIP(ctx context.Context, client openstackclient.Networking, id string) error {
-	return client.DeleteFloatingIP(ctx, id)
-}
-
-func findFipByName(ctx context.Context, client openstackclient.Networking, name string) ([]floatingips.FloatingIP, error) {
-	return client.GetFipByName(ctx, name)
-}
-
-func createSecurityGroup(ctx context.Context, client openstackclient.Networking, createOpts groups.CreateOpts) (*groups.SecGroup, error) {
-	return client.CreateSecurityGroup(ctx, createOpts)
-}
-
-func deleteSecurityGroup(ctx context.Context, client openstackclient.Networking, groupid string) error {
-	return client.DeleteSecurityGroup(ctx, groupid)
-}
-
-func getSecurityGroups(ctx context.Context, client openstackclient.Networking, name string) ([]groups.SecGroup, error) {
-	return client.GetSecurityGroupByName(ctx, name)
-}
-
-func createRules(ctx context.Context, client openstackclient.Networking, createOpts rules.CreateOpts) (*rules.SecGroupRule, error) {
-	return client.CreateRule(ctx, createOpts)
-}
-
-func listRules(ctx context.Context, client openstackclient.Networking, secGroupID string) ([]rules.SecGroupRule, error) {
-	listOpts := rules.ListOpts{
-		SecGroupID: secGroupID,
-	}
-	return client.ListRules(ctx, listOpts)
-}
-
-func deleteRule(ctx context.Context, client openstackclient.Networking, ruleID string) error {
-	return client.DeleteRule(ctx, ruleID)
 }
 
 func useBastionControllerConfig(bastionConfig *controllerconfig.BastionConfig) bool {

--- a/pkg/controller/bastion/actuator_delete.go
+++ b/pkg/controller/bastion/actuator_delete.go
@@ -97,7 +97,7 @@ func removeBastionInstance(ctx context.Context, client openstackclient.Compute, 
 }
 
 func removePublicIPAddress(ctx context.Context, client openstackclient.Networking, opts BaseOptions) error {
-	fips, err := findFipByName(ctx, client, opts.BastionInstanceName)
+	fips, err := client.GetFipByName(ctx, opts.BastionInstanceName)
 	if err != nil {
 		return err
 	}
@@ -107,7 +107,7 @@ func removePublicIPAddress(ctx context.Context, client openstackclient.Networkin
 	}
 
 	opts.Logr.Info("Deleting Public IP", "public IP ID", fips[0].ID)
-	err = deleteFloatingIP(ctx, client, fips[0].ID)
+	err = client.DeleteFloatingIP(ctx, fips[0].ID)
 	if err != nil {
 		return fmt.Errorf("failed to terminate bastion Public IP: %w", err)
 	}
@@ -117,7 +117,7 @@ func removePublicIPAddress(ctx context.Context, client openstackclient.Networkin
 }
 
 func removeSecurityGroup(ctx context.Context, client openstackclient.Networking, opts BaseOptions) error {
-	bastionSecurityGroups, err := getSecurityGroups(ctx, client, opts.SecurityGroup)
+	bastionSecurityGroups, err := client.GetSecurityGroupByName(ctx, opts.SecurityGroup)
 	if err != nil {
 		return err
 	}
@@ -127,7 +127,7 @@ func removeSecurityGroup(ctx context.Context, client openstackclient.Networking,
 	}
 
 	opts.Logr.Info("Deleting Bastion Security Group", "security group ID", bastionSecurityGroups[0].ID)
-	return deleteSecurityGroup(ctx, client, bastionSecurityGroups[0].ID)
+	return client.DeleteSecurityGroup(ctx, bastionSecurityGroups[0].ID)
 }
 
 func isInstanceDeleted(ctx context.Context, client openstackclient.Compute, opts BaseOptions) (bool, error) {

--- a/pkg/controller/bastion/actuator_reconcile.go
+++ b/pkg/controller/bastion/actuator_reconcile.go
@@ -174,7 +174,7 @@ func Retry(maxRetries int, delay time.Duration, log logr.Logger, fn func() error
 func ensurePublicIPAddress(ctx context.Context, opts Options, client openstackclient.Networking, infraStatus *openstackapi.InfrastructureStatus) (floatingips.FloatingIP, error) {
 	opts.Logr.Info("Ensuring public IP address for bastion instance", "name", opts.BastionInstanceName)
 
-	fips, err := findFipByName(ctx, client, opts.BastionInstanceName)
+	fips, err := client.GetFipByName(ctx, opts.BastionInstanceName)
 	if err != nil {
 		return floatingips.FloatingIP{}, err
 	}
@@ -426,7 +426,7 @@ func ensureSecurityGroupRules(ctx context.Context, client openstackclient.Networ
 	}
 	wantedRules = append(wantedRules, EgressAllowSSHToWorker(opts, secGroupID, infraStatus.SecurityGroups[0].ID))
 
-	currentRules, err := listRules(ctx, client, secGroupID)
+	currentRules, err := client.ListRules(ctx, rules.ListOpts{SecGroupID: secGroupID})
 	if err != nil {
 		return fmt.Errorf("failed to list rules: %w", err)
 	}
@@ -441,7 +441,7 @@ func ensureSecurityGroupRules(ctx context.Context, client openstackclient.Networ
 	}
 
 	for _, rule := range rulesToDelete {
-		if err := deleteRule(ctx, client, rule.ID); err != nil {
+		if err := client.DeleteRule(ctx, rule.ID); err != nil {
 			if openstackclient.IsNotFoundError(err) {
 				continue
 			}
@@ -524,7 +524,7 @@ func ruleEqual(a rules.CreateOpts, b rules.SecGroupRule) bool {
 }
 
 func createSecurityGroupRuleIfNotExist(ctx context.Context, log logr.Logger, client openstackclient.Networking, createOpts rules.CreateOpts) error {
-	if _, err := createRules(ctx, client, createOpts); err != nil {
+	if _, err := client.CreateRule(ctx, createOpts); err != nil {
 		if gophercloud.ResponseCodeIs(err, http.StatusConflict) {
 			log.Info("Security Group Rule already exists", "rule", createOpts.Description)
 			return nil
@@ -538,7 +538,7 @@ func createSecurityGroupRuleIfNotExist(ctx context.Context, log logr.Logger, cli
 func ensureSecurityGroup(ctx context.Context, client openstackclient.Networking, opts Options) (groups.SecGroup, error) {
 	opts.Logr.Info("Ensuring security group for bastion", "name", opts.SecurityGroup)
 
-	securityGroups, err := getSecurityGroups(ctx, client, opts.SecurityGroup)
+	securityGroups, err := client.GetSecurityGroupByName(ctx, opts.SecurityGroup)
 	if err != nil {
 		return groups.SecGroup{}, err
 	}
@@ -553,7 +553,7 @@ func ensureSecurityGroup(ctx context.Context, client openstackclient.Networking,
 	}
 
 	opts.Logr.Info("Creating new security group", "security group", opts.SecurityGroup)
-	result, err := createSecurityGroup(ctx, client, groups.CreateOpts{
+	result, err := client.CreateSecurityGroup(ctx, groups.CreateOpts{
 		Name:        opts.SecurityGroup,
 		Description: opts.SecurityGroup,
 	})

--- a/pkg/controller/bastion/actuator_reconcile.go
+++ b/pkg/controller/bastion/actuator_reconcile.go
@@ -184,7 +184,9 @@ func ensurePublicIPAddress(ctx context.Context, opts Options, client openstackcl
 	}
 
 	if len(fips) == 1 {
-		if fips[0].Status == "ACTIVE" {
+		// A FIP that has no port associated, might be ACTIVE or DOWN depending on the version of Neutron
+		// Since it should never be DOWN and have a port associated, check against that
+		if fips[0].Status == "ACTIVE" || (fips[0].Status == "DOWN" && fips[0].PortID == "") {
 			opts.Logr.Info("Found existing public IP address for bastion instance", "name", opts.BastionInstanceName, "ip", fips[0].FloatingIP)
 			return fips[0], nil
 		}
@@ -259,11 +261,12 @@ func ensurePublicIPAddress(ctx context.Context, opts Options, client openstackcl
 			return err
 		}
 
-		if fip.Status != "ACTIVE" {
-			return fmt.Errorf("fip not active yet, status: %s", fip.Status)
+		switch fip.Status {
+		case "ACTIVE", "DOWN":
+			return nil
+		default:
+			return fmt.Errorf("fip in undefined state, status: %s", fip.Status)
 		}
-
-		return nil
 	})
 
 	return fip, err

--- a/pkg/controller/bastion/actuator_reconcile_test.go
+++ b/pkg/controller/bastion/actuator_reconcile_test.go
@@ -1,0 +1,208 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package bastion
+
+import (
+	"context"
+
+	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/layer3/floatingips"
+	"github.com/gophercloud/gophercloud/v2/openstack/networking/v2/extensions/layer3/routers"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.uber.org/mock/gomock"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	openstackapi "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack"
+	mockopenstackclient "github.com/gardener/gardener-extension-provider-openstack/pkg/openstack/client/mocks"
+)
+
+var _ = Describe("EnsurePublicIPAddress", func() {
+	var (
+		ctrl                *gomock.Controller
+		networkingClient    *mockopenstackclient.MockNetworking
+		ctx                 context.Context
+		opts                Options
+		infraStatus         *openstackapi.InfrastructureStatus
+		bastionInstanceName string
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		networkingClient = mockopenstackclient.NewMockNetworking(ctrl)
+		ctx = context.Background()
+		bastionInstanceName = "test-bastion-instance"
+
+		opts = Options{
+			BaseOptions: BaseOptions{
+				BastionInstanceName: bastionInstanceName,
+				Logr:                logf.Log.WithName("test"),
+			},
+		}
+
+		infraStatus = &openstackapi.InfrastructureStatus{
+			Networks: openstackapi.NetworkStatus{
+				FloatingPool: openstackapi.FloatingPoolStatus{
+					ID:   "floating-pool-id",
+					Name: "floating-pool-name",
+				},
+				Router: openstackapi.RouterStatus{
+					ID: "router-id",
+				},
+			},
+		}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
+	Describe("reusing existing FIP", func() {
+		It("should return existing FIP when status is ACTIVE", func() {
+			existingFips := []floatingips.FloatingIP{{
+				ID:         "fip-1",
+				FloatingIP: "1.2.3.4",
+				Status:     "ACTIVE",
+				PortID:     "port-id",
+			}}
+
+			networkingClient.EXPECT().
+				GetFipByName(ctx, bastionInstanceName).
+				Return(existingFips, nil)
+
+			fip, err := ensurePublicIPAddress(ctx, opts, networkingClient, infraStatus)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(fip.ID).To(Equal("fip-1"))
+			Expect(fip.FloatingIP).To(Equal("1.2.3.4"))
+		})
+
+		It("should return existing FIP when status is DOWN and PortID is empty", func() {
+			existingFips := []floatingips.FloatingIP{{
+				ID:         "fip-2",
+				FloatingIP: "2.3.4.5",
+				Status:     "DOWN",
+				PortID:     "",
+			}}
+
+			networkingClient.EXPECT().
+				GetFipByName(ctx, bastionInstanceName).
+				Return(existingFips, nil)
+
+			fip, err := ensurePublicIPAddress(ctx, opts, networkingClient, infraStatus)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(fip.ID).To(Equal("fip-2"))
+			Expect(fip.FloatingIP).To(Equal("2.3.4.5"))
+		})
+
+		It("should error when existing FIP is DOWN and PortID is not empty", func() {
+			existingFips := []floatingips.FloatingIP{{
+				ID:         "fip-3",
+				FloatingIP: "3.4.5.6",
+				Status:     "DOWN",
+				PortID:     "port-id",
+			}}
+
+			networkingClient.EXPECT().
+				GetFipByName(ctx, bastionInstanceName).
+				Return(existingFips, nil)
+
+			_, err := ensurePublicIPAddress(ctx, opts, networkingClient, infraStatus)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("not active"))
+		})
+
+		It("should error when existing FIP has ERROR status", func() {
+			existingFip := floatingips.FloatingIP{
+				ID:         "fip-4",
+				FloatingIP: "4.5.6.7",
+				Status:     "ERROR",
+				PortID:     "",
+			}
+
+			networkingClient.EXPECT().
+				GetFipByName(ctx, bastionInstanceName).
+				Return([]floatingips.FloatingIP{existingFip}, nil)
+
+			_, err := ensurePublicIPAddress(ctx, opts, networkingClient, infraStatus)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("not active"))
+		})
+	})
+
+	Describe("creating new FIP", func() {
+		It("should create new FIP and accept ACTIVE status", func() {
+			networkingClient.EXPECT().
+				GetFipByName(ctx, bastionInstanceName).
+				Return([]floatingips.FloatingIP{}, nil)
+
+			router := &routers.Router{
+				ID:     "router-id",
+				Status: "ACTIVE",
+				GatewayInfo: routers.GatewayInfo{
+					NetworkID: "ext-net-id",
+					ExternalFixedIPs: []routers.ExternalFixedIP{{
+						IPAddress: "10.0.0.1",
+						SubnetID:  "ext-subnet-id",
+					}},
+				},
+			}
+			networkingClient.EXPECT().
+				GetRouterByID(ctx, infraStatus.Networks.Router.ID).
+				Return(router, nil)
+
+			mockFip := floatingips.FloatingIP{
+				ID:         "fip-new",
+				FloatingIP: "5.6.7.8",
+				Status:     "ACTIVE",
+			}
+			networkingClient.EXPECT().
+				CreateFloatingIP(ctx, gomock.Any()).
+				Return(&mockFip, nil)
+			networkingClient.EXPECT().
+				GetFloatingIP(ctx, gomock.Any()).
+				Return(mockFip, nil)
+
+			fip, err := ensurePublicIPAddress(ctx, opts, networkingClient, infraStatus)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(fip.ID).To(Equal("fip-new"))
+		})
+
+		It("should create new FIP and accept DOWN status after creation", func() {
+			networkingClient.EXPECT().
+				GetFipByName(ctx, bastionInstanceName).
+				Return([]floatingips.FloatingIP{}, nil)
+
+			router := &routers.Router{
+				ID:     "router-id",
+				Status: "ACTIVE",
+				GatewayInfo: routers.GatewayInfo{
+					NetworkID: "ext-net-id",
+					ExternalFixedIPs: []routers.ExternalFixedIP{{
+						IPAddress: "10.0.0.1",
+						SubnetID:  "ext-subnet-id",
+					}},
+				},
+			}
+			networkingClient.EXPECT().
+				GetRouterByID(ctx, infraStatus.Networks.Router.ID).
+				Return(router, nil)
+
+			mockFip := floatingips.FloatingIP{
+				ID:         "fip-new-down",
+				FloatingIP: "6.7.8.9",
+				Status:     "DOWN",
+			}
+			networkingClient.EXPECT().
+				CreateFloatingIP(ctx, gomock.Any()).
+				Return(&mockFip, nil)
+			networkingClient.EXPECT().
+				GetFloatingIP(ctx, gomock.Any()).
+				Return(mockFip, nil)
+
+			fip, err := ensurePublicIPAddress(ctx, opts, networkingClient, infraStatus)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(fip.ID).To(Equal("fip-new-down"))
+		})
+	})
+})


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area networking
/kind bug
/platform openstack

**What this PR does / why we need it**:

On our version of Neutron (2023.1) the floating IP is in state DOWN when it is created. This only signals that the FloatingIP was not yet associated with a port and thus down. It does not hint at an error.

Without this change, `gardenctl ssh` does not work without manually attaching the FIP to the server.

**Special notes for your reviewer**:

--

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
fix gardenctl ssh floating ip attachment
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bastion networking cleanup during deletion.
  * Bastions now correctly reuse unassociated floating IPs in active or inactive states.
  * Newly created floating IPs are accepted when reported as ready in either supported state.
  * Improved handling of security groups and rules during bastion creation, reconciliation, and removal.
  * Preserved existing behavior for resource conflicts and missing resources.
  * Improved reliability when floating IPs are temporarily reported in an inactive state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->