### PR TITLE
Internal load balancer

### DIFF
--- a/charts/internal/cloud-provider-config/templates/cloud-provider-config-loadbalancer.tpl
+++ b/charts/internal/cloud-provider-config/templates/cloud-provider-config-loadbalancer.tpl
@@ -5,6 +5,7 @@ monitor-delay="{{ .Values.monitorDelay }}"
 monitor-timeout="{{ .Values.monitorTimeout }}"
 monitor-max-retries={{ .Values.monitorMaxRetries }}
 lb-version="v2"
+internal-lb={{ .Values.internalLoadBalancer }}
 lb-provider="{{ .Values.lbProvider }}"
 {{- if eq .Values.lbProvider "ovn" }}
 lb-method="SOURCE_IP_PORT"

--- a/charts/internal/cloud-provider-config/values.yaml
+++ b/charts/internal/cloud-provider-config/values.yaml
@@ -12,6 +12,7 @@ insecure: false
 region: eu
 # [LoadBalancer]
 lbProvider: foobar
+internalLoadBalancer: false
 # floatingNetworkID: foo-bar-123
 # floatingSubnetID: asd12345
 # floatingSubnetName: "*abc*"

--- a/docs/usage/usage.md
+++ b/docs/usage/usage.md
@@ -166,6 +166,7 @@ loadBalancerClasses:
   purpose: private
   subnetID: internal-id
 # cloudControllerManager:
+#   internalLoadBalancer: true
 #   featureGates:
 #     SomeKubernetesFeature: true
 # storage:
@@ -191,6 +192,18 @@ The `loadBalancerClasses` field contains an optional list of load balancer class
 The `cloudControllerManager.featureGates` contains a map of explicitly enabled or disabled feature gates.
 For production usage it's not recommended to use this field at all as you can enable alpha features or disable beta/stable features, potentially impacting the cluster stability.
 If you don't want to configure anything for the `cloudControllerManager` simply omit the key in the YAML specification.
+
+The optional `cloudControllerManager.internalLoadBalancer` field controls
+whether Services of type `LoadBalancer` are provisioned as internal load
+balancers. When set to `true`, the OpenStack cloud-controller-manager
+configures all load balancers in the Shoot without floating IPs. Consequently,
+users cannot request externally accessible load balancers. The field defaults
+to `false`.
+
+The field can also be enabled for existing Shoots. Be aware that doing so may
+cause the OpenStack cloud-controller-manager to detach floating IPs from
+existing load balancers during reconciliation. Workloads relying on these
+floating IPs may consequently become unreachable from external networks.
 
 The optional `storage.csiManila.enabled` field is used to enable the deployment of the CSI Manila driver to support NFS persistent volumes.
 In this case, please ensure to set `networks.shareNetwork.enabled=true` in the `InfrastructureConfig`, too.

--- a/hack/api-reference/api.md
+++ b/hack/api-reference/api.md
@@ -80,6 +80,18 @@ object (keys:string, values:boolean)
 <p>FeatureGates contains information about enabled feature gates.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>internalLoadBalancer</code></br>
+<em>
+boolean
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>InternalLoadBalancer configures all Services of type LoadBalancer<br />to be internal and prevents creating external load balancers.</p>
+</td>
+</tr>
 
 </tbody>
 </table>

--- a/pkg/apis/openstack/types_controlplane.go
+++ b/pkg/apis/openstack/types_controlplane.go
@@ -41,8 +41,8 @@ type CloudControllerManagerConfig struct {
 	// FeatureGates contains information about enabled feature gates.
 	FeatureGates map[string]bool
 	// InternalLoadBalancer configures all Services of type LoadBalancer
-    // to be internal and prevents creating external load balancers.
-    InternalLoadBalancer bool
+	// to be internal and prevents creating external load balancers.
+	InternalLoadBalancer bool
 }
 
 // Storage contains configuration for storage in the cluster.

--- a/pkg/apis/openstack/types_controlplane.go
+++ b/pkg/apis/openstack/types_controlplane.go
@@ -40,6 +40,9 @@ const (
 type CloudControllerManagerConfig struct {
 	// FeatureGates contains information about enabled feature gates.
 	FeatureGates map[string]bool
+	// InternalLoadBalancer configures all Services of type LoadBalancer
+    // to be internal and prevents creating external load balancers.
+    InternalLoadBalancer bool
 }
 
 // Storage contains configuration for storage in the cluster.

--- a/pkg/apis/openstack/v1alpha1/types_controlplane.go
+++ b/pkg/apis/openstack/v1alpha1/types_controlplane.go
@@ -38,9 +38,9 @@ type CloudControllerManagerConfig struct {
 	// +optional
 	FeatureGates map[string]bool `json:"featureGates,omitempty"`
 	// InternalLoadBalancer configures all Services of type LoadBalancer
-    // to be internal and prevents creating external load balancers.
-    // +optional
-    InternalLoadBalancer bool `json:"internalLoadBalancer,omitempty"`
+	// to be internal and prevents creating external load balancers.
+	// +optional
+	InternalLoadBalancer bool `json:"internalLoadBalancer,omitempty"`
 }
 
 // Storage contains configuration for storage in the cluster.

--- a/pkg/apis/openstack/v1alpha1/types_controlplane.go
+++ b/pkg/apis/openstack/v1alpha1/types_controlplane.go
@@ -37,6 +37,10 @@ type CloudControllerManagerConfig struct {
 	// FeatureGates contains information about enabled feature gates.
 	// +optional
 	FeatureGates map[string]bool `json:"featureGates,omitempty"`
+	// InternalLoadBalancer configures all Services of type LoadBalancer
+    // to be internal and prevents creating external load balancers.
+    // +optional
+    InternalLoadBalancer bool `json:"internalLoadBalancer,omitempty"`
 }
 
 // Storage contains configuration for storage in the cluster.

--- a/pkg/apis/openstack/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/openstack/v1alpha1/zz_generated.conversion.go
@@ -412,6 +412,7 @@ func Convert_openstack_CSIManila_To_v1alpha1_CSIManila(in *openstack.CSIManila, 
 
 func autoConvert_v1alpha1_CloudControllerManagerConfig_To_openstack_CloudControllerManagerConfig(in *CloudControllerManagerConfig, out *openstack.CloudControllerManagerConfig, s conversion.Scope) error {
 	out.FeatureGates = *(*map[string]bool)(unsafe.Pointer(&in.FeatureGates))
+	out.InternalLoadBalancer = in.InternalLoadBalancer
 	return nil
 }
 
@@ -422,6 +423,7 @@ func Convert_v1alpha1_CloudControllerManagerConfig_To_openstack_CloudControllerM
 
 func autoConvert_openstack_CloudControllerManagerConfig_To_v1alpha1_CloudControllerManagerConfig(in *openstack.CloudControllerManagerConfig, out *CloudControllerManagerConfig, s conversion.Scope) error {
 	out.FeatureGates = *(*map[string]bool)(unsafe.Pointer(&in.FeatureGates))
+	out.InternalLoadBalancer = in.InternalLoadBalancer
 	return nil
 }
 

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -547,8 +547,7 @@ func getConfigChartValues(
 	}
 
 	if cpConfig.CloudControllerManager != nil {
-		values["internalLoadBalancer"] =
-			cpConfig.CloudControllerManager.InternalLoadBalancer
+		values["internalLoadBalancer"] = cpConfig.CloudControllerManager.InternalLoadBalancer
 	}
 
 	if !isUsingOverlay {

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -546,6 +546,11 @@ func getConfigChartValues(
 		"internalNetworkName": infraStatus.Networks.Name,
 	}
 
+	if cpConfig.CloudControllerManager != nil {
+    values["internalLoadBalancer"] =
+        cpConfig.CloudControllerManager.InternalLoadBalancer
+    }
+
 	if !isUsingOverlay {
 		values["routerID"] = infraStatus.Networks.Router.ID
 	}

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -547,9 +547,9 @@ func getConfigChartValues(
 	}
 
 	if cpConfig.CloudControllerManager != nil {
-    values["internalLoadBalancer"] =
-        cpConfig.CloudControllerManager.InternalLoadBalancer
-    }
+		values["internalLoadBalancer"] =
+			cpConfig.CloudControllerManager.InternalLoadBalancer
+	}
 
 	if !isUsingOverlay {
 		values["routerID"] = infraStatus.Networks.Router.ID

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -432,15 +432,15 @@ var _ = Describe("ValuesProvider", func() {
 				},
 				nil,
 			)
-		
+
 			expectedValues := utils.MergeMaps(configChartValues, map[string]interface{}{
 				"internalLoadBalancer": true,
 			})
-		
+
 			values, err := vp.GetConfigChartValues(ctx, cp, cluster)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(values).To(Equal(expectedValues))
-		})					
+		})
 
 		It("should return correct config chart values with load balancer classes with purpose", func() {
 			var (

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -420,7 +420,7 @@ var _ = Describe("ValuesProvider", func() {
 
 		It("should return correct config chart values with internal load balancer enabled", func() {
 			cp := controlPlane(
-				floatingNetworkID,
+				"floating-network-id",
 				&api.ControlPlaneConfig{
 					LoadBalancerProvider: "load-balancer-provider",
 					CloudControllerManager: &api.CloudControllerManagerConfig{

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -309,6 +309,7 @@ var _ = Describe("ValuesProvider", func() {
 			"region":                      region,
 			"subnetID":                    "subnet-acbd1234",
 			"lbProvider":                  "load-balancer-provider",
+			"internalLoadBalancer":        false,
 			"floatingNetworkID":           "floating-network-id",
 			"insecure":                    false,
 			"authUrl":                     authURL,
@@ -416,6 +417,30 @@ var _ = Describe("ValuesProvider", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(values).To(Equal(expectedValues))
 		})
+
+		It("should return correct config chart values with internal load balancer enabled", func() {
+			cp := controlPlane(
+				floatingNetworkID,
+				&api.ControlPlaneConfig{
+					LoadBalancerProvider: "load-balancer-provider",
+					CloudControllerManager: &api.CloudControllerManagerConfig{
+						InternalLoadBalancer: true,
+						FeatureGates: map[string]bool{
+							"SomeKubernetesFeature": true,
+						},
+					},
+				},
+				nil,
+			)
+		
+			expectedValues := utils.MergeMaps(configChartValues, map[string]interface{}{
+				"internalLoadBalancer": true,
+			})
+		
+			values, err := vp.GetConfigChartValues(ctx, cp, cluster)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(values).To(Equal(expectedValues))
+		})					
 
 		It("should return correct config chart values with load balancer classes with purpose", func() {
 			var (


### PR DESCRIPTION

**How to categorize this PR?**

/area networking
/area control-plane
/kind enhancement
/kind api-change
/platform openstack

**What this PR does / why we need it**:

This PR adds the optional `cloudControllerManager.internalLoadBalancer` field to the OpenStack `ControlPlaneConfig`.

The value is propagated to the OpenStack cloud-controller-manager configuration as:

```ini
[LoadBalancer]
internal-lb=true
```

This allows users to configure on a per-Shoot basis whether all Kubernetes Services of type `LoadBalancer` should be provisioned as internal load balancers without floating IPs.

Example:

```yaml
spec:
  provider:
    controlPlaneConfig:
      apiVersion: openstack.provider.extensions.gardener.cloud/v1alpha1
      kind: ControlPlaneConfig
      loadBalancerProvider: ovn
      cloudControllerManager:
        internalLoadBalancer: true
```

The option defaults to `false`, preserving the existing behavior for all current and newly created Shoots that do not explicitly enable it.

**Which issue(s) this PR fixes**:

Partially addresses #947.

**Special notes for your reviewer**:

This change exposes the existing `internal-lb` configuration option of the OpenStack cloud-controller-manager. It does not introduce custom load balancer behavior in the Gardener extension.

When enabled, the setting applies to all Services of type `LoadBalancer` in the respective Shoot, not only to a particular ingress controller.

The setting can also be changed for existing Shoots. Enabling it may cause the OpenStack cloud-controller-manager to detach floating IPs from existing load balancers during reconciliation.

**Release note**:

```feature user
OpenStack Shoot clusters can now configure `cloudControllerManager.internalLoadBalancer` in their `ControlPlaneConfig`. When enabled, all Services of type `LoadBalancer` are provisioned as internal load balancers without floating IPs.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to configure all `LoadBalancer` Services as internal.
  * Prevented external load balancer creation when internal load balancing is enabled.
  * Added configuration support across control plane settings and deployment values.

* **Documentation**
  * Documented the optional setting, its default behavior, and its impact on existing load balancers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->