### PR TITLE
Fix: don't read bastion floating IP from Nova server addresses

### DIFF
--- a/pkg/controller/bastion/actuator.go
+++ b/pkg/controller/bastion/actuator.go
@@ -66,9 +66,12 @@ func deleteBastionInstance(ctx context.Context, client openstackclient.Compute, 
 	return client.DeleteServer(ctx, id)
 }
 
-// GetIPs returns the first found private and public IPs for the given server and options.
-func GetIPs(s servers.Server, opts Options) (string, string, error) {
-	var privateIP, publicIP string
+// GetPrivateIP returns the first found private (fixed) IP for the given server.
+// The public (floating) IP is not read from the server addresses because the
+// floating IP is associated at the Neutron port level, which is not reliably
+// reflected in Nova's server addresses view.
+func GetPrivateIP(s servers.Server, opts Options) (string, error) {
+	var privateIP string
 
 	type InstanceNic struct {
 		MacAddr string `json:"OS-EXT-IPS-MAC:mac_addr"`
@@ -81,38 +84,28 @@ func GetIPs(s servers.Server, opts Options) (string, string, error) {
 
 	addresses, ok := s.Addresses[opts.ShootName]
 	if !ok {
-		return "", "", fmt.Errorf("network %q not found in server addresses", opts.ShootName)
+		return "", fmt.Errorf("network %q not found in server addresses", opts.ShootName)
 	}
 	bytes, err := json.Marshal(addresses)
 	if err != nil {
-		return "", "", err
+		return "", err
 	}
 	err = json.Unmarshal(bytes, &instanceNic)
 	if err != nil {
-		return "", "", err
+		return "", err
 	}
 
 	for _, v := range instanceNic {
-		switch v.Type {
-		case "fixed":
-			if privateIP == "" {
-				privateIP = v.Addr
-			}
-		case "floating":
-			if publicIP == "" {
-				publicIP = v.Addr
-			}
+		if v.Type == "fixed" && privateIP == "" {
+			privateIP = v.Addr
 		}
 	}
 
 	if privateIP == "" {
-		return "", "", fmt.Errorf("no private IP found")
-	}
-	if publicIP == "" {
-		return "", "", fmt.Errorf("no public IP found")
+		return "", fmt.Errorf("no private IP found")
 	}
 
-	return privateIP, publicIP, nil
+	return privateIP, nil
 }
 
 func createFloatingIP(ctx context.Context, client openstackclient.Networking, parameters floatingips.CreateOpts) (floatingips.FloatingIP, error) {

--- a/pkg/controller/bastion/actuator_reconcile.go
+++ b/pkg/controller/bastion/actuator_reconcile.go
@@ -145,7 +145,7 @@ func (a *actuator) Reconcile(ctx context.Context, log logr.Logger, bastion *exte
 	}
 
 	// check if the instance already exists and has an IP
-	endpoints, err := ensureEndpoints(instance, opts)
+	endpoints, err := ensureEndpoints(instance, fipID, opts)
 	if err != nil {
 		return util.DetermineError(err, helper.KnownCodes)
 	}
@@ -328,14 +328,14 @@ func ensureComputeInstance(ctx context.Context, client openstackclient.Compute, 
 	return instance, err
 }
 
-func getInstanceEndpoints(instance servers.Server, opts Options) (bastionEndpoints, error) {
+func getInstanceEndpoints(instance servers.Server, floatingIP floatingips.FloatingIP, opts Options) (bastionEndpoints, error) {
 	if instance.Status != "ACTIVE" {
 		return bastionEndpoints{}, errors.New("compute instance not active yet")
 	}
 
 	endpoints := bastionEndpoints{}
 
-	privateIP, externalIP, err := GetIPs(instance, opts)
+	privateIP, err := GetPrivateIP(instance, opts)
 	if err != nil {
 		return bastionEndpoints{}, fmt.Errorf("no IP found: %w", err)
 	}
@@ -344,7 +344,7 @@ func getInstanceEndpoints(instance servers.Server, opts Options) (bastionEndpoin
 		endpoints.private = ingress
 	}
 
-	if ingress := addressToIngress("", externalIP); ingress != nil {
+	if ingress := addressToIngress("", floatingIP.FloatingIP); ingress != nil {
 		endpoints.public = ingress
 	}
 	return endpoints, nil
@@ -577,9 +577,9 @@ func ensureShootWorkerSecurityGroupRules(ctx context.Context, client openstackcl
 	return nil
 }
 
-func ensureEndpoints(instance servers.Server, opts Options) (bastionEndpoints, error) {
+func ensureEndpoints(instance servers.Server, floatingIP floatingips.FloatingIP, opts Options) (bastionEndpoints, error) {
 	// check if the instance already exists and has an IP
-	endpoints, err := getInstanceEndpoints(instance, opts)
+	endpoints, err := getInstanceEndpoints(instance, floatingIP, opts)
 	if err != nil {
 		return bastionEndpoints{}, err
 	}

--- a/test/integration/bastion/bastion_test.go
+++ b/test/integration/bastion/bastion_test.go
@@ -787,8 +787,12 @@ func verifyCreation(options bastionctrl.Options) {
 	Expect(servers[0].Name).To(Equal(options.BastionInstanceName))
 
 	By("checking bastion ingress IPs exist")
-	privateIP, externalIP, err := bastionctrl.GetIPs(servers[0], options)
+	privateIP, err := bastionctrl.GetPrivateIP(servers[0], options)
 	Expect(err).To(Succeed())
-	Expect(privateIP).NotTo(BeNil())
-	Expect(externalIP).NotTo(BeNil())
+	Expect(privateIP).NotTo(BeEmpty())
+
+	fips, err := networkClient.GetFipByName(context.Background(), options.BastionInstanceName)
+	Expect(err).To(Succeed())
+	Expect(fips).To(HaveLen(1))
+	Expect(fips[0].FloatingIP).NotTo(BeEmpty())
 }


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area robustness
/kind enhancement
/platform openstack

**What this PR does / why we need it**:
The bastion controller failed to become ready with: `Error reconciling Bastion: no IP found: no public IP found`
 **Root cause:**
 The reconcile flow associates the floating IP to the bastion at the **Neutron port level** via `UpdateFIPWithPort`. Afterwards, `GetIPs` tried to rediscover that public IP by parsing Nova's `server.Addresses` map for an entry of type `OS-EXT-IPS:type == "floating"`.
When a floating IP is attached directly through Neutron, Nova's server `Addresses` view does not reliably expose the floating entry. As a result `GetIPs` returned `no public IP found`, and the bastion never reached a ready state regardless of requeues. This is not a floating-IP quota issue.
**Fix:**
The floating IP object is already known from `ensurePublicIPAddress`, so there is no need to read it back out of Nova

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Don't read bastion floating IP from Nova server addresses
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Bastion endpoints now use the correct floating IP for public access.
  * Private endpoint discovery now reliably returns the server’s fixed private IP.
  * Improved handling when public IP information is unavailable.

* **Tests**
  * Updated bastion creation checks to validate private and floating IPs separately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->